### PR TITLE
fix: honor affiliate cookie attribution window

### DIFF
--- a/src/app/api/affiliates/click/route.ts
+++ b/src/app/api/affiliates/click/route.ts
@@ -18,13 +18,14 @@ export async function GET(request: NextRequest) {
     const admin = createServiceClient();
 
     // Look up the offer from the tracking code
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: app } = await (admin as any)
       .from("affiliate_applications")
-      .select(`
+      .select(
+        `
         offer_id,
-        affiliate_offers!inner(product_url, slug, listing_id, skill_listings(slug))
-      `)
+        affiliate_offers!inner(product_url, slug, listing_id, cookie_days, skill_listings(slug))
+      `
+      )
       .eq("tracking_code", ref)
       .eq("status", "approved")
       .single();
@@ -34,9 +35,10 @@ export async function GET(request: NextRequest) {
     }
 
     // Record the click
-    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
-      || request.headers.get("x-real-ip")
-      || "unknown";
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      request.headers.get("x-real-ip") ||
+      "unknown";
 
     await recordClick(admin, {
       trackingCode: ref,
@@ -63,13 +65,15 @@ export async function GET(request: NextRequest) {
     const dest = new URL(redirectUrl);
     dest.searchParams.set("ugig_ref", ref);
 
-    // Set affiliate tracking cookie (30 days default, offer can override)
+    const cookieDays = offer.cookie_days || 30;
+
+    // Set affiliate tracking cookie for the offer's attribution window
     const response = NextResponse.redirect(dest);
     response.cookies.set("aff_ref", ref, {
       httpOnly: true,
       secure: true,
       sameSite: "lax",
-      maxAge: 30 * 24 * 60 * 60, // 30 days
+      maxAge: cookieDays * 24 * 60 * 60,
       path: "/",
     });
 

--- a/src/lib/affiliates/tracking.test.ts
+++ b/src/lib/affiliates/tracking.test.ts
@@ -1,5 +1,88 @@
-import { describe, it, expect } from "vitest";
-import { generateTrackingCode, hashIP } from "./tracking";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { findAttribution, generateTrackingCode, hashIP } from "./tracking";
+
+type MockClick = {
+  id: string;
+  offer_id: string;
+  affiliate_id: string;
+  tracking_code: string;
+  visitor_id?: string | null;
+  created_at: string;
+};
+
+function makeAffiliateSupabase({
+  application,
+  offer,
+  clicks,
+}: {
+  application?: { affiliate_id: string; tracking_code: string; status: string; offer_id: string };
+  offer?: { id: string; cookie_days: number };
+  clicks?: MockClick[];
+}) {
+  return {
+    from(table: string) {
+      const state: {
+        filters: Record<string, unknown>;
+        gte: Record<string, string>;
+        limit?: number;
+      } = { filters: {}, gte: {} };
+      const builder: Record<string, unknown> = {};
+
+      builder.select = () => builder;
+      builder.eq = (column: string, value: unknown) => {
+        state.filters[column] = value;
+        return builder;
+      };
+      builder.gte = (column: string, value: string) => {
+        state.gte[column] = value;
+        return builder;
+      };
+      builder.order = () => builder;
+      builder.limit = (limit: number) => {
+        state.limit = limit;
+        let rows = clicks || [];
+        rows = rows.filter((click) =>
+          Object.entries(state.filters).every(
+            ([key, value]) => click[key as keyof MockClick] === value
+          )
+        );
+        if (state.gte.created_at) {
+          rows = rows.filter((click) => click.created_at >= state.gte.created_at);
+        }
+        rows = [...rows].sort((a, b) => b.created_at.localeCompare(a.created_at));
+        return Promise.resolve({ data: rows.slice(0, limit), error: null });
+      };
+      builder.single = () => {
+        if (table === "affiliate_applications" && application) {
+          const matches =
+            state.filters.tracking_code === application.tracking_code &&
+            state.filters.offer_id === application.offer_id &&
+            state.filters.status === application.status;
+          return Promise.resolve({
+            data: matches ? application : null,
+            error: matches ? null : { message: "Not found" },
+          });
+        }
+
+        if (table === "affiliate_offers" && offer) {
+          const matches = state.filters.id === offer.id;
+          return Promise.resolve({
+            data: matches ? offer : null,
+            error: matches ? null : { message: "Not found" },
+          });
+        }
+
+        return Promise.resolve({ data: null, error: { message: "Not found" } });
+      };
+
+      return builder;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("generateTrackingCode", () => {
   it("includes username in the code", () => {
@@ -33,5 +116,99 @@ describe("hashIP", () => {
   it("returns a 16-char hex string", () => {
     const hash = hashIP("1.2.3.4");
     expect(hash).toMatch(/^[a-f0-9]{16}$/);
+  });
+});
+
+describe("findAttribution", () => {
+  it("credits a tracking code only when a click is inside the offer cookie window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T12:00:00Z"));
+
+    const admin = makeAffiliateSupabase({
+      application: {
+        affiliate_id: "aff-1",
+        tracking_code: "alice-abc123",
+        status: "approved",
+        offer_id: "offer-1",
+      },
+      offer: { id: "offer-1", cookie_days: 1 },
+      clicks: [
+        {
+          id: "click-1",
+          offer_id: "offer-1",
+          affiliate_id: "aff-1",
+          tracking_code: "alice-abc123",
+          created_at: "2026-05-20T06:00:00Z",
+        },
+      ],
+    });
+
+    const result = await findAttribution(admin as any, {
+      offerId: "offer-1",
+      trackingCode: "alice-abc123",
+    });
+
+    expect(result).toEqual({
+      affiliated: true,
+      affiliate_id: "aff-1",
+      click_id: "click-1",
+      tracking_code: "alice-abc123",
+    });
+  });
+
+  it("does not credit an expired tracking-code cookie", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T12:00:00Z"));
+
+    const admin = makeAffiliateSupabase({
+      application: {
+        affiliate_id: "aff-1",
+        tracking_code: "alice-abc123",
+        status: "approved",
+        offer_id: "offer-1",
+      },
+      offer: { id: "offer-1", cookie_days: 1 },
+      clicks: [
+        {
+          id: "old-click",
+          offer_id: "offer-1",
+          affiliate_id: "aff-1",
+          tracking_code: "alice-abc123",
+          created_at: "2026-05-18T12:00:00Z",
+        },
+      ],
+    });
+
+    const result = await findAttribution(admin as any, {
+      offerId: "offer-1",
+      trackingCode: "alice-abc123",
+    });
+
+    expect(result).toEqual({ affiliated: false });
+  });
+
+  it("does not attribute buyer-id-only lookups to the latest offer click", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T12:00:00Z"));
+
+    const admin = makeAffiliateSupabase({
+      offer: { id: "offer-1", cookie_days: 30 },
+      clicks: [
+        {
+          id: "click-1",
+          offer_id: "offer-1",
+          affiliate_id: "aff-1",
+          tracking_code: "alice-abc123",
+          created_at: "2026-05-20T06:00:00Z",
+        },
+      ],
+    });
+
+    const result = await findAttribution(admin as any, {
+      offerId: "offer-1",
+      buyerId: "buyer-1",
+    });
+
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/affiliates/tracking.ts
+++ b/src/lib/affiliates/tracking.ts
@@ -1,15 +1,29 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import crypto from "crypto";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
+
+async function getAttributionWindowStart(admin: SupabaseClient, offerId: string): Promise<string> {
+  const { data: offer } = await (admin as AnySupabase)
+    .from("affiliate_offers")
+    .select("cookie_days")
+    .eq("id", offerId)
+    .single();
+
+  const cookieDays = offer?.cookie_days || 30;
+  return new Date(Date.now() - cookieDays * 24 * 60 * 60 * 1000).toISOString();
+}
 
 /**
  * Generate a unique tracking code for an affiliate+offer pair.
  */
 export function generateTrackingCode(username: string, offerSlug: string): string {
   const base = `${username}-${offerSlug}`;
-  const hash = crypto.createHash("sha256").update(base + Date.now()).digest("hex").slice(0, 6);
+  const hash = crypto
+    .createHash("sha256")
+    .update(base + Date.now())
+    .digest("hex")
+    .slice(0, 6);
   return `${username}-${hash}`;
 }
 
@@ -147,34 +161,35 @@ export async function findAttribution(
       .single();
 
     if (app) {
-      // Find the most recent click for this tracking code
+      const windowStart = await getAttributionWindowStart(admin, offerId);
+
+      // Require a real click inside the offer's attribution window.
       const { data: clicks } = await (admin as AnySupabase)
         .from("affiliate_clicks")
         .select("id")
         .eq("tracking_code", trackingCode)
+        .eq("offer_id", offerId)
+        .gte("created_at", windowStart)
         .order("created_at", { ascending: false })
         .limit(1);
+
+      if (!clicks || clicks.length === 0) {
+        return { affiliated: false };
+      }
 
       return {
         affiliated: true,
         affiliate_id: app.affiliate_id,
-        click_id: clicks?.[0]?.id,
+        click_id: clicks[0].id,
         tracking_code: app.tracking_code,
       };
     }
   }
 
-  if (!visitorId && !buyerId) return null;
+  if (!visitorId) return null;
 
   // Fallback: search by visitor_id within cookie window
-  const { data: offer } = await (admin as AnySupabase)
-    .from("affiliate_offers")
-    .select("cookie_days")
-    .eq("id", offerId)
-    .single();
-
-  const cookieDays = offer?.cookie_days || 30;
-  const windowStart = new Date(Date.now() - cookieDays * 24 * 60 * 60 * 1000).toISOString();
+  const windowStart = await getAttributionWindowStart(admin, offerId);
 
   let query = (admin as AnySupabase)
     .from("affiliate_clicks")


### PR DESCRIPTION
Fixes #111.

## Summary

- use each offer's `cookie_days` value when setting the `aff_ref` cookie
- require a recorded click inside the offer attribution window before crediting a tracking-code cookie
- stop buyer-id-only attribution from falling through to the latest unrelated offer click
- add focused coverage for valid, expired, and buyer-id-only attribution cases

## Validation

- `corepack pnpm@10.14.0 vitest run src/lib/affiliates/tracking.test.ts 'src/app/api/skills/[slug]/purchase/route.test.ts'`
- `corepack pnpm@10.14.0 exec eslint src/lib/affiliates/tracking.ts src/lib/affiliates/tracking.test.ts src/app/api/affiliates/click/route.ts`
- `corepack pnpm@10.14.0 type-check`
- `git diff --check`

Install was run with `corepack pnpm@10.14.0 install --ignore-scripts`.
