### PR TITLE
Validate referral invite email types

### DIFF
--- a/src/app/api/referrals/route.test.ts
+++ b/src/app/api/referrals/route.test.ts
@@ -147,6 +147,20 @@ describe("POST /api/referrals", () => {
     expect(body.error).toContain("Maximum 20");
   });
 
+  it("should return 400 when any invite email is not a string", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+
+    const res = await POST(makePostRequest({ emails: ["friend@test.com", 42] }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("All invite emails must be strings");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+  });
+
   it("should create referrals for valid emails", async () => {
     mockGetAuthContext.mockResolvedValue({
       user: { id: "user1" },

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -62,6 +62,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (!emails.every((email) => typeof email === "string")) {
+      return NextResponse.json(
+        { error: "All invite emails must be strings" },
+        { status: 400 }
+      );
+    }
+
     if (emails.length > 20) {
       return NextResponse.json(
         { error: "Maximum 20 invites at a time" },


### PR DESCRIPTION
## Summary

- fixes #141
- rejects non-string entries in the referral invite `emails` array with a 400 response
- prevents malformed invite payloads from reaching throttling, duplicate lookup, insert, or email-send work
- adds regression coverage for mixed string/non-string invite arrays

## Why

The endpoint already checks that `emails` is an array, but then calls `trim().toLowerCase()` on every entry. A malformed client payload with a non-string entry could throw and return a generic 500 instead of a validation error.

## Validation

- `pnpm test:run src/app/api/referrals/route.test.ts`
- `pnpm exec eslint src/app/api/referrals/route.ts src/app/api/referrals/route.test.ts`
- `pnpm type-check`
- `git diff --check`

Payment for the active uGig affiliate testing bounty can go to SOL: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`.

Payment fallback: PayPal cultofrozen@gmail.com