### PR TITLE
Use current origin for referral links

### DIFF
--- a/src/app/api/referrals/code/route.test.ts
+++ b/src/app/api/referrals/code/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GET } from "./route";
 import { NextRequest } from "next/server";
 
@@ -12,8 +12,19 @@ function makeRequest() {
 }
 
 describe("GET /api/referrals/code", () => {
+  const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    if (originalAppUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_URL;
+    } else {
+      process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+    }
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -46,7 +57,35 @@ describe("GET /api/referrals/code", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.code).toBe("johndoe");
-    expect(body.link).toBe("https://ugig.net/?ref=johndoe");
+    expect(body.link).toBe("http://localhost/?ref=johndoe");
+  });
+
+  it("should prefer configured app URL and encode referral code", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://staging.ugig.net/";
+    const mockSupabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            single: () =>
+              Promise.resolve({
+                data: { referral_code: "ref code/1", username: "johndoe" },
+                error: null,
+              }),
+          }),
+        }),
+      }),
+    };
+
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.code).toBe("ref code/1");
+    expect(body.link).toBe("https://staging.ugig.net/?ref=ref%20code%2F1");
   });
 
   it("should return 404 when profile not found", async () => {

--- a/src/app/api/referrals/code/route.ts
+++ b/src/app/api/referrals/code/route.ts
@@ -10,7 +10,6 @@ export async function GET(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: profile, error } = await (supabase as any)
       .from("profiles")
       .select("referral_code, username")
@@ -22,10 +21,13 @@ export async function GET(request: NextRequest) {
     }
 
     const code = profile.referral_code || profile.username;
+    const baseUrl = (
+      process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin || "https://ugig.net"
+    ).replace(/\/$/, "");
 
     return NextResponse.json({
       code,
-      link: `https://ugig.net/?ref=${code}`,
+      link: `${baseUrl}/?ref=${encodeURIComponent(code)}`,
     });
   } catch {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- build referral invite links from `NEXT_PUBLIC_APP_URL` or the current request origin instead of hardcoding production
- URL-encode referral codes before placing them in the invite URL
- add regression coverage for request-origin fallback and configured app URL behavior

Fixes #127

## Validation
- `pnpm test:run src/app/api/referrals/code/route.test.ts`
- `pnpm type-check`
- `pnpm exec eslint src/app/api/referrals/code/route.ts src/app/api/referrals/code/route.test.ts`
- `git diff --check`

## Bounty / payment
Submitted for the active uGig affiliate-program testing task. SOL receive address: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`.

Payment fallback: PayPal cultofrozen@gmail.com