### PR TITLE
fix(types): resolve excessive type instantiation in agentpass-login route

### DIFF
--- a/src/app/api/auth/agentpass-login/route.ts
+++ b/src/app/api/auth/agentpass-login/route.ts
@@ -75,16 +75,16 @@ export async function POST(request: NextRequest) {
     let userId: string | null = null;
 
     const { data: byPassport } = await supabase
-      .from("profiles")
+      .from("profiles" as any)
       .select("id")
-      .eq("agentpass_id" as any, passportId)
+      .eq("agentpass_id", passportId)
       .maybeSingle();
 
     if (byPassport) {
       userId = byPassport.id;
     } else {
       const { data: byEmail } = await supabase
-        .from("profiles")
+        .from("profiles" as any)
         .select("id")
         .eq("email", email)
         .maybeSingle();
@@ -93,8 +93,8 @@ export async function POST(request: NextRequest) {
         userId = byEmail.id;
         // Link passport ID
         await supabase
-          .from("profiles")
-          .update({ agentpass_id: passportId } as any)
+          .from("profiles" as any)
+          .update({ agentpass_id: passportId })
           .eq("id", byEmail.id);
       }
     }
@@ -129,7 +129,7 @@ export async function POST(request: NextRequest) {
       if (authData?.user) {
         userId = authData.user.id;
 
-        await supabase.from("profiles").upsert(
+        await supabase.from("profiles" as any).upsert(
           {
             id: userId,
             email,
@@ -140,11 +140,11 @@ export async function POST(request: NextRequest) {
             agent_name: displayName,
             agentpass_id: passportId,
             profile_completed: false,
-          } as any,
+          },
           { onConflict: "id" }
         );
 
-        await (supabase as any).from("oauth_identities").insert({
+        await supabase.from("oauth_identities" as any).insert({
           user_id: userId,
           provider: "agentpass",
           provider_user_id: passportId,
@@ -172,8 +172,8 @@ export async function POST(request: NextRequest) {
           if (found) {
             userId = found.id;
             await supabase
-              .from("profiles")
-              .update({ agentpass_id: passportId } as any)
+              .from("profiles" as any)
+              .update({ agentpass_id: passportId })
               .eq("id", found.id);
           }
           page++;


### PR DESCRIPTION
## Summary

Fixes the pre-existing TypeScript build error (TS2589) that blocks CI.

## Problem

```
src/app/api/auth/agentpass-login/route.ts:77:40
Type error: Type instantiation is excessively deep and possibly infinite.
```

Supabase's type inference was recursively expanding the `profiles` table schema when checking the `agentpass_id` column, causing the compiler to hit its recursion limit.

## Fix

Moved the `as any` cast from column-level to table-level (`.from("profiles" as any)`), consistent with the rest of the codebase. This prevents Supabase from deeply type-checking columns against the inferred schema.

- 5 table references updated: `profiles` (4x), `oauth_identities` (1x)
- No runtime behavior change
- Build now passes clean: ✓ Compiled, ✓ TypeScript, ✓ Generated

## Related

Discovered during work on #97 (security fixes).