### PR TITLE
Validate affiliate conversion sat amounts

### DIFF
--- a/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { GET, POST } from "./route";
+import { GET, POST, PUT } from "./route";
 import { NextRequest } from "next/server";
 
 // Mock auth
@@ -18,8 +18,10 @@ vi.mock("@/lib/supabase/service", () => ({
 
 // Mock recordConversion
 const mockRecordConversion = vi.fn();
+const mockCalculateCommission = vi.fn();
 vi.mock("@/lib/affiliates/commission", () => ({
   recordConversion: (...args: unknown[]) => mockRecordConversion(...args),
+  calculateCommission: (...args: unknown[]) => mockCalculateCommission(...args),
 }));
 
 function makeGetRequest(id: string) {
@@ -33,6 +35,17 @@ function makePostRequest(id: string, body: Record<string, unknown>) {
     `http://localhost/api/affiliates/offers/${id}/conversions`,
     {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function makePutRequest(id: string, body: Record<string, unknown>) {
+  return new NextRequest(
+    `http://localhost/api/affiliates/offers/${id}/conversions`,
+    {
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     }
@@ -319,6 +332,73 @@ describe("POST /api/affiliates/offers/[id]/conversions", () => {
     );
     expect(res2.status).toBe(400);
     const body2 = await res2.json();
-    expect(body2.error).toBe("sale_amount_sats must be a positive number");
+    expect(body2.error).toBe("sale_amount_sats must be a positive integer");
+  });
+
+  it("rejects fractional sale amounts", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+        });
+      }
+      return chainable([]);
+    });
+
+    const res = await POST(
+      makePostRequest("offer-1", {
+        affiliate_id: "aff-1",
+        sale_amount_sats: 100.5,
+      }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("sale_amount_sats must be a positive integer");
+    expect(mockRecordConversion).not.toHaveBeenCalled();
+  });
+});
+
+describe("PUT /api/affiliates/offers/[id]/conversions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects fractional sale amount updates", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+          commission_rate: 10,
+          commission_type: "percentage",
+          commission_flat_sats: null,
+        });
+      }
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await PUT(
+      makePutRequest("offer-1", {
+        conversion_id: "conv-1",
+        sale_amount_sats: 100.5,
+      }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("sale_amount_sats must be a positive integer");
+    expect(mockCalculateCommission).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/affiliates/offers/[id]/conversions/route.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.ts
@@ -3,8 +3,11 @@ import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { recordConversion } from "@/lib/affiliates/commission";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
+
+function isPositiveIntegerSats(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
 
 /**
  * GET /api/affiliates/offers/[id]/conversions - List conversions for an offer (seller only)
@@ -141,9 +144,9 @@ export async function POST(
       );
     }
 
-    if (!sale_amount_sats || typeof sale_amount_sats !== "number" || sale_amount_sats <= 0) {
+    if (!isPositiveIntegerSats(sale_amount_sats)) {
       return NextResponse.json(
-        { error: "sale_amount_sats must be a positive number" },
+        { error: "sale_amount_sats must be a positive integer" },
         { status: 400 }
       );
     }
@@ -242,7 +245,13 @@ export async function PUT(
     if (typeof status === "string" && ["pending", "paid", "clawed_back"].includes(status)) {
       updateData.status = status;
     }
-    if (typeof sale_amount_sats === "number" && sale_amount_sats > 0) {
+    if (sale_amount_sats !== undefined && !isPositiveIntegerSats(sale_amount_sats)) {
+      return NextResponse.json(
+        { error: "sale_amount_sats must be a positive integer" },
+        { status: 400 }
+      );
+    }
+    if (typeof sale_amount_sats === "number") {
       updateData.sale_amount_sats = sale_amount_sats;
       const { calculateCommission } = await import("@/lib/affiliates/commission");
       updateData.commission_sats = calculateCommission(offer, sale_amount_sats);


### PR DESCRIPTION
## Summary

- fixes #139
- rejects fractional `sale_amount_sats` values when creating manual affiliate conversions
- rejects fractional `sale_amount_sats` values before recalculating edited conversions
- adds regression coverage for fractional create and update requests

## Why

Satoshi amounts are indivisible. Allowing decimal sale amounts can store impossible conversion values and feed fractional inputs into commission calculation.

## Validation

- `pnpm test:run src/app/api/affiliates/offers/[id]/conversions/route.test.ts`
- `pnpm exec eslint src/app/api/affiliates/offers/[id]/conversions/route.ts src/app/api/affiliates/offers/[id]/conversions/route.test.ts`
- `pnpm type-check`
- `git diff --check`

Payment for the active uGig affiliate testing bounty can go to SOL: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`.

Payment fallback: PayPal cultofrozen@gmail.com