### PR TITLE
Add affiliate commission estimates

### DIFF
--- a/src/app/api/affiliates/offers/[id]/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/route.test.ts
@@ -106,6 +106,29 @@ describe("GET /api/affiliates/offers/[id]", () => {
     expect(body.offer.product_url).toBeUndefined();
   });
 
+  it("includes commission estimate fields in offer details (#90)", async () => {
+    const offer = {
+      id: "some-uuid",
+      title: "Percentage Offer",
+      seller_id: "seller1",
+      slug: "percentage-offer",
+      commission_type: "percentage",
+      commission_rate: 0.2,
+      commission_flat_sats: 0,
+      price_sats: 2500,
+    };
+
+    mockFrom.mockReturnValue(chainable(offer));
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await GET(makeRequest("percentage-offer"), makeParams("percentage-offer"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.offer.estimated_commission_sats).toBe(500);
+    expect(body.offer.commission_basis).toBe("listed_price");
+  });
+
   it("returns 404 for non-existent offer", async () => {
     mockFrom.mockReturnValue(chainable(null, { message: "not found" }));
 

--- a/src/app/api/affiliates/offers/[id]/route.ts
+++ b/src/app/api/affiliates/offers/[id]/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
+import { withCommissionEstimate } from "@/lib/affiliates/commission";
 import { createServiceClient } from "@/lib/supabase/service";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnySupabase = any;
 import { validateOfferInput } from "@/lib/affiliates/validation";
 
+type AnySupabase = any;
 
 /**
  * GET /api/affiliates/offers/[id] - Get offer details
@@ -57,12 +56,14 @@ export async function GET(
       isApprovedAffiliate = !!app;
     }
 
+    const offerWithEstimate = withCommissionEstimate(offer);
+
     if (!isOwner && !isApprovedAffiliate) {
-      const { product_url, ...safeOffer } = offer;
+      const { product_url, ...safeOffer } = offerWithEstimate;
       return NextResponse.json({ offer: safeOffer });
     }
 
-    return NextResponse.json({ offer });
+    return NextResponse.json({ offer: offerWithEstimate });
   } catch {
     return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }

--- a/src/app/api/affiliates/offers/route.test.ts
+++ b/src/app/api/affiliates/offers/route.test.ts
@@ -98,6 +98,50 @@ describe("GET /api/affiliates/offers", () => {
     expect(res.status).toBe(200);
     expect(body.offers[0].product_url).toBeUndefined();
   });
+
+  it("includes commission estimate fields for affiliates (#90)", async () => {
+    const offers = [
+      {
+        id: "flat",
+        title: "Flat Offer",
+        seller_id: "seller1",
+        commission_type: "flat",
+        commission_rate: 0.2,
+        commission_flat_sats: 1500,
+        price_sats: 0,
+      },
+      {
+        id: "percentage",
+        title: "Percentage Offer",
+        seller_id: "seller2",
+        commission_type: "percentage",
+        commission_rate: 0.2,
+        commission_flat_sats: 0,
+        price_sats: 10000,
+      },
+      {
+        id: "variable",
+        title: "Variable Offer",
+        seller_id: "seller3",
+        commission_type: "percentage",
+        commission_rate: 0.2,
+        commission_flat_sats: 0,
+        price_sats: 0,
+      },
+    ];
+    mockFrom.mockReturnValue(chainable(offers, null, offers.length));
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.offers).toMatchObject([
+      { id: "flat", estimated_commission_sats: 1500, commission_basis: "flat" },
+      { id: "percentage", estimated_commission_sats: 2000, commission_basis: "listed_price" },
+      { id: "variable", estimated_commission_sats: null, commission_basis: "sale_amount" },
+    ]);
+  });
 });
 
 describe("POST /api/affiliates/offers", () => {

--- a/src/app/api/affiliates/offers/route.ts
+++ b/src/app/api/affiliates/offers/route.ts
@@ -2,11 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, rateLimitExceeded, getRateLimitIdentifier } from "@/lib/rate-limit";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnySupabase = any;
+import { withCommissionEstimate } from "@/lib/affiliates/commission";
 import { validateOfferInput } from "@/lib/affiliates/validation";
 
+type AnySupabase = any;
 
 function slugify(text: string): string {
   return text
@@ -102,13 +101,14 @@ export async function GET(request: NextRequest) {
     }
 
     const sanitizedOffers = (offers || []).map((offer: any) => {
+      const offerWithEstimate = withCommissionEstimate(offer);
       const isOwner = auth && offer.seller_id === auth.user.id;
       const isApprovedAffiliate = auth && approvedOfferIds.has(offer.id);
       if (!isOwner && !isApprovedAffiliate) {
-        const { product_url, ...rest } = offer;
+        const { product_url, ...rest } = offerWithEstimate;
         return rest;
       }
-      return offer;
+      return offerWithEstimate;
     });
 
     return NextResponse.json({

--- a/src/lib/affiliates/commission.test.ts
+++ b/src/lib/affiliates/commission.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { calculateCommission, calculatePlatformFee, recordConversion } from "./commission";
+import { calculateCommission, calculatePlatformFee, estimateOfferCommission, recordConversion } from "./commission";
 
 describe("calculateCommission", () => {
   it("calculates percentage commission", () => {
@@ -32,6 +32,50 @@ describe("calculateCommission", () => {
       10000
     );
     expect(result).toBe(0);
+  });
+});
+
+describe("estimateOfferCommission", () => {
+  it("returns exact flat commission estimates", () => {
+    expect(
+      estimateOfferCommission({
+        commission_rate: 0.2,
+        commission_type: "flat",
+        commission_flat_sats: 500,
+        price_sats: 0,
+      })
+    ).toEqual({
+      estimated_commission_sats: 500,
+      commission_basis: "flat",
+    });
+  });
+
+  it("estimates percentage commission from the listed price", () => {
+    expect(
+      estimateOfferCommission({
+        commission_rate: 0.2,
+        commission_type: "percentage",
+        commission_flat_sats: 0,
+        price_sats: 1234,
+      })
+    ).toEqual({
+      estimated_commission_sats: 246,
+      commission_basis: "listed_price",
+    });
+  });
+
+  it("marks zero-price percentage offers as sale-amount dependent", () => {
+    expect(
+      estimateOfferCommission({
+        commission_rate: 0.2,
+        commission_type: "percentage",
+        commission_flat_sats: 0,
+        price_sats: 0,
+      })
+    ).toEqual({
+      estimated_commission_sats: null,
+      commission_basis: "sale_amount",
+    });
   });
 });
 

--- a/src/lib/affiliates/commission.ts
+++ b/src/lib/affiliates/commission.ts
@@ -22,6 +22,16 @@ export interface CommissionResult {
   error?: string;
 }
 
+export interface CommissionEstimate {
+  estimated_commission_sats: number | null;
+  commission_basis: "flat" | "listed_price" | "sale_amount";
+}
+
+type CommissionEstimateOffer = Pick<
+  AffiliateOffer,
+  "commission_rate" | "commission_type" | "commission_flat_sats" | "price_sats"
+>;
+
 async function findConversionByPurchaseId(
   admin: SupabaseClient,
   purchaseId?: string
@@ -60,6 +70,49 @@ export function calculateCommission(
     return offer.commission_flat_sats || 0;
   }
   return Math.floor(saleAmountSats * offer.commission_rate);
+}
+
+/**
+ * Estimate the commission an affiliate can expect from the offer listing.
+ *
+ * Flat offers are exact. Percentage offers are estimated from the public
+ * listing price when one exists; otherwise the real commission depends on the
+ * eventual sale amount passed to recordConversion().
+ */
+export function estimateOfferCommission(offer: CommissionEstimateOffer): CommissionEstimate {
+  const commissionType = offer.commission_type === "flat" ? "flat" : "percentage";
+  const flatSats = Number(offer.commission_flat_sats ?? 0);
+
+  if (commissionType === "flat") {
+    return {
+      estimated_commission_sats: Number.isFinite(flatSats) ? Math.max(0, Math.floor(flatSats)) : 0,
+      commission_basis: "flat",
+    };
+  }
+
+  const priceSats = Number(offer.price_sats ?? 0);
+  const commissionRate = Number(offer.commission_rate ?? 0);
+
+  if (!Number.isFinite(priceSats) || priceSats <= 0 || !Number.isFinite(commissionRate)) {
+    return {
+      estimated_commission_sats: null,
+      commission_basis: "sale_amount",
+    };
+  }
+
+  return {
+    estimated_commission_sats: Math.max(0, Math.floor(priceSats * commissionRate)),
+    commission_basis: "listed_price",
+  };
+}
+
+export function withCommissionEstimate<T extends CommissionEstimateOffer>(
+  offer: T
+): T & CommissionEstimate {
+  return {
+    ...offer,
+    ...estimateOfferCommission(offer),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- fixes #90 by adding derived `estimated_commission_sats` and `commission_basis` fields to affiliate offer list/detail API responses
- reports flat offers as exact, percentage offers with a listing price as `listed_price`, and zero-price percentage offers as sale-amount dependent
- keeps `product_url` authorization behavior unchanged while still exposing the safe estimate fields

## Validation
- `pnpm test:run src/lib/affiliates/commission.test.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.test.ts'`\n- `pnpm exec eslint src/lib/affiliates/commission.ts src/lib/affiliates/commission.test.ts src/app/api/affiliates/offers/route.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.ts' 'src/app/api/affiliates/offers/[id]/route.test.ts'`\n- `pnpm type-check`\n- `git diff --check`