### PR TITLE
fix: restore bearer + API key auth for programmatic clients

### DIFF
--- a/src/lib/auth/api-key.test.ts
+++ b/src/lib/auth/api-key.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpcMock = vi.fn();
+const verifyApiKeyMock = vi.fn();
+const getKeyPrefixMock = vi.fn((k: string) => k.slice(0, 16));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({
+    rpc: rpcMock,
+  })),
+}));
+
+vi.mock("@/lib/api-keys", () => ({
+  verifyApiKey: (key: string, hash: string) => verifyApiKeyMock(key, hash),
+  getKeyPrefix: (key: string) => getKeyPrefixMock(key),
+}));
+
+import { authenticateApiKey } from "./api-key";
+
+describe("authenticateApiKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+
+    rpcMock.mockImplementation((fnName: string) => {
+      if (fnName === "get_api_key_user") {
+        return Promise.resolve({
+          data: [{ user_id: "user-1", key_id: "key-1", key_hash: "hash-1" }],
+          error: null,
+        });
+      }
+
+      if (fnName === "update_api_key_last_used") {
+        return Promise.resolve({ data: null, error: null });
+      }
+
+      return Promise.resolve({ data: null, error: null });
+    });
+
+    verifyApiKeyMock.mockResolvedValue(true);
+  });
+
+  it("authenticates with X-API-Key header", async () => {
+    const result = await authenticateApiKey(null, "ugig_live_abc123");
+    expect(result).toEqual({ userId: "user-1", keyId: "key-1" });
+  });
+
+  it("authenticates with Bearer API key in Authorization header", async () => {
+    const result = await authenticateApiKey("Bearer ugig_live_abc123", null);
+    expect(result).toEqual({ userId: "user-1", keyId: "key-1" });
+  });
+
+  it("authenticates with ApiKey auth scheme", async () => {
+    const result = await authenticateApiKey("ApiKey ugig_live_abc123", null);
+    expect(result).toEqual({ userId: "user-1", keyId: "key-1" });
+  });
+
+  it("rejects non-API-key Bearer tokens", async () => {
+    const result = await authenticateApiKey("Bearer eyJhbGciOi...", null);
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/auth/api-key.ts
+++ b/src/lib/auth/api-key.ts
@@ -11,17 +11,41 @@ export type ApiKeyAuthResult = {
  * Authenticate a request using an API key from the Authorization header.
  * Returns the user ID and key ID if valid, null otherwise.
  */
+function isLikelyApiKey(value: string | null | undefined): value is string {
+  if (!value) return false;
+  const v = value.trim();
+  return /^ugig_[a-z]+_/i.test(v);
+}
+
+function extractApiKey(
+  authHeader: string | null,
+  apiKeyHeader?: string | null
+): string | null {
+  const headerKey = apiKeyHeader?.trim() || null;
+  if (isLikelyApiKey(headerKey)) {
+    return headerKey;
+  }
+
+  if (!authHeader) return null;
+  const trimmed = authHeader.trim();
+
+  // Support common auth schemes used by API clients
+  const patterns = [/^Bearer\s+(.+)$/i, /^ApiKey\s+(.+)$/i, /^Token\s+(.+)$/i];
+  for (const pattern of patterns) {
+    const match = trimmed.match(pattern);
+    if (match && isLikelyApiKey(match[1])) {
+      return match[1].trim();
+    }
+  }
+
+  return null;
+}
+
 export async function authenticateApiKey(
   authHeader: string | null,
   apiKeyHeader?: string | null
 ): Promise<ApiKeyAuthResult | null> {
-  // Determine the raw key from X-API-Key header or Authorization header
-  let rawKey: string | null = null;
-  if (apiKeyHeader?.startsWith("ugig_live_")) {
-    rawKey = apiKeyHeader;
-  } else if (authHeader?.startsWith("Bearer ") && authHeader.slice(7).startsWith("ugig_live_")) {
-    rawKey = authHeader.slice(7);
-  }
+  const rawKey = extractApiKey(authHeader, apiKeyHeader);
 
   if (!rawKey) {
     return null;

--- a/src/lib/auth/get-user.ts
+++ b/src/lib/auth/get-user.ts
@@ -1,7 +1,10 @@
 import { NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { authenticateApiKey } from "./api-key";
-import { createClient as createSupabaseAdmin } from "@supabase/supabase-js";
+import {
+  createServiceClient as createServiceRoleClient,
+  authenticateWithToken,
+} from "@/lib/supabase/service";
 import type { Database } from "@/types/database";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -44,19 +47,16 @@ export async function getAuthContext(
 
   // Try Bearer token auth (Supabase JWT via Authorization header)
   const authHeader = request.headers.get("authorization");
-  if (authHeader?.startsWith("Bearer ") && !authHeader.slice(7).startsWith("ugig_live_")) {
-    const token = authHeader.slice(7);
-    const bearerClient = createSupabaseAdmin<Database>(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    );
-    const { data: { user: bearerUser }, error } = await bearerClient.auth.getUser(token);
-    if (bearerUser && !error) {
-      return {
-        user: { id: bearerUser.id, email: bearerUser.email, authMethod: "session" as const },
-        supabase: bearerClient,
-      };
-    }
+  const tokenAuth = await authenticateWithToken(authHeader);
+  if (tokenAuth) {
+    return {
+      user: {
+        id: tokenAuth.user.id,
+        email: tokenAuth.user.email,
+        authMethod: "session",
+      },
+      supabase: tokenAuth.supabase,
+    };
   }
 
   // Fall back to API key auth
@@ -64,7 +64,7 @@ export async function getAuthContext(
   const apiKeyResult = await authenticateApiKey(authHeader, apiKeyHeader);
 
   if (apiKeyResult) {
-    const serviceClient = createServiceClient();
+    const serviceClient = createServiceRoleClient();
     return {
       user: {
         id: apiKeyResult.userId,
@@ -78,12 +78,9 @@ export async function getAuthContext(
 }
 
 /**
- * Create a Supabase client with service role (admin) privileges.
- * Used for API key authenticated requests where there is no user session.
+ * Backward-compatible export used by several routes.
  */
 export function createServiceClient() {
-  return createSupabaseAdmin<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
+  return createServiceRoleClient();
 }
+


### PR DESCRIPTION
## Summary
- normalize non-cookie auth handling in `getAuthContext` by reusing `authenticateWithToken`
- broaden API key extraction to support:
  - `X-API-Key: <key>`
  - `Authorization: Bearer <api-key>`
  - `Authorization: ApiKey <api-key>`
  - `Authorization: Token <api-key>`
- trim/validate API key formats more defensively (`ugig_<env>_...`)
- add regression tests for API key auth parsing/authentication paths

## Why
Issue reports showed programmatic auth flows failing while cookie auth worked. This patch hardens header parsing and unifies bearer token handling so stateless clients (CLI/agents) can authenticate reliably.

## Validation
- `npm run -s type-check`
- `npm run -s test:run -- src/lib/auth/api-key.test.ts src/lib/api-keys.test.ts`
- repo pre-commit pipeline passed during commit (tests + build)

Fixes #7
Fixes #8
