### PR TITLE
Document affiliate apply and tracking endpoints in OpenAPI

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -270,6 +270,61 @@
           "tracking_url": { "type": "string", "format": "uri" }
         }
       },
+      "AffiliateConversion": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "affiliate_id": { "type": "string", "format": "uuid" },
+          "username": { "type": "string", "nullable": true },
+          "sale_amount_sats": { "type": "integer", "minimum": 0 },
+          "commission_sats": { "type": "integer", "minimum": 0 },
+          "status": { "type": "string", "enum": ["pending", "paid", "clawed_back"] },
+          "source": { "type": "string", "enum": ["auto", "manual", "webhook"] },
+          "note": { "type": "string", "nullable": true },
+          "created_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "AffiliateConversionInput": {
+        "type": "object",
+        "required": ["affiliate_id", "sale_amount_sats"],
+        "properties": {
+          "affiliate_id": { "type": "string", "format": "uuid" },
+          "sale_amount_sats": { "type": "integer", "minimum": 1 },
+          "note": { "type": "string", "maxLength": 1000 }
+        }
+      },
+      "AffiliateConversionUpdateInput": {
+        "type": "object",
+        "required": ["conversion_id"],
+        "properties": {
+          "conversion_id": { "type": "string", "format": "uuid" },
+          "sale_amount_sats": { "type": "integer", "minimum": 1 },
+          "note": { "type": "string", "maxLength": 1000 },
+          "status": { "type": "string", "enum": ["pending", "paid", "clawed_back"] }
+        }
+      },
+      "AffiliateConversionActionInput": {
+        "type": "object",
+        "required": ["conversion_id"],
+        "properties": {
+          "conversion_id": { "type": "string", "format": "uuid" }
+        }
+      },
+      "AffiliateConversionMutationResponse": {
+        "type": "object",
+        "properties": {
+          "conversion": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "format": "uuid" },
+              "commission_sats": { "type": "integer", "minimum": 0 },
+              "settles_at": { "type": "string", "format": "date-time", "nullable": true },
+              "source": { "type": "string", "enum": ["manual"] },
+              "note": { "type": "string", "nullable": true }
+            }
+          }
+        }
+      },
       "Post": {
         "type": "object",
         "properties": {
@@ -1755,6 +1810,147 @@
           "404": { "description": "Offer not found or inactive", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
           "409": { "description": "Already applied", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
           "429": { "description": "Rate limit exceeded" }
+        }
+      }
+    },
+    "/api/affiliates/click": {
+      "get": {
+        "tags": ["Affiliate Marketplace"],
+        "summary": "Record an affiliate click and redirect",
+        "description": "Tracking endpoint for affiliate links. Records a click for the approved tracking code, stores attribution cookies, and redirects to the offer destination.",
+        "operationId": "recordAffiliateClick",
+        "parameters": [
+          { "name": "ugig_ref", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Affiliate tracking code returned by the apply endpoint" }
+        ],
+        "responses": {
+          "302": { "description": "Redirects to the offer destination or affiliate marketplace fallback" },
+          "307": { "description": "Redirects to the offer destination or affiliate marketplace fallback" }
+        }
+      }
+    },
+    "/api/affiliates/offers/{id}/conversions": {
+      "get": {
+        "tags": ["Affiliate Marketplace"],
+        "summary": "List conversions for an affiliate offer",
+        "description": "Seller-only endpoint for inspecting recorded affiliate conversions on one offer.",
+        "operationId": "listAffiliateConversions",
+        "security": [{ "bearerAuth": [] }, { "apiKey": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" }, "description": "Affiliate offer id" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Affiliate conversions for the offer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "conversions": { "type": "array", "items": { "$ref": "#/components/schemas/AffiliateConversion" } }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "403": { "description": "Not authorized for this offer", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "404": { "description": "Offer not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "500": { "description": "Unexpected error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
+        }
+      },
+      "post": {
+        "tags": ["Affiliate Marketplace"],
+        "summary": "Record a manual affiliate conversion",
+        "description": "Seller-only endpoint for recording an external sale against an approved affiliate for an offer.",
+        "operationId": "recordAffiliateConversion",
+        "security": [{ "bearerAuth": [] }, { "apiKey": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" }, "description": "Affiliate offer id" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AffiliateConversionInput" } } }
+        },
+        "responses": {
+          "200": {
+            "description": "Manual conversion recorded",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AffiliateConversionMutationResponse" } } }
+          },
+          "400": { "description": "Invalid conversion input", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "403": { "description": "Not authorized for this offer", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "404": { "description": "Offer not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "500": { "description": "Unexpected error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
+        }
+      },
+      "put": {
+        "tags": ["Affiliate Marketplace"],
+        "summary": "Update an affiliate conversion",
+        "description": "Seller-only endpoint for updating a conversion's note, status, or sale amount.",
+        "operationId": "updateAffiliateConversion",
+        "security": [{ "bearerAuth": [] }, { "apiKey": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" }, "description": "Affiliate offer id" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AffiliateConversionUpdateInput" } } }
+        },
+        "responses": {
+          "200": { "description": "Conversion updated", "content": { "application/json": { "schema": { "type": "object", "properties": { "ok": { "type": "boolean" } } } } } },
+          "400": { "description": "Invalid update input", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "403": { "description": "Not authorized for this offer", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "500": { "description": "Unexpected error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
+        }
+      },
+      "delete": {
+        "tags": ["Affiliate Marketplace"],
+        "summary": "Delete an unpaid affiliate conversion",
+        "description": "Seller-only endpoint for deleting a conversion that has not already been paid.",
+        "operationId": "deleteAffiliateConversion",
+        "security": [{ "bearerAuth": [] }, { "apiKey": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" }, "description": "Affiliate offer id" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AffiliateConversionActionInput" } } }
+        },
+        "responses": {
+          "200": { "description": "Conversion deleted", "content": { "application/json": { "schema": { "type": "object", "properties": { "ok": { "type": "boolean" } } } } } },
+          "400": { "description": "Invalid delete input or paid conversion", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "403": { "description": "Not authorized for this offer", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "404": { "description": "Conversion not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "500": { "description": "Unexpected error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
+        }
+      }
+    },
+    "/api/affiliates/offers/{id}/conversions/pay": {
+      "post": {
+        "tags": ["Affiliate Marketplace"],
+        "summary": "Pay an affiliate conversion",
+        "description": "Seller-only endpoint that pays a pending affiliate conversion through the internal Lightning wallet transfer flow.",
+        "operationId": "payAffiliateConversion",
+        "security": [{ "bearerAuth": [] }, { "apiKey": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" }, "description": "Affiliate offer id" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AffiliateConversionActionInput" } } }
+        },
+        "responses": {
+          "200": {
+            "description": "Conversion paid",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "ok": { "type": "boolean" }, "commission_sats": { "type": "integer", "minimum": 0 } } } } }
+          },
+          "400": { "description": "Invalid payment input or conversion state", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "403": { "description": "Not authorized for this offer", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "404": { "description": "Conversion not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "500": { "description": "Payment or unexpected error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
         }
       }
     },

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -30,6 +30,7 @@
     { "name": "Gigs", "description": "Browse, create, update, and delete gigs" },
     { "name": "Gig Comments", "description": "Questions and answers on gigs" },
     { "name": "Applications", "description": "Apply to gigs and manage applications" },
+    { "name": "Affiliate Marketplace", "description": "Browse affiliate offers and join them as an affiliate" },
     { "name": "Saved Gigs", "description": "Save and unsave gigs" },
     { "name": "Feed", "description": "Community feed of posts" },
     { "name": "Posts", "description": "Create, update, delete, and vote on posts" },
@@ -234,6 +235,39 @@
           "proposed_timeline": { "type": "string", "nullable": true },
           "portfolio_items": { "type": "array", "items": { "type": "string", "format": "uri" }, "maxItems": 5 },
           "ai_tools_to_use": { "type": "array", "items": { "type": "string" }, "maxItems": 10 }
+        }
+      },
+      "AffiliateApplication": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "offer_id": { "type": "string", "format": "uuid" },
+          "affiliate_id": { "type": "string", "format": "uuid" },
+          "tracking_code": { "type": "string" },
+          "status": { "type": "string", "enum": ["pending", "approved", "rejected"] },
+          "note": { "type": "string", "nullable": true },
+          "approved_at": { "type": "string", "format": "date-time", "nullable": true },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "AffiliateApplyInput": {
+        "type": "object",
+        "properties": {
+          "offer_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Required when using /api/affiliates/apply. Ignored for the offer-scoped endpoint."
+          },
+          "note": { "type": "string", "maxLength": 1000 }
+        }
+      },
+      "AffiliateApplyResponse": {
+        "type": "object",
+        "properties": {
+          "application": { "$ref": "#/components/schemas/AffiliateApplication" },
+          "tracking_code": { "type": "string" },
+          "tracking_url": { "type": "string", "format": "uri" }
         }
       },
       "Post": {
@@ -1651,6 +1685,76 @@
           "400": { "description": "Validation error, gig inactive, already applied, or own gig", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
           "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
           "404": { "description": "Gig not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
+        }
+      }
+    },
+    "/api/affiliates/apply": {
+      "post": {
+        "tags": ["Affiliate Marketplace"],
+        "summary": "Apply to an affiliate offer",
+        "description": "Programmatic wrapper for agents and CLI clients. Reads offer_id from the request body and forwards to the offer-scoped apply endpoint, returning the approved affiliate application and tracking link.",
+        "operationId": "applyToAffiliateOfferByBody",
+        "security": [{ "bearerAuth": [] }, { "apiKey": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["offer_id"],
+                "properties": {
+                  "offer_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Affiliate offer id to apply for"
+                  },
+                  "note": { "type": "string", "maxLength": 1000 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Affiliate application approved and tracking link issued",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AffiliateApplyResponse" } } }
+          },
+          "400": { "description": "Missing offer_id, own offer, or invalid application", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "404": { "description": "Offer not found or inactive", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "409": { "description": "Already applied", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "429": { "description": "Rate limit exceeded" }
+        }
+      }
+    },
+    "/api/affiliates/offers/{id}/apply": {
+      "post": {
+        "tags": ["Affiliate Marketplace"],
+        "summary": "Apply to a specific affiliate offer",
+        "description": "Join an active affiliate offer. The current implementation auto-approves eligible affiliates, creates a unique tracking code, increments total_affiliates, and returns a tracking URL.",
+        "operationId": "applyToAffiliateOffer",
+        "security": [{ "bearerAuth": [] }, { "apiKey": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" }, "description": "Affiliate offer id" }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AffiliateApplyInput" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Affiliate application approved and tracking link issued",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AffiliateApplyResponse" } } }
+          },
+          "400": { "description": "Own offer, invalid application, or database validation error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "404": { "description": "Offer not found or inactive", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "409": { "description": "Already applied", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "429": { "description": "Rate limit exceeded" }
         }
       }
     },

--- a/src/app/api/openapi.json/spec.test.ts
+++ b/src/app/api/openapi.json/spec.test.ts
@@ -7,6 +7,19 @@ import spec from "../../../../public/openapi.json";
 
 const VALID_HTTP_METHODS = ["get", "post", "put", "patch", "delete", "options", "head", "trace"];
 
+type JsonResponse = {
+  content?: {
+    "application/json"?: {
+      schema: unknown;
+    };
+  };
+};
+
+type PostOperation = {
+  operationId: string;
+  responses: Record<string, JsonResponse>;
+};
+
 describe("OpenAPI spec (public/openapi.json)", () => {
   it("is valid JSON and parses as an object", () => {
     expect(spec).toBeDefined();
@@ -30,6 +43,8 @@ describe("OpenAPI spec (public/openapi.json)", () => {
       "/api/notifications",
       "/api/reviews",
       "/api/applications",
+      "/api/affiliates/apply",
+      "/api/affiliates/offers/{id}/apply",
     ];
 
     for (const p of requiredPaths) {
@@ -53,6 +68,9 @@ describe("OpenAPI spec (public/openapi.json)", () => {
       "PostInput",
       "Profile",
       "Application",
+      "AffiliateApplication",
+      "AffiliateApplyInput",
+      "AffiliateApplyResponse",
       "Review",
       "Notification",
       "Comment",
@@ -106,6 +124,18 @@ describe("OpenAPI spec (public/openapi.json)", () => {
   it("has valid OpenAPI version", () => {
     expect(spec.openapi).toBeDefined();
     expect(spec.openapi).toMatch(/^3\.\d+\.\d+$/);
+  });
+
+  it("documents the affiliate offer apply endpoints (#91)", () => {
+    const { paths } = spec;
+    const wrapper = paths["/api/affiliates/apply"] as { post: PostOperation };
+    const scoped = paths["/api/affiliates/offers/{id}/apply"] as { post: PostOperation };
+
+    expect(wrapper.post.operationId).toBe("applyToAffiliateOfferByBody");
+    expect(scoped.post.operationId).toBe("applyToAffiliateOffer");
+    expect(scoped.post.responses["201"].content?.["application/json"]?.schema).toEqual({
+      "$ref": "#/components/schemas/AffiliateApplyResponse",
+    });
   });
 
   it("has server definitions", () => {

--- a/src/app/api/openapi.json/spec.test.ts
+++ b/src/app/api/openapi.json/spec.test.ts
@@ -45,6 +45,9 @@ describe("OpenAPI spec (public/openapi.json)", () => {
       "/api/applications",
       "/api/affiliates/apply",
       "/api/affiliates/offers/{id}/apply",
+      "/api/affiliates/click",
+      "/api/affiliates/offers/{id}/conversions",
+      "/api/affiliates/offers/{id}/conversions/pay",
     ];
 
     for (const p of requiredPaths) {
@@ -71,6 +74,11 @@ describe("OpenAPI spec (public/openapi.json)", () => {
       "AffiliateApplication",
       "AffiliateApplyInput",
       "AffiliateApplyResponse",
+      "AffiliateConversion",
+      "AffiliateConversionInput",
+      "AffiliateConversionUpdateInput",
+      "AffiliateConversionActionInput",
+      "AffiliateConversionMutationResponse",
       "Review",
       "Notification",
       "Comment",
@@ -135,6 +143,28 @@ describe("OpenAPI spec (public/openapi.json)", () => {
     expect(scoped.post.operationId).toBe("applyToAffiliateOffer");
     expect(scoped.post.responses["201"].content?.["application/json"]?.schema).toEqual({
       "$ref": "#/components/schemas/AffiliateApplyResponse",
+    });
+  });
+
+  it("documents affiliate tracking and conversion endpoints (#89)", () => {
+    const { paths } = spec;
+    const click = paths["/api/affiliates/click"] as { get: PostOperation };
+    const conversions = paths["/api/affiliates/offers/{id}/conversions"] as {
+      get: PostOperation;
+      post: PostOperation;
+      put: PostOperation;
+      delete: PostOperation;
+    };
+    const pay = paths["/api/affiliates/offers/{id}/conversions/pay"] as { post: PostOperation };
+
+    expect(click.get.operationId).toBe("recordAffiliateClick");
+    expect(conversions.get.operationId).toBe("listAffiliateConversions");
+    expect(conversions.post.operationId).toBe("recordAffiliateConversion");
+    expect(conversions.put.operationId).toBe("updateAffiliateConversion");
+    expect(conversions.delete.operationId).toBe("deleteAffiliateConversion");
+    expect(pay.post.operationId).toBe("payAffiliateConversion");
+    expect(conversions.post.responses["200"].content?.["application/json"]?.schema).toEqual({
+      "$ref": "#/components/schemas/AffiliateConversionMutationResponse",
     });
   });
 


### PR DESCRIPTION
Resolves #91. Also addresses the API-discovery part of #89 by documenting the existing click/conversion flow.

## Summary
- Adds an `Affiliate Marketplace` OpenAPI tag plus schemas for affiliate applications, apply responses, and conversions.
- Documents `POST /api/affiliates/apply` and `POST /api/affiliates/offers/{id}/apply` so agents/CLI clients can discover the join/apply flow.
- Documents `GET /api/affiliates/click?ugig_ref=...` plus seller conversion management endpoints: list, manual record, update, delete, and pay conversions.
- Extends the OpenAPI spec tests so these affiliate paths and schemas stay published.

The implementation routes already existed in the app; this makes the apply, click-tracking, and conversion-management flow discoverable through the public OpenAPI spec.

## Validation
- `python3 -m json.tool public/openapi.json >/dev/null`
- `./node_modules/.bin/vitest run src/app/api/openapi.json/spec.test.ts src/app/api/openapi.json/route.test.ts`
- `./node_modules/.bin/eslint public/openapi.json src/app/api/openapi.json/spec.test.ts` (0 errors; JSON file reports the existing ignored-file warning)
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint .` (0 errors; existing warnings only)
- `OPENAI_API_KEY=dummy NEXT_PUBLIC_SUPABASE_URL=https://test.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key SUPABASE_SERVICE_ROLE_KEY=test-service-key NODE_OPTIONS="--max-old-space-size=1024" ./node_modules/.bin/next build`
- `git diff --check`
