### PR TITLE
Expose affiliate tracking URLs in dashboard API and CLI

### DIFF
--- a/cli/src/commands/affiliates.ts
+++ b/cli/src/commands/affiliates.ts
@@ -260,6 +260,7 @@ export function registerAffiliatesCommands(program: Command): void {
               { header: "Offer", key: "offer_title", width: 30, transform: truncate(28) },
               { header: "Status", key: "status", width: 12 },
               { header: "Tracking Code", key: "tracking_code", width: 16 },
+              { header: "Tracking URL", key: "tracking_url", width: 42, transform: truncate(40) },
               { header: "Applied", key: "created_at", transform: relativeDate },
             ],
             result.applications.map((a: Record<string, unknown>) => ({
@@ -312,8 +313,12 @@ export function registerAffiliatesCommands(program: Command): void {
             { label: "Application ID", key: "id" },
             { label: "Status", key: "status" },
             { label: "Tracking Code", key: "tracking_code" },
+            { label: "Tracking URL", key: "tracking_url" },
           ],
-          result.application || (result as unknown as Record<string, unknown>),
+          {
+            ...(result.application || (result as unknown as Record<string, unknown>)),
+            tracking_url: (result as unknown as Record<string, unknown>).tracking_url,
+          },
           opts as OutputOptions,
         );
       } catch (err) {

--- a/cli/src/commands/affiliates.ts
+++ b/cli/src/commands/affiliates.ts
@@ -305,6 +305,7 @@ export function registerAffiliatesCommands(program: Command): void {
 
         const result = await client.post<{
           application: Record<string, unknown>;
+          tracking_url?: string;
         }>(`/api/affiliates/offers/${id}/apply`, body);
         spinner?.stop();
         printSuccess("Applied to affiliate offer", opts as OutputOptions);
@@ -316,8 +317,8 @@ export function registerAffiliatesCommands(program: Command): void {
             { label: "Tracking URL", key: "tracking_url" },
           ],
           {
-            ...(result.application || (result as unknown as Record<string, unknown>)),
-            tracking_url: (result as unknown as Record<string, unknown>).tracking_url,
+            ...result.application,
+            tracking_url: result.tracking_url,
           },
           opts as OutputOptions,
         );

--- a/src/app/api/affiliates/my/route.test.ts
+++ b/src/app/api/affiliates/my/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { GET } from "./route";
 
@@ -32,8 +32,12 @@ describe("GET /api/affiliates/my", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("adds shareable tracking URLs to approved affiliate applications", async () => {
-    process.env.NEXT_PUBLIC_APP_URL = "https://ugig.net";
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://ugig.net");
     mockGetAuthContext.mockResolvedValue({
       user: { id: "user-affiliate", authMethod: "session" },
     });

--- a/src/app/api/affiliates/my/route.test.ts
+++ b/src/app/api/affiliates/my/route.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  }),
+}));
+
+function chainable(data: unknown, error: unknown = null) {
+  const result = { data, error };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop) {
+      if (prop === "then") return undefined;
+      if (prop === "data") return data;
+      if (prop === "error") return error;
+      return () => new Proxy(result, handler);
+    },
+  };
+  return new Proxy(result, handler);
+}
+
+describe("GET /api/affiliates/my", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds shareable tracking URLs to approved affiliate applications", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://ugig.net";
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-affiliate", authMethod: "session" },
+    });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_applications") {
+        return chainable([
+          {
+            id: "app-approved",
+            status: "approved",
+            tracking_code: "alice-abc123",
+            affiliate_offers: { title: "Demo offer" },
+          },
+          {
+            id: "app-pending",
+            status: "pending",
+            tracking_code: "alice-def456",
+            affiliate_offers: { title: "Pending offer" },
+          },
+        ]);
+      }
+      if (table === "affiliate_conversions" || table === "affiliate_clicks") {
+        return chainable([]);
+      }
+      return chainable([]);
+    });
+
+    const response = await GET(new NextRequest("http://localhost/api/affiliates/my"));
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.applications[0].tracking_url).toBe("https://ugig.net/ref/alice-abc123");
+    expect(body.applications[1].tracking_url).toBeNull();
+  });
+});

--- a/src/app/api/affiliates/my/route.ts
+++ b/src/app/api/affiliates/my/route.ts
@@ -97,9 +97,18 @@ export async function GET(request: NextRequest) {
       .filter((c: any) => c.status === "pending")
       .reduce((sum: number, c: any) => sum + (c.commission_sats || 0), 0);
 
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
+    const applicationsWithTrackingUrls = (applications || []).map((application: any) => ({
+      ...application,
+      tracking_url:
+        application.status === "approved" && application.tracking_code
+          ? `${appUrl}/ref/${encodeURIComponent(application.tracking_code)}`
+          : null,
+    }));
+
     return NextResponse.json({
       view: "affiliate",
-      applications: applications || [],
+      applications: applicationsWithTrackingUrls,
       conversions: conversions || [],
       stats: {
         total_clicks_30d: (clicks || []).length,


### PR DESCRIPTION
## Summary
- add shareable `/ref/:tracking_code` URLs to approved applications returned by `/api/affiliates/my`
- show tracking URLs in the affiliate CLI dashboard and immediately after `ugig affiliates apply`
- add route coverage proving approved applications get a shareable tracking URL while pending applications do not

Addresses #89 by making the click-through mechanism visible to API/CLI users instead of requiring them to know how to construct the redirect URL manually.

## Validation
- `pnpm test:run src/app/api/affiliates/my/route.test.ts cli/src/commands/affiliates.test.ts`
- `pnpm type-check`
- `pnpm --dir cli test:run src/commands/affiliates.test.ts`
- `pnpm --dir cli typecheck`