### PR TITLE
Fix stored referral signup hydration

### DIFF
--- a/src/components/auth/SignupForm.test.tsx
+++ b/src/components/auth/SignupForm.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SignupForm } from "./SignupForm";
+import { auth } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  auth: {
+    signup: vi.fn(),
+  },
+}));
+
+const signupMock = vi.mocked(auth.signup);
+
+const storage = new Map<string, string>();
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    storage.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    storage.delete(key);
+  }),
+  clear: vi.fn(() => {
+    storage.clear();
+  }),
+};
+
+function fillValidSignupForm() {
+  fireEvent.change(screen.getByLabelText("Username"), {
+    target: { value: "newuser" },
+  });
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: "newuser@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText("Password"), {
+    target: { value: "Strongpass1" },
+  });
+}
+
+describe("SignupForm referral handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("localStorage", localStorageMock);
+    localStorage.clear();
+    signupMock.mockResolvedValue({ data: {}, error: null });
+  });
+
+  it("loads a stored referral and submits it with the signup request", async () => {
+    localStorage.setItem("ugig_referral_code", "stored-ref");
+
+    render(<SignupForm />);
+
+    expect(await screen.findByText("Referred by")).toBeInTheDocument();
+    expect(screen.getByText("stored-ref")).toBeInTheDocument();
+
+    fillValidSignupForm();
+    fireEvent.click(screen.getByRole("button", { name: "Create Account" }));
+
+    await waitFor(() => {
+      expect(signupMock).toHaveBeenCalledWith(
+        expect.objectContaining({ ref: "stored-ref" })
+      );
+    });
+  });
+
+  it("prefers the referral from the signup URL over a stored referral", async () => {
+    localStorage.setItem("ugig_referral_code", "stored-ref");
+
+    render(<SignupForm referralCode="url-ref" />);
+
+    expect(screen.getByText("url-ref")).toBeInTheDocument();
+
+    fillValidSignupForm();
+    fireEvent.click(screen.getByRole("button", { name: "Create Account" }));
+
+    await waitFor(() => {
+      expect(signupMock).toHaveBeenCalledWith(
+        expect.objectContaining({ ref: "url-ref" })
+      );
+    });
+  });
+});

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
@@ -13,11 +13,19 @@ import { Label } from "@/components/ui/label";
 import { getStoredReferral, clearStoredReferral } from "@/components/referral/ReferralTracker";
 
 export function SignupForm({ referralCode }: { referralCode?: string | null }) {
-  // Check prop first (from server), then localStorage (set by ReferralTracker on any page)
-  const ref = referralCode || getStoredReferral();
+  const [ref, setRef] = useState<string | null>(referralCode ?? null);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (referralCode) {
+      setRef(referralCode);
+      return;
+    }
+
+    setRef(getStoredReferral());
+  }, [referralCode]);
 
   const {
     register,


### PR DESCRIPTION
## Summary
- move stored referral lookup into a client effect so signup no longer reads localStorage during initial render
- keep URL referral codes taking precedence over stored referrals
- add focused coverage for stored referral submission and URL-ref precedence

Related Ugig gig: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

## Test
- npm run test:run -- src/components/auth/SignupForm.test.tsx