### PR TITLE
Fix affiliate conversion idempotency

### DIFF
--- a/src/lib/affiliates/commission.test.ts
+++ b/src/lib/affiliates/commission.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { calculateCommission, calculatePlatformFee } from "./commission";
+import { calculateCommission, calculatePlatformFee, recordConversion } from "./commission";
 
 describe("calculateCommission", () => {
   it("calculates percentage commission", () => {
@@ -46,5 +46,153 @@ describe("calculatePlatformFee", () => {
 
   it("returns 0 for zero commission", () => {
     expect(calculatePlatformFee(0)).toBe(0);
+  });
+});
+
+function createAdminMock(options: {
+  existingConversion?: { id: string; commission_sats: number; settles_at: string };
+  existingConversionAfterInsertConflict?: { id: string; commission_sats: number; settles_at: string };
+  insertError?: { code?: string; message: string };
+} = {}) {
+  const calls: Array<{ table: string; op: string; payload?: unknown }> = [];
+  let conversionLookupCount = 0;
+
+  const admin = {
+    from(table: string) {
+      const query = {
+        table,
+        op: "",
+        payload: undefined as unknown,
+        select() {
+          this.op = "select";
+          calls.push({ table, op: "select" });
+          return this;
+        },
+        eq() {
+          return this;
+        },
+        maybeSingle() {
+          calls.push({ table, op: "maybeSingle" });
+          if (table === "affiliate_conversions") {
+            conversionLookupCount += 1;
+            const conversion =
+              conversionLookupCount === 1
+                ? options.existingConversion
+                : options.existingConversionAfterInsertConflict;
+
+            return Promise.resolve({ data: conversion ?? null, error: null });
+          }
+
+          return Promise.resolve({ data: null, error: null });
+        },
+        single() {
+          calls.push({ table, op: `${this.op}.single` });
+
+          if (table === "affiliate_offers") {
+            return Promise.resolve({
+              data: {
+                id: "offer_1",
+                seller_id: "seller_1",
+                commission_rate: 0.2,
+                commission_type: "percentage",
+                commission_flat_sats: 0,
+                settlement_delay_days: 7,
+                total_conversions: 1,
+                total_revenue_sats: 10000,
+                total_commissions_sats: 2000,
+              },
+              error: null,
+            });
+          }
+
+          if (table === "affiliate_conversions" && this.payload) {
+            if (options.insertError) {
+              return Promise.resolve({ data: null, error: options.insertError });
+            }
+
+            return Promise.resolve({ data: { id: "conversion_1" }, error: null });
+          }
+
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert(payload: unknown) {
+          this.op = "insert";
+          this.payload = payload;
+          calls.push({ table, op: "insert", payload });
+          return this;
+        },
+        update(payload: unknown) {
+          this.op = "update";
+          this.payload = payload;
+          calls.push({ table, op: "update", payload });
+          return this;
+        },
+        limit() {
+          return this;
+        },
+        lte() {
+          return this;
+        },
+      };
+
+      return query;
+    },
+  };
+
+  return { admin, calls };
+}
+
+describe("recordConversion", () => {
+  it("returns an existing purchase conversion without inserting or incrementing metrics", async () => {
+    const existingConversion = {
+      id: "conversion_existing",
+      commission_sats: 2500,
+      settles_at: "2026-05-27T00:00:00.000Z",
+    };
+    const { admin, calls } = createAdminMock({ existingConversion });
+
+    const result = await recordConversion(admin as never, {
+      offerId: "offer_1",
+      affiliateId: "affiliate_1",
+      purchaseId: "purchase_1",
+      saleAmountSats: 12500,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      conversion_id: "conversion_existing",
+      commission_sats: 2500,
+      settles_at: "2026-05-27T00:00:00.000Z",
+    });
+    expect(calls.some((call) => call.op === "insert")).toBe(false);
+    expect(calls.some((call) => call.op === "update")).toBe(false);
+    expect(calls.some((call) => call.table === "affiliate_offers")).toBe(false);
+  });
+
+  it("returns the existing conversion after a unique-index race", async () => {
+    const { admin, calls } = createAdminMock({
+      insertError: { code: "23505", message: "duplicate key value violates unique constraint" },
+      existingConversionAfterInsertConflict: {
+        id: "conversion_winner",
+        commission_sats: 2000,
+        settles_at: "2026-05-27T00:00:00.000Z",
+      },
+    });
+
+    const result = await recordConversion(admin as never, {
+      offerId: "offer_1",
+      affiliateId: "affiliate_1",
+      purchaseId: "purchase_1",
+      saleAmountSats: 10000,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      conversion_id: "conversion_winner",
+      commission_sats: 2000,
+      settles_at: "2026-05-27T00:00:00.000Z",
+    });
+    expect(calls.filter((call) => call.op === "insert")).toHaveLength(1);
+    expect(calls.some((call) => call.op === "update")).toBe(false);
   });
 });

--- a/src/lib/affiliates/commission.ts
+++ b/src/lib/affiliates/commission.ts
@@ -1,7 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { AFFILIATE_DEFAULTS, PLATFORM_WALLET_USER_ID } from "@/lib/constants";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 
 
@@ -21,6 +20,33 @@ export interface CommissionResult {
   commission_sats?: number;
   settles_at?: string;
   error?: string;
+}
+
+async function findConversionByPurchaseId(
+  admin: SupabaseClient,
+  purchaseId?: string
+): Promise<CommissionResult | null> {
+  if (!purchaseId) return null;
+
+  const { data, error } = await (admin as AnySupabase)
+    .from("affiliate_conversions")
+    .select("id, commission_sats, settles_at")
+    .eq("purchase_id", purchaseId)
+    .maybeSingle();
+
+  if (error) {
+    console.warn("Failed to check existing affiliate conversion:", error);
+    return null;
+  }
+
+  if (!data) return null;
+
+  return {
+    ok: true,
+    conversion_id: data.id,
+    commission_sats: data.commission_sats,
+    settles_at: data.settles_at,
+  };
 }
 
 /**
@@ -60,6 +86,9 @@ export async function recordConversion(
 ): Promise<CommissionResult> {
   const { offerId, affiliateId, buyerId, clickId, purchaseId, saleAmountSats } = params;
 
+  const existing = await findConversionByPurchaseId(admin, purchaseId);
+  if (existing) return existing;
+
   // Fetch offer
   const { data: offer, error: offerErr } = await (admin as AnySupabase)
     .from("affiliate_offers")
@@ -97,6 +126,11 @@ export async function recordConversion(
     .single();
 
   if (convErr) {
+    if (purchaseId && convErr.code === "23505") {
+      const raceWinner = await findConversionByPurchaseId(admin, purchaseId);
+      if (raceWinner) return raceWinner;
+    }
+
     console.error("Failed to create conversion:", convErr);
     return { ok: false, error: convErr.message };
   }

--- a/supabase/migrations/20260520114500_affiliate_conversion_purchase_id_unique.sql
+++ b/supabase/migrations/20260520114500_affiliate_conversion_purchase_id_unique.sql
@@ -1,0 +1,4 @@
+-- Prevent duplicate affiliate commissions for the same marketplace purchase.
+CREATE UNIQUE INDEX IF NOT EXISTS affiliate_conversions_purchase_id_unique
+  ON affiliate_conversions (purchase_id)
+  WHERE purchase_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- fixes #114
- makes `recordConversion()` idempotent for non-null `purchaseId` by returning the existing conversion before inserting
- handles the concurrent retry race by returning the existing row after a Postgres `23505` unique-constraint conflict
- adds a partial unique index on `affiliate_conversions(purchase_id)` for non-null purchase ids
- adds regression tests that prove duplicate purchase processing does not insert a second conversion or increment offer metrics

## Validation
- `pnpm test:run src/lib/affiliates/commission.test.ts` -> 9 passed
- `pnpm type-check`
- `pnpm exec eslint src/lib/affiliates/commission.ts src/lib/affiliates/commission.test.ts`
- `git diff --check`
- pre-commit lint/type-check/full test run reached `123 passed` test files / `1347 passed` tests
- `OPENAI_API_KEY=sk-build-placeholder pnpm build` compiled and TypeScript passed, then stopped during static prerender because this local worktree lacks Supabase service-role configuration for `/blog`; no source/build error from this PR was reported before that environment gate