### PR TITLE
Disable referral copy until link loads

### DIFF
--- a/src/app/dashboard/referrals/page.copy-loading.test.tsx
+++ b/src/app/dashboard/referrals/page.copy-loading.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ReferralsPage from "./page";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("ReferralsPage copy loading state", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("disables referral link copying until the link is loaded", async () => {
+    const codeResponse = deferred<{
+      ok: boolean;
+      json: () => Promise<{ code: string; link: string }>;
+    }>();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url === "/api/referrals/code") {
+          return codeResponse.promise;
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            data: [],
+            stats: {
+              total_invited: 0,
+              total_registered: 0,
+              conversion_rate: 0,
+            },
+          }),
+        };
+      })
+    );
+
+    render(<ReferralsPage />);
+
+    const copyButton = screen.getByRole("button", { name: /copy/i });
+    expect(copyButton).toBeDisabled();
+
+    codeResponse.resolve({
+      ok: true,
+      json: async () => ({
+        code: "alice",
+        link: "https://ugig.net/?ref=alice",
+      }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("https://ugig.net/?ref=alice")).toBeTruthy();
+    });
+    expect(copyButton).not.toBeDisabled();
+  });
+});

--- a/src/app/dashboard/referrals/page.tsx
+++ b/src/app/dashboard/referrals/page.tsx
@@ -63,6 +63,11 @@ export default function ReferralsPage() {
   }, []);
 
   const copyLink = async () => {
+    if (!referralLink) {
+      setError("Referral link is still loading. Please try again.");
+      return;
+    }
+
     await navigator.clipboard.writeText(referralLink);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
@@ -166,7 +171,8 @@ export default function ReferralsPage() {
           />
           <button
             onClick={copyLink}
-            className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors text-sm"
+            disabled={!referralLink}
+            className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors text-sm disabled:opacity-50"
           >
             <Copy className="h-4 w-4" />
             {copied ? "Copied!" : "Copy"}


### PR DESCRIPTION
## Summary
- disable the Invite Friends Copy button until `/api/referrals/code` has populated a link
- guard `copyLink` against empty referral-link values
- add regression coverage for the loading window before the referral link resolves

Fixes #133

## Validation
- `pnpm test:run src/app/dashboard/referrals/page.copy-loading.test.tsx`
- `pnpm type-check`
- `pnpm exec eslint src/app/dashboard/referrals/page.tsx src/app/dashboard/referrals/page.copy-loading.test.tsx`
- `git diff --check`

## Bounty / payment
Submitted for the active uGig affiliate-program testing task. SOL receive address: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`.

Payment fallback: PayPal cultofrozen@gmail.com