### PR TITLE
fix: only append ugig_ref to internal redirect URLs

### DIFF
--- a/src/app/api/affiliates/click/route.ts
+++ b/src/app/api/affiliates/click/route.ts
@@ -59,9 +59,12 @@ export async function GET(request: NextRequest) {
       redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"}/affiliates/${offer.slug}`;
     }
 
-    // Add ref param to destination for client-side cookie tracking
+    // Add ref param to destination for client-side cookie tracking (internal URLs only)
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
     const dest = new URL(redirectUrl);
-    dest.searchParams.set("ugig_ref", ref);
+    if (dest.origin === new URL(appUrl).origin) {
+      dest.searchParams.set("ugig_ref", ref);
+    }
 
     // Set affiliate tracking cookie (30 days default, offer can override)
     const response = NextResponse.redirect(dest);


### PR DESCRIPTION
Fixes #95

Only appends `ugig_ref` tracking param when redirecting to ugig.net internal URLs. External `product_url` destinations (e.g. Mercury) no longer receive the meaningless tracking parameter.

## Changes
- Check `dest.origin` matches app URL before appending `ugig_ref`
- External redirects rely solely on `aff_ref` cookie for attribution

## Before
```
GET /api/affiliates/click?ugig_ref=nullref-9fd38c
→ 307 Location: https://mercury.com/r/profullstack?ugig_ref=nullref-9fd38c  ← leaks tracking
```

## After
```
GET /api/affiliates/click?ugig_ref=nullref-9fd38c
→ 307 Location: https://mercury.com/r/profullstack  ← clean external URL
```

🤖 Generated with Claude Code