### PR TITLE
Guard referral storage access

### DIFF
--- a/src/components/referral/ReferralTracker.test.tsx
+++ b/src/components/referral/ReferralTracker.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearStoredReferral,
+  getStoredReferral,
+  ReferralTracker,
+} from "./ReferralTracker";
+
+let searchParams = new URLSearchParams();
+const originalLocalStorage = Object.getOwnPropertyDescriptor(window, "localStorage");
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParams,
+}));
+
+function createStorageMock(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+}
+
+describe("ReferralTracker", () => {
+  beforeEach(() => {
+    searchParams = new URLSearchParams();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+  });
+
+  afterEach(() => {
+    if (originalLocalStorage) {
+      Object.defineProperty(window, "localStorage", originalLocalStorage);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("stores referral codes from the query string", async () => {
+    searchParams = new URLSearchParams("ref=invite-123");
+
+    render(<ReferralTracker />);
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem("ugig_referral_code")).toBe("invite-123");
+    });
+  });
+
+  it("reads and clears stored referral codes", () => {
+    window.localStorage.setItem("ugig_referral_code", "invite-456");
+
+    expect(getStoredReferral()).toBe("invite-456");
+
+    clearStoredReferral();
+
+    expect(getStoredReferral()).toBeNull();
+  });
+
+  it("does not throw when localStorage is unavailable", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("Storage is blocked", "SecurityError");
+      },
+    });
+    searchParams = new URLSearchParams("ref=invite-789");
+
+    expect(() => render(<ReferralTracker />)).not.toThrow();
+    expect(getStoredReferral()).toBeNull();
+    expect(() => clearStoredReferral()).not.toThrow();
+  });
+
+  it("does not throw when localStorage rejects writes", () => {
+    const storage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(() => {
+        throw new DOMException("Quota exceeded", "QuotaExceededError");
+      }),
+      removeItem: vi.fn(),
+    } as unknown as Storage;
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+    searchParams = new URLSearchParams("ref=invite-999");
+
+    expect(() => render(<ReferralTracker />)).not.toThrow();
+    expect(storage.setItem).toHaveBeenCalledWith("ugig_referral_code", "invite-999");
+  });
+});

--- a/src/components/referral/ReferralTracker.tsx
+++ b/src/components/referral/ReferralTracker.tsx
@@ -5,6 +5,16 @@ import { useSearchParams } from "next/navigation";
 
 const REFERRAL_KEY = "ugig_referral_code";
 
+function getLocalStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Captures ?ref= param from any page URL and stores it in localStorage.
  * Drop this component into the root layout so referrals persist across navigation.
@@ -14,8 +24,13 @@ export function ReferralTracker() {
 
   useEffect(() => {
     const ref = searchParams.get("ref");
+    const storage = getLocalStorage();
     if (ref) {
-      localStorage.setItem(REFERRAL_KEY, ref);
+      try {
+        storage?.setItem(REFERRAL_KEY, ref);
+      } catch {
+        // Some privacy modes expose localStorage but reject writes.
+      }
     }
   }, [searchParams]);
 
@@ -24,12 +39,18 @@ export function ReferralTracker() {
 
 /** Read the stored referral code (call from signup form, etc.) */
 export function getStoredReferral(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(REFERRAL_KEY);
+  try {
+    return getLocalStorage()?.getItem(REFERRAL_KEY) ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /** Clear stored referral after successful signup */
 export function clearStoredReferral(): void {
-  if (typeof window === "undefined") return;
-  localStorage.removeItem(REFERRAL_KEY);
+  try {
+    getLocalStorage()?.removeItem(REFERRAL_KEY);
+  } catch {
+    // Ignore storage cleanup failures so signup completion can continue.
+  }
 }


### PR DESCRIPTION
## Summary
- guard referral `localStorage` reads, writes, and cleanup so blocked storage does not break invite signup flows
- add regression coverage for normal referral storage, unavailable storage, and write-rejecting storage

Fixes #125

## Validation
- `pnpm test:run src/components/referral/ReferralTracker.test.tsx`
- `pnpm type-check`
- `pnpm exec eslint src/components/referral/ReferralTracker.tsx src/components/referral/ReferralTracker.test.tsx`
- `git diff --check`

## Bounty / payment
Submitted for the active uGig affiliate-program testing task. SOL receive address: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`.

Payment fallback: PayPal cultofrozen@gmail.com