### PR TITLE
fix: use NEXT_PUBLIC_APP_URL for affiliate fallback redirects

### DIFF
--- a/src/app/api/affiliates/click/route.ts
+++ b/src/app/api/affiliates/click/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
     const ref = searchParams.get("ugig_ref");
 
     if (!ref) {
-      return NextResponse.redirect(new URL("/affiliates", request.url));
+      return NextResponse.redirect(new URL("/affiliates", process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"));
     }
 
     const admin = createServiceClient();
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
       .single();
 
     if (!app) {
-      return NextResponse.redirect(new URL("/affiliates", request.url));
+      return NextResponse.redirect(new URL("/affiliates", process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"));
     }
 
     // Read or generate a persistent visitor ID from cookie
@@ -99,6 +99,6 @@ export async function GET(request: NextRequest) {
     return response;
   } catch (err) {
     console.error("Affiliate click error:", err);
-    return NextResponse.redirect(new URL("/affiliates", request.url));
+    return NextResponse.redirect(new URL("/affiliates", process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"));
   }
 }


### PR DESCRIPTION
﻿## What

Replaces request.url with NEXT_PUBLIC_APP_URL for fallback redirects in the affiliate click endpoint.

## Why

Closes #94. Behind Railway's reverse proxy, request.url contains the internal server URL (http://localhost:8080) instead of the public-facing URL. This causes fallback redirects to send users to an unreachable localhost URL.

## How

Changed three fallback redirects in src/app/api/affiliates/click/route.ts:
- Missing ref param
- Invalid/unknown ref
- Catch-all error handler

All now use process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net" as the base URL, matching the pattern already used elsewhere in the same file.

## Testing

- Code compiles and follows existing patterns
- Uses same env var approach already proven in the file
