### PR TITLE
fix: add copy button for shareable marketplace links (closes #100)

### DIFF
--- a/src/app/dashboard/affiliates/DashboardClient.tsx
+++ b/src/app/dashboard/affiliates/DashboardClient.tsx
@@ -98,19 +98,31 @@ function StatCard({
   );
 }
 
-function CopyButton({ text }: { text: string }) {
+function CopyButton({ text, label, stopPropagation }: { text: string; label?: string; stopPropagation?: boolean }) {
   const [copied, setCopied] = useState(false);
   return (
     <Button
       size="sm"
       variant="outline"
-      onClick={() => {
+      title={label}
+      onClick={(e) => {
+        if (stopPropagation) e.preventDefault();
         navigator.clipboard.writeText(text);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       }}
     >
-      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? (
+        <>
+          <Check className="h-3.5 w-3.5 mr-1" />
+          <span className="text-xs">Copied!</span>
+        </>
+      ) : (
+        <>
+          <Copy className="h-3.5 w-3.5 mr-1" />
+          {label && <span className="text-xs">{label}</span>}
+        </>
+      )}
     </Button>
   );
 }
@@ -424,13 +436,20 @@ export default function AffiliateDashboardClient() {
                           : `${Math.round(offer.commission_rate * 100)}% commission`}
                       </div>
                     </div>
-                    <div className="text-right">
-                      <div className="font-medium text-amber-500 flex items-center gap-1">
-                        <Zap className="h-4 w-4 fill-amber-500" />
-                        {formatSats(offer.total_revenue_sats || 0)} sats
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        revenue
+                    <div className="flex items-center gap-3">
+                      <CopyButton
+                        text={`${window.location.origin}/affiliates/${offer.slug}`}
+                        label="Share"
+                        stopPropagation
+                      />
+                      <div className="text-right">
+                        <div className="font-medium text-amber-500 flex items-center gap-1">
+                          <Zap className="h-4 w-4 fill-amber-500" />
+                          {formatSats(offer.total_revenue_sats || 0)} sats
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          revenue
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/app/dashboard/affiliates/[id]/page.tsx
+++ b/src/app/dashboard/affiliates/[id]/page.tsx
@@ -71,12 +71,13 @@ function formatSats(sats: number): string {
   return sats.toLocaleString();
 }
 
-function CopyButton({ text }: { text: string }) {
+function CopyButton({ text, label }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
   return (
     <Button
       size="sm"
       variant="outline"
+      title={label}
       onClick={() => {
         navigator.clipboard.writeText(text);
         setCopied(true);
@@ -84,9 +85,15 @@ function CopyButton({ text }: { text: string }) {
       }}
     >
       {copied ? (
-        <Check className="h-3.5 w-3.5" />
+        <>
+          <Check className="h-3.5 w-3.5 mr-1" />
+          <span className="text-xs">Copied!</span>
+        </>
       ) : (
-        <Copy className="h-3.5 w-3.5" />
+        <>
+          <Copy className="h-3.5 w-3.5 mr-1" />
+          {label && <span className="text-xs">{label}</span>}
+        </>
       )}
     </Button>
   );
@@ -313,12 +320,18 @@ export default function SellerOfferDetailPage() {
               </span>
             </label>
           </div>
-          <Link href={`/affiliates/${offer.slug}/edit`}>
-            <Button variant="outline" size="sm">
-              <Pencil className="h-4 w-4 mr-2" />
-              Edit Offer
-            </Button>
-          </Link>
+          <div className="flex items-center gap-2">
+            <CopyButton
+              text={`${typeof window !== "undefined" ? window.location.origin : ""}/affiliates/${offer.slug}`}
+              label="Copy shareable link"
+            />
+            <Link href={`/affiliates/${offer.slug}/edit`}>
+              <Button variant="outline" size="sm">
+                <Pencil className="h-4 w-4 mr-2" />
+                Edit Offer
+              </Button>
+            </Link>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Closes #100

## Problem
Sellers copy the dashboard URL (`/dashboard/affiliates/:id`) and share it with potential affiliates. That URL is auth-gated → **404** for anyone who clicks it.

## Fix
Added a **Share** button that copies the correct public URL (`/affiliates/:slug`) with visual "Copied!" feedback.

**Changes:**
- `DashboardClient.tsx` — Share button on each seller offer card. `e.preventDefault()` ensures clicking the button doesn't navigate away.
- `[id]/page.tsx` — "Copy shareable link" button next to Edit Offer in the offer header.
- Both `CopyButton` components updated to support optional `label` prop + "Copied!" text feedback.