### PR TITLE
Send referral invite emails

### DIFF
--- a/src/app/api/referrals/route.test.ts
+++ b/src/app/api/referrals/route.test.ts
@@ -14,6 +14,13 @@ vi.mock("@/lib/supabase/service", () => ({
   createServiceClient: () => mockCreateServiceClient(),
 }));
 
+const mockSendEmail = vi.fn();
+const mockReferralInviteEmail = vi.fn();
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+  referralInviteEmail: (...args: unknown[]) => mockReferralInviteEmail(...args),
+}));
+
 const mockSelect = vi.fn();
 const mockInsert = vi.fn();
 const mockEq = vi.fn();
@@ -64,6 +71,12 @@ describe("GET /api/referrals", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateServiceClient.mockReturnValue(makeServiceClientWithNoExistingReferrals());
+    mockReferralInviteEmail.mockReturnValue({
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+    mockSendEmail.mockResolvedValue({ success: true });
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -143,7 +156,7 @@ describe("POST /api/referrals", () => {
     const mockSelectChain = {
       eq: vi.fn().mockReturnValue({
         single: vi.fn().mockResolvedValue({
-          data: { referral_code: "testuser", username: "testuser" },
+          data: { referral_code: "testuser", username: "testuser", full_name: "Test User" },
           error: null,
         }),
       }),
@@ -164,7 +177,57 @@ describe("POST /api/referrals", () => {
     const res = await POST(makePostRequest({ emails: ["friend@test.com"] }));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.message).toContain("1 invite(s) created");
+    expect(body.message).toContain("1 invite(s) created and sent");
+    expect(body.email_delivery_failed).toBe(0);
+    expect(mockReferralInviteEmail).toHaveBeenCalledWith({
+      inviterName: "Test User",
+      referralCode: "testuser",
+    });
+    expect(mockSendEmail).toHaveBeenCalledWith({
+      to: "friend@test.com",
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+  });
+
+  it("should keep created invites when email delivery fails", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+    mockSendEmail.mockResolvedValueOnce({ success: false, error: "resend failed" });
+
+    const mockSelectChain = {
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { referral_code: null, username: "testuser", full_name: null },
+          error: null,
+        }),
+      }),
+    };
+    const mockInsertChain = {
+      select: vi.fn().mockResolvedValue({
+        data: [{ id: "ref1", referred_email: "friend@test.com", status: "pending" }],
+        error: null,
+      }),
+    };
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "profiles") return { select: () => mockSelectChain };
+      if (table === "referrals") return { insert: () => mockInsertChain };
+      return {};
+    });
+
+    const res = await POST(makePostRequest({ emails: ["friend@test.com"] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain("1 email(s) failed to send");
+    expect(body.email_delivery_failed).toBe(1);
+    expect(mockReferralInviteEmail).toHaveBeenCalledWith({
+      inviterName: "testuser",
+      referralCode: "testuser",
+    });
   });
 
   it("should return 400 for invalid emails only", async () => {

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
+import { referralInviteEmail, sendEmail } from "@/lib/email";
 import { createServiceClient } from "@/lib/supabase/service";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 
 // GET /api/referrals - List my referrals
@@ -25,7 +25,6 @@ export async function GET(request: NextRequest) {
     }
 
     const total = referrals?.length || 0;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const registered = referrals?.filter((r: any) => r.status !== "pending").length || 0;
 
     return NextResponse.json({
@@ -120,10 +119,9 @@ export async function POST(request: NextRequest) {
     }
 
     // Get user's referral code
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: profile } = await (supabase as any)
       .from("profiles")
-      .select("referral_code, username")
+      .select("referral_code, username, full_name")
       .eq("id", user.id)
       .single();
 
@@ -132,6 +130,7 @@ export async function POST(request: NextRequest) {
     }
 
     const referralCode = profile.referral_code || profile.username;
+    const inviterName = profile.full_name || profile.username || "Someone";
 
     // Validate emails and create referrals
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -160,9 +159,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
+    const emailContent = referralInviteEmail({ inviterName, referralCode });
+    const emailResults = await Promise.all(
+      validEmails.map((email: string) =>
+        sendEmail({ to: email, ...emailContent })
+      )
+    );
+    const failedEmailCount = emailResults.filter((result) => !result.success).length;
+
     return NextResponse.json({
-      message: `${validEmails.length} invite(s) created`,
+      message: failedEmailCount > 0
+        ? `${validEmails.length} invite(s) created; ${failedEmailCount} email(s) failed to send`
+        : `${validEmails.length} invite(s) created and sent`,
       data: referrals,
+      email_delivery_failed: failedEmailCount,
     });
   } catch {
     return NextResponse.json(

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { videoCallInviteEmail } from "./email";
+import { referralInviteEmail, videoCallInviteEmail } from "./email";
 
 describe("videoCallInviteEmail", () => {
   beforeEach(() => {
@@ -109,5 +109,23 @@ describe("videoCallInviteEmail", () => {
     });
 
     expect(result.html).toContain("https://ugig.net/dashboard/calls/call-123");
+  });
+});
+
+describe("referralInviteEmail", () => {
+  beforeEach(() => {
+    vi.stubEnv("APP_URL", "https://ugig.net");
+  });
+
+  it("generates a signup invite with the referral code", () => {
+    const result = referralInviteEmail({
+      inviterName: "Codex Earner",
+      referralCode: "codex/ref code",
+    });
+
+    expect(result.subject).toBe("Codex Earner invited you to join ugig.net");
+    expect(result.html).toContain("https://ugig.net/signup?ref=codex%2Fref%20code");
+    expect(result.text).toContain("https://ugig.net/signup?ref=codex%2Fref%20code");
+    expect(result.html).toContain("Accept Invite");
   });
 });

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -145,6 +145,68 @@ ugig.net - AI-Powered Gig Marketplace
   };
 }
 
+export function referralInviteEmail(params: {
+  inviterName: string;
+  referralCode: string;
+}) {
+  const { inviterName, referralCode } = params;
+  const baseUrl = getBaseUrl();
+  const signupUrl = `${baseUrl}/signup?ref=${encodeURIComponent(referralCode)}`;
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Join ugig.net</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; border-radius: 10px 10px 0 0;">
+    <h1 style="color: white; margin: 0; font-size: 24px;">You're invited to ugig.net</h1>
+  </div>
+
+  <div style="background: #f9fafb; padding: 30px; border: 1px solid #e5e7eb; border-top: none;">
+    <p style="margin-top: 0;">Hi there,</p>
+
+    <p><strong>${inviterName}</strong> invited you to join ugig.net, a marketplace for AI-assisted professionals.</p>
+
+    <a href="${signupUrl}" style="display: inline-block; background: #667eea; color: white; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500; margin-top: 10px;">
+      Accept Invite
+    </a>
+
+    <p style="color: #6b7280; font-size: 14px; margin-top: 30px;">
+      Use this invite link to create your account and connect the referral automatically.
+    </p>
+  </div>
+
+  <div style="text-align: center; padding: 20px; color: #9ca3af; font-size: 12px;">
+    <p style="margin: 0;">ugig.net - AI-Powered Gig Marketplace</p>
+  </div>
+</body>
+</html>
+`;
+
+  const text = `
+You're invited to ugig.net
+
+Hi there,
+
+${inviterName} invited you to join ugig.net, a marketplace for AI-assisted professionals.
+
+Accept the invite: ${signupUrl}
+
+---
+ugig.net - AI-Powered Gig Marketplace
+`;
+
+  return {
+    subject: `${inviterName} invited you to join ugig.net`,
+    html,
+    text,
+  };
+}
+
 export function newApplicationEmail(params: {
   posterName: string;
   applicantName: string;


### PR DESCRIPTION
## Summary

Fixes #109. The Invite Friends flow now dispatches an actual referral invite email after creating referral rows, instead of only recording pending rows.

Changes:
- add `referralInviteEmail()` with a signup link carrying the referral code
- call `sendEmail()` after successful `/api/referrals` row creation
- preserve created referral rows if email delivery fails and report `email_delivery_failed`
- cover the route dispatch and email template with focused tests

## Validation

- `corepack pnpm@10.14.0 vitest run src/app/api/referrals/route.test.ts src/lib/email.test.ts`
- `corepack pnpm@10.14.0 exec eslint src/app/api/referrals/route.ts src/app/api/referrals/route.test.ts src/lib/email.ts src/lib/email.test.ts`
- `corepack pnpm@10.14.0 type-check`
- `git diff --check`

Note: local install was run with `--ignore-scripts` to avoid executing dependency build scripts in the worktree; focused validation above passed.