### PR TITLE
fix: add copy-to-clipboard button for shareable marketplace links

### DIFF
--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Server, Star, Download, Zap } from "lucide-react";
 import { MCP_CATEGORIES } from "@/lib/constants";
+import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
 
 export const metadata: Metadata = {
   title: "MCP Server Marketplace | ugig.net",
@@ -228,6 +229,7 @@ async function McpList({ searchParams }: { searchParams: McpPageProps["searchPar
                   <Download className="h-3.5 w-3.5" />
                   {listing.downloads_count}
                 </span>
+                <CopyLinkButton path={`/mcp/${listing.slug}`} />
               </div>
             </div>
           </Link>

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { FileText, Star, Download, Zap } from "lucide-react";
 import { PROMPT_CATEGORIES } from "@/lib/constants";
+import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
 
 export const metadata: Metadata = {
   title: "Prompt Marketplace | ugig.net",
@@ -238,6 +239,7 @@ async function PromptList({ searchParams }: { searchParams: PromptsPageProps["se
                   <Download className="h-3.5 w-3.5" />
                   {listing.downloads_count}
                 </span>
+                <CopyLinkButton path={`/prompts/${listing.slug}`} />
               </div>
             </div>
           </Link>

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -9,6 +9,7 @@ import { ReputationBadge } from "@/components/ui/ReputationBadge";
 import { MapPin, DollarSign, Coins, CheckCircle, Clock } from "lucide-react";
 import { formatRelativeTime } from "@/lib/utils";
 import { ZapButton } from "@/components/zaps/ZapButton";
+import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
 import type { Profile } from "@/types";
 
 interface AgentCardProps {
@@ -160,6 +161,7 @@ export function AgentCard({ agent, highlightTags = [] }: AgentCardProps) {
               <Button size="sm">Hire Agent</Button>
             </Link>
             <ZapButton targetType="profile" targetId={agent.id} recipientId={agent.id} />
+            <CopyLinkButton path={`/u/${agent.username}`} />
           </div>
         </div>
       </div>

--- a/src/components/gigs/GigCard.tsx
+++ b/src/components/gigs/GigCard.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { AgentBadge } from "@/components/ui/AgentBadge";
 import { VerifiedBadge } from "@/components/ui/VerifiedBadge";
 import { SaveGigButton } from "./SaveGigButton";
+import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
 import { formatCurrency, formatRelativeTime } from "@/lib/utils";
 import { linkifyText } from "@/lib/linkify";
 import type { Gig, Profile } from "@/types";
@@ -103,6 +104,7 @@ export function GigCard({
           {poster?.account_type === "agent" && (
             <AgentBadge size="sm" />
           )}
+          <CopyLinkButton path={detailHref} />
           {showSaveButton && (
             <SaveGigButton
               gigId={gig.id}

--- a/src/components/ui/CopyLinkButton.tsx
+++ b/src/components/ui/CopyLinkButton.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { Link, Check } from "lucide-react";
+
+interface CopyLinkButtonProps {
+  path: string;
+  className?: string;
+}
+
+export function CopyLinkButton({ path, className = "" }: CopyLinkButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const url = `${window.location.origin}${path}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={copied ? "Copied!" : "Copy shareable link"}
+      className={`inline-flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:text-primary hover:bg-muted transition-colors ${className}`}
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-green-500" />
+      ) : (
+        <Link className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
Fixes #100 — adds a "Copy Link" button to all marketplace listing cards so users can copy the shareable public URL instead of manually constructing it or sharing dashboard links that 404.

## Changes
- New `CopyLinkButton` component (`src/components/ui/CopyLinkButton.tsx`) — click to copy, shows green check for 2s
- Added to: **GigCard**, **AgentCard**, **MCP listings**, **Prompt listings**
- Uses `e.preventDefault()` + `e.stopPropagation()` so it works inside `<Link>` wrappers without navigating

## Test plan
- [ ] Click copy button on a gig card → URL copied to clipboard
- [ ] Click copy button on an agent card → correct `/u/{username}` URL
- [ ] Click copy button on MCP/Prompt cards → correct slug-based URL
- [ ] Paste copied URL in incognito → page loads (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)