### PR TITLE
Require destinations for active affiliate offers

### DIFF
--- a/src/app/affiliates/[slug]/edit/page.tsx
+++ b/src/app/affiliates/[slug]/edit/page.tsx
@@ -32,6 +32,7 @@ export default function EditOfferPage() {
     description: "",
     product_url: "",
     product_type: "digital",
+    listing_id: "",
     price_sats: "",
     commission_rate: "20",
     commission_type: "percentage",
@@ -113,6 +114,7 @@ export default function EditOfferPage() {
             description: o.description || "",
             product_url: o.product_url || "",
             product_type: o.product_type || "digital",
+            listing_id: o.listing_id || "",
             price_sats: String(o.price_sats || 0),
             commission_rate: String(Math.round((o.commission_rate || 0) * 100)),
             commission_type: o.commission_type || "percentage",
@@ -135,13 +137,19 @@ export default function EditOfferPage() {
     setLoading(true);
     setError("");
 
+    if (!form.product_url.trim() && !form.listing_id) {
+      setError("Product URL is required for affiliate offers");
+      setLoading(false);
+      return;
+    }
+
     const res = await fetch(`/api/affiliates/offers/${offerId}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         title: form.title,
         description: form.description,
-        product_url: form.product_url || undefined,
+        product_url: form.product_url.trim() || undefined,
         product_type: form.product_type,
         price_sats: parseInt(form.price_sats) || 0,
         commission_rate: form.commission_type === "percentage" ? parseFloat(form.commission_rate) / 100 : 0,
@@ -250,13 +258,14 @@ export default function EditOfferPage() {
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="product_url">Product URL</Label>
+          <Label htmlFor="product_url">Product URL{form.listing_id ? "" : " *"}</Label>
           <Input
             id="product_url"
             type="url"
             value={form.product_url}
             onChange={(e) => updateForm("product_url", e.target.value)}
             placeholder="https://..."
+            required={!form.listing_id}
           />
           <p className="text-xs text-muted-foreground">Where buyers land after clicking affiliate links</p>
         </div>

--- a/src/app/affiliates/new/NewOfferClient.tsx
+++ b/src/app/affiliates/new/NewOfferClient.tsx
@@ -110,6 +110,11 @@ export default function NewOfferClient() {
       setLoading(false);
       return;
     }
+    if (!form.product_url.trim()) {
+      setError("Product URL is required for affiliate offers");
+      setLoading(false);
+      return;
+    }
     if (form.commission_type === "percentage") {
       const rate = parseFloat(form.commission_rate);
       if (!rate || rate < 1 || rate > 90) {
@@ -133,7 +138,7 @@ export default function NewOfferClient() {
       body: JSON.stringify({
         title: form.title,
         description: form.description,
-        product_url: form.product_url || undefined,
+        product_url: form.product_url.trim(),
         product_type: form.product_type,
         price_sats: parseInt(form.price_sats) || 0,
         commission_rate: form.commission_type === "percentage" ? parseFloat(form.commission_rate) / 100 : 0,
@@ -242,13 +247,14 @@ export default function NewOfferClient() {
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="product_url">Product URL</Label>
+          <Label htmlFor="product_url">Product URL *</Label>
           <Input
             id="product_url"
             type="url"
             value={form.product_url}
             onChange={(e) => updateForm("product_url", e.target.value)}
             placeholder="https://..."
+            required
           />
           <p className="text-xs text-muted-foreground">Where buyers land after clicking affiliate links</p>
         </div>

--- a/src/app/api/affiliates/offers/[id]/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/route.test.ts
@@ -15,14 +15,10 @@ vi.mock("@/lib/supabase/service", () => ({
   }),
 }));
 
-vi.mock("@/lib/affiliates/validation", () => ({
-  validateOfferInput: vi.fn(),
-}));
+import { GET, PATCH } from "./route";
 
-import { GET } from "./route";
-
-function makeRequest(id: string) {
-  return new NextRequest(`http://localhost/api/affiliates/offers/${id}`);
+function makeRequest(id: string, init?: ConstructorParameters<typeof NextRequest>[1]) {
+  return new NextRequest(`http://localhost/api/affiliates/offers/${id}`, init);
 }
 
 function makeParams(id: string) {
@@ -111,5 +107,96 @@ describe("GET /api/affiliates/offers/[id]", () => {
 
     const res = await GET(makeRequest("nonexistent"), makeParams("nonexistent"));
     expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/affiliates/offers/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({ user: { id: "seller1" } });
+  });
+
+  it("rejects clearing the last active destination (#88)", async () => {
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({
+            data: {
+              id: "offer1",
+              seller_id: "seller1",
+              product_url: "https://example.com/product",
+              listing_id: null,
+              status: "active",
+            },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const res = await PATCH(
+      makeRequest("offer1", {
+        method: "PATCH",
+        body: JSON.stringify({ product_url: "   " }),
+      }),
+      makeParams("offer1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("product_url");
+    expect(body.error).toContain("listing_id");
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows clearing product_url when a listing_id still provides a destination (#88)", async () => {
+    const updateMock = vi.fn().mockReturnValue({
+      eq: () => ({
+        select: () => ({
+          single: () => Promise.resolve({
+            data: {
+              id: "offer1",
+              seller_id: "seller1",
+              product_url: null,
+              listing_id: "listing-1",
+              status: "active",
+            },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    mockFrom
+      .mockReturnValueOnce({
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({
+              data: {
+                id: "offer1",
+                seller_id: "seller1",
+                product_url: "https://example.com/product",
+                listing_id: "listing-1",
+                status: "active",
+              },
+              error: null,
+            }),
+          }),
+        }),
+      })
+      .mockReturnValueOnce({
+        update: updateMock,
+      });
+
+    const res = await PATCH(
+      makeRequest("offer1", {
+        method: "PATCH",
+        body: JSON.stringify({ product_url: "   " }),
+      }),
+      makeParams("offer1")
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({ product_url: null }));
   });
 });

--- a/src/app/api/affiliates/offers/[id]/route.ts
+++ b/src/app/api/affiliates/offers/[id]/route.ts
@@ -1,11 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
+import { isValidUrl } from "@/lib/affiliates/validation";
 import { createServiceClient } from "@/lib/supabase/service";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
-import { validateOfferInput } from "@/lib/affiliates/validation";
-
 
 /**
  * GET /api/affiliates/offers/[id] - Get offer details
@@ -87,7 +85,7 @@ export async function PATCH(
     // Check ownership
     const { data: existing } = await (admin as AnySupabase)
       .from("affiliate_offers")
-      .select("id, seller_id")
+      .select("id, seller_id, product_url, listing_id, status")
       .eq("id", id)
       .single();
 
@@ -99,10 +97,22 @@ export async function PATCH(
 
     // Partial validation — only validate provided fields
     const updateData: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    let nextProductUrl = existing.product_url || null;
+    let nextListingId = existing.listing_id || null;
+    let nextStatus = existing.status || "active";
 
     if (body.title !== undefined) updateData.title = body.title.trim();
     if (body.description !== undefined) updateData.description = body.description.trim();
-    if (body.product_url !== undefined) updateData.product_url = body.product_url;
+    if (body.product_url !== undefined) {
+      if (body.product_url !== null && typeof body.product_url !== "string") {
+        return NextResponse.json({ error: "product_url must be a string" }, { status: 400 });
+      }
+      nextProductUrl = typeof body.product_url === "string" ? body.product_url.trim() || null : null;
+      if (nextProductUrl && !isValidUrl(nextProductUrl)) {
+        return NextResponse.json({ error: "product_url must use http:// or https:// scheme" }, { status: 400 });
+      }
+      updateData.product_url = nextProductUrl;
+    }
     if (body.product_type !== undefined) updateData.product_type = body.product_type;
     if (body.price_sats !== undefined) updateData.price_sats = body.price_sats;
     if (body.commission_rate !== undefined) updateData.commission_rate = body.commission_rate;
@@ -113,8 +123,22 @@ export async function PATCH(
     if (body.promo_text !== undefined) updateData.promo_text = body.promo_text;
     if (body.category !== undefined) updateData.category = body.category;
     if (body.tags !== undefined) updateData.tags = body.tags;
-    if (body.status !== undefined) updateData.status = body.status;
+    if (body.listing_id !== undefined) {
+      if (body.listing_id !== null && typeof body.listing_id !== "string") {
+        return NextResponse.json({ error: "listing_id must be a string" }, { status: 400 });
+      }
+      nextListingId = typeof body.listing_id === "string" ? body.listing_id.trim() || null : null;
+      updateData.listing_id = nextListingId;
+    }
+    if (body.status !== undefined) {
+      nextStatus = body.status;
+      updateData.status = body.status;
+    }
     if (body.auto_pay !== undefined) updateData.auto_pay = !!body.auto_pay;
+
+    if (nextStatus === "active" && !nextProductUrl && !nextListingId) {
+      return NextResponse.json({ error: "Active affiliate offers require product_url or listing_id" }, { status: 400 });
+    }
 
     const { data: offer, error } = await (admin as AnySupabase)
       .from("affiliate_offers")

--- a/src/app/api/affiliates/offers/route.test.ts
+++ b/src/app/api/affiliates/offers/route.test.ts
@@ -152,6 +152,7 @@ describe("POST /api/affiliates/offers", () => {
       body: JSON.stringify({
         title: "<b>Test</b> Offer",
         description: "A description that is long enough for validation",
+        product_url: "https://example.com/product",
         price_sats: 1000,
         commission_type: "percentage",
         commission_rate: 0.2,
@@ -174,6 +175,7 @@ describe("POST /api/affiliates/offers", () => {
       body: JSON.stringify({
         title: "Test Offer",
         description: "A description that is long enough",
+        product_url: "https://example.com/product",
         price_sats: 1000,
         commission_type: "flat",
         commission_flat_sats: -500,
@@ -182,6 +184,29 @@ describe("POST /api/affiliates/offers", () => {
 
     const res = await POST(req);
     expect(res.status).toBe(400);
+  });
+
+  it("rejects active offers without a product_url or listing_id (#88)", async () => {
+    mockGetAuthContext.mockResolvedValue({ user: { id: "user1" } });
+
+    const req = new NextRequest("http://localhost/api/affiliates/offers", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "Test Offer",
+        description: "A description that is long enough",
+        product_url: "   ",
+        price_sats: 1000,
+        commission_type: "percentage",
+        commission_rate: 0.2,
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("product_url");
+    expect(body.error).toContain("listing_id");
   });
 
   it("returns 401 for unauthenticated requests", async () => {

--- a/src/lib/affiliates/validation.test.ts
+++ b/src/lib/affiliates/validation.test.ts
@@ -105,13 +105,24 @@ describe("validateOfferInput", () => {
     expect(result.errors.some((e) => e.includes("price_sats"))).toBe(true);
   });
 
-  it("trims whitespace-only product_url to undefined", () => {
+  it("rejects active offers without product_url or listing_id (#88)", () => {
     const result = validateOfferInput({
       ...validInput,
       product_url: "   ",
     });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("product_url") && e.includes("listing_id"))).toBe(true);
+  });
+
+  it("accepts active offers with a listing_id fallback (#88)", () => {
+    const result = validateOfferInput({
+      ...validInput,
+      product_url: "   ",
+      listing_id: " listing-123 ",
+    });
     expect(result.ok).toBe(true);
     expect(result.sanitized!.product_url).toBeFalsy();
+    expect(result.sanitized!.listing_id).toBe("listing-123");
   });
 
   // Regression tests for defaults

--- a/src/lib/affiliates/validation.ts
+++ b/src/lib/affiliates/validation.ts
@@ -60,13 +60,22 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
   }
 
   // Normalize product_url — trim whitespace, treat blank as null (#18 - XSS prevention)
-  if (input.product_url) {
-    input.product_url = input.product_url.trim();
-    if (input.product_url.length === 0) {
-      input.product_url = undefined;
-    } else if (!isValidUrl(input.product_url)) {
+  if (input.product_url !== undefined) {
+    const productUrl = input.product_url.trim();
+    input.product_url = productUrl || undefined;
+    if (input.product_url && !isValidUrl(input.product_url)) {
       errors.push("product_url must use http:// or https:// scheme");
     }
+  }
+
+  if (input.listing_id !== undefined) {
+    const listingId = input.listing_id.trim();
+    input.listing_id = listingId || undefined;
+  }
+
+  const status = input.status || "active";
+  if (status === "active" && !input.product_url && !input.listing_id) {
+    errors.push("Active affiliate offers require product_url or listing_id");
   }
 
   // Default price_sats to 0 if not provided (#28)
@@ -140,6 +149,8 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
       settlement_delay_days: settlementDays,
       product_type: input.product_type || "digital",
       tags: input.tags?.map((t) => t.trim().toLowerCase()).filter(Boolean) || [],
+      listing_id: input.listing_id,
+      status,
     },
   };
 }


### PR DESCRIPTION
## Summary
- require active affiliate offers to have either a product_url or listing_id destination
- prevent edits from clearing the last active destination while preserving listing-linked offers
- mark the create/edit product URL field required when no listing fallback is available

## Tests
- pnpm test:run src/lib/affiliates/validation.test.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.test.ts'
- pnpm exec eslint src/lib/affiliates/validation.ts src/lib/affiliates/validation.test.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.ts' 'src/app/api/affiliates/offers/[id]/route.test.ts' src/app/affiliates/new/NewOfferClient.tsx 'src/app/affiliates/[slug]/edit/page.tsx'
- pnpm type-check
- git diff --check
- OPENAI_API_KEY=dummy NEXT_PUBLIC_SUPABASE_URL=https://test.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key SUPABASE_SERVICE_ROLE_KEY=test-service-key pnpm build

Closes #88