### PR TITLE
Fix affiliate tracking URL origin

### DIFF
--- a/src/app/api/affiliates/offers/[id]/affiliates/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/affiliates/route.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/supabase/service", () => ({
 
 function makeRequest(id: string) {
   return new NextRequest(
-    `http://localhost/api/affiliates/offers/${id}/affiliates`
+    `http://localhost:3000/api/affiliates/offers/${id}/affiliates`
   );
 }
 
@@ -173,7 +173,7 @@ describe("GET /api/affiliates/offers/[id]/affiliates", () => {
     expect(alice.username).toBe("alice");
     expect(alice.status).toBe("approved");
     expect(alice.tracking_url).toBe(
-      "https://ugig.net/api/affiliates/click?ugig_ref=alice-abc123"
+      "http://localhost:3000/api/affiliates/click?ugig_ref=alice-abc123"
     );
     expect(alice.clicks_30d).toBe(3);
     expect(alice.conversions).toBe(2);

--- a/src/app/api/affiliates/offers/[id]/affiliates/route.ts
+++ b/src/app/api/affiliates/offers/[id]/affiliates/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
+import {
+  buildAffiliateTrackingUrl,
+  getAffiliateBaseUrl,
+} from "@/lib/affiliates/tracking-url";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 
 /**
@@ -135,6 +138,7 @@ export async function GET(
     }
 
     // Build response with per-affiliate stats
+    const baseUrl = getAffiliateBaseUrl(request.url);
     const affiliates = affiliateList.map(
       (app: {
         id: string;
@@ -159,7 +163,7 @@ export async function GET(
           tracking_code: app.tracking_code,
           tracking_url:
             app.status === "approved" && app.tracking_code
-              ? `https://ugig.net/api/affiliates/click?ugig_ref=${app.tracking_code}`
+              ? buildAffiliateTrackingUrl(baseUrl, app.tracking_code)
               : null,
           clicks_30d: clicksByAffiliate[app.affiliate_id] || 0,
           conversions: convStats.count,

--- a/src/app/api/affiliates/offers/[id]/apply/route.ts
+++ b/src/app/api/affiliates/offers/[id]/apply/route.ts
@@ -2,11 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, rateLimitExceeded, getRateLimitIdentifier } from "@/lib/rate-limit";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnySupabase = any;
 import { generateTrackingCode } from "@/lib/affiliates/tracking";
+import {
+  buildAffiliateTrackingUrl,
+  getAffiliateBaseUrl,
+} from "@/lib/affiliates/tracking-url";
 
+type AnySupabase = any;
 
 /**
  * POST /api/affiliates/offers/[id]/apply - Apply to become an affiliate for an offer
@@ -127,7 +129,7 @@ export async function POST(
     return NextResponse.json({
       application,
       tracking_code: trackingCode,
-      tracking_url: `${process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"}/ref/${trackingCode}`,
+      tracking_url: buildAffiliateTrackingUrl(getAffiliateBaseUrl(request.url), trackingCode),
     }, { status: 201 });
   } catch {
     return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });

--- a/src/app/ref/[code]/route.test.ts
+++ b/src/app/ref/[code]/route.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeParams(code: string) {
+  return { params: Promise.resolve({ code }) };
+}
+
+describe("GET /ref/[code]", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("redirects to the current request origin when no app URL is configured", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+
+    const res = await GET(
+      new NextRequest("http://localhost:3000/ref/alice code/1"),
+      makeParams("alice code/1")
+    );
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost:3000/api/affiliates/click?ugig_ref=alice+code%2F1"
+    );
+  });
+
+  it("redirects to the configured public app URL when present", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://staging.ugig.example");
+
+    const res = await GET(
+      new NextRequest("http://localhost:3000/ref/alice"),
+      makeParams("alice")
+    );
+
+    expect(res.headers.get("location")).toBe(
+      "https://staging.ugig.example/api/affiliates/click?ugig_ref=alice"
+    );
+  });
+});

--- a/src/app/ref/[code]/route.ts
+++ b/src/app/ref/[code]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { buildAffiliateTrackingUrl, getAffiliateBaseUrl } from "@/lib/affiliates/tracking-url";
 
 /**
  * GET /ref/[code] - Short affiliate tracking link
@@ -9,6 +10,7 @@ export async function GET(
   { params }: { params: Promise<{ code: string }> }
 ) {
   const { code } = await params;
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
-  return NextResponse.redirect(`${baseUrl}/api/affiliates/click?ugig_ref=${encodeURIComponent(code)}`);
+  return NextResponse.redirect(
+    buildAffiliateTrackingUrl(getAffiliateBaseUrl(request.url), code)
+  );
 }

--- a/src/lib/affiliates/tracking-url.test.ts
+++ b/src/lib/affiliates/tracking-url.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildAffiliateTrackingUrl, getAffiliateBaseUrl } from "./tracking-url";
+
+describe("affiliate tracking URLs", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the current request origin when no app URL is configured", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+
+    expect(getAffiliateBaseUrl("http://localhost:3000/api/affiliates/offers/offer-1/affiliates"))
+      .toBe("http://localhost:3000");
+  });
+
+  it("prefers the configured public app URL", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://staging.ugig.example");
+
+    expect(getAffiliateBaseUrl("http://localhost:3000/api/affiliates/offers/offer-1/affiliates"))
+      .toBe("https://staging.ugig.example");
+  });
+
+  it("builds encoded click URLs", () => {
+    expect(buildAffiliateTrackingUrl("https://staging.ugig.example", "alice code/1"))
+      .toBe("https://staging.ugig.example/api/affiliates/click?ugig_ref=alice+code%2F1");
+  });
+});

--- a/src/lib/affiliates/tracking-url.ts
+++ b/src/lib/affiliates/tracking-url.ts
@@ -1,0 +1,9 @@
+export function getAffiliateBaseUrl(requestUrl: string): string {
+  return process.env.NEXT_PUBLIC_APP_URL || new URL(requestUrl).origin;
+}
+
+export function buildAffiliateTrackingUrl(baseUrl: string, trackingCode: string): string {
+  const url = new URL("/api/affiliates/click", baseUrl);
+  url.searchParams.set("ugig_ref", trackingCode);
+  return url.toString();
+}


### PR DESCRIPTION
## Summary
- build affiliate tracking URLs from `NEXT_PUBLIC_APP_URL` or the current request origin instead of hardcoding production links
- return click-route tracking URLs from both the affiliate application response and seller affiliate list API
- add focused URL-builder coverage and update the seller affiliate list regression test for non-production origins

Fixes #135

## Validation
- `pnpm test:run src/lib/affiliates/tracking-url.test.ts 'src/app/api/affiliates/offers/[id]/affiliates/route.test.ts'`
- `pnpm exec eslint src/lib/affiliates/tracking-url.ts src/lib/affiliates/tracking-url.test.ts 'src/app/api/affiliates/offers/[id]/affiliates/route.ts' 'src/app/api/affiliates/offers/[id]/affiliates/route.test.ts' 'src/app/api/affiliates/offers/[id]/apply/route.ts'`
- `pnpm type-check`
- `git diff --check`

## Bounty / payment
Submitted for the active uGig affiliate-program testing task. SOL receive address: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`.

Payment fallback: PayPal cultofrozen@gmail.com