### PR TITLE
fix: affiliate click fallback redirects to localhost in production

### DIFF
--- a/src/app/api/affiliates/click/route.ts
+++ b/src/app/api/affiliates/click/route.ts
@@ -8,12 +8,14 @@ import { randomUUID } from "crypto";
  * This is the tracking endpoint — affiliate links hit this, then redirect to the offer.
  */
 export async function GET(request: NextRequest) {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
+
   try {
     const { searchParams } = new URL(request.url);
     const ref = searchParams.get("ugig_ref");
 
     if (!ref) {
-      return NextResponse.redirect(new URL("/affiliates", request.url));
+      return NextResponse.redirect(new URL("/affiliates", appUrl));
     }
 
     const admin = createServiceClient();
@@ -32,7 +34,7 @@ export async function GET(request: NextRequest) {
       .single();
 
     if (!app) {
-      return NextResponse.redirect(new URL("/affiliates", request.url));
+      return NextResponse.redirect(new URL("/affiliates", appUrl));
     }
 
     // Read or generate a persistent visitor ID from cookie
@@ -67,7 +69,6 @@ export async function GET(request: NextRequest) {
     }
 
     // Add ref param to destination for client-side cookie tracking (internal URLs only)
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
     const dest = new URL(redirectUrl);
     if (dest.origin === new URL(appUrl).origin) {
       dest.searchParams.set("ugig_ref", ref);
@@ -99,6 +100,7 @@ export async function GET(request: NextRequest) {
     return response;
   } catch (err) {
     console.error("Affiliate click error:", err);
-    return NextResponse.redirect(new URL("/affiliates", request.url));
+    const appFallback = process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
+    return NextResponse.redirect(new URL("/affiliates", appFallback));
   }
 }


### PR DESCRIPTION
## Summary

- Fixes fallback redirects in `GET /api/affiliates/click` that resolve to `localhost:8080` behind Railway's reverse proxy
- Uses `NEXT_PUBLIC_APP_URL` (already available in the same file) as the base URL for all redirect fallbacks
- All 3 fallback paths (missing ref, invalid tracking code, catch block) are fixed

Fixes #94

## Context

This is part of testing the affiliate/invite-friends flow for the gig:
https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

## Test plan

- [ ] Verify `curl -si "https://ugig.net/api/affiliates/click"` returns `307` to `https://ugig.net/affiliates` (not localhost)
- [ ] Verify `curl -si "https://ugig.net/api/affiliates/click?ugig_ref=invalid"` also redirects to public URL
- [ ] All existing tests pass (1347 tests green)
- [ ] TypeScript type check passes
- [ ] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)