### PR TITLE
Validate referral invite emails before throttling

### DIFF
--- a/src/app/api/referrals/route.test.ts
+++ b/src/app/api/referrals/route.test.ts
@@ -147,6 +147,21 @@ describe("POST /api/referrals", () => {
     expect(body.error).toContain("Maximum 20");
   });
 
+  it("should validate email syntax before rate limiting", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+
+    const emails = Array.from({ length: 11 }, (_, i) => `not-email-${i}`);
+    const res = await POST(makePostRequest({ emails }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("No valid email");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+  });
+
   it("should create referrals for valid emails", async () => {
     mockGetAuthContext.mockResolvedValue({
       user: { id: "user1" },

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -69,6 +69,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const normalizedEmails = emails.map((e: string) => e.trim().toLowerCase());
+    const validEmails = normalizedEmails.filter((e: string) => emailRegex.test(e));
+
+    if (validEmails.length === 0) {
+      return NextResponse.json(
+        { error: "No valid email addresses provided" },
+        { status: 400 }
+      );
+    }
+
     // Spam throttling: max 50 invites per day, max 10 per hour
     const svc = createServiceClient();
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
@@ -80,7 +91,7 @@ export async function POST(request: NextRequest) {
       .eq("referrer_id", user.id)
       .gte("created_at", oneHourAgo);
 
-    if ((hourlyCount ?? 0) + emails.length > 10) {
+    if ((hourlyCount ?? 0) + validEmails.length > 10) {
       return NextResponse.json(
         { error: "Too many invites. Max 10 per hour." },
         { status: 429 }
@@ -93,7 +104,7 @@ export async function POST(request: NextRequest) {
       .eq("referrer_id", user.id)
       .gte("created_at", oneDayAgo);
 
-    if ((dailyCount ?? 0) + emails.length > 50) {
+    if ((dailyCount ?? 0) + validEmails.length > 50) {
       return NextResponse.json(
         { error: "Daily invite limit reached. Max 50 per day." },
         { status: 429 }
@@ -101,15 +112,14 @@ export async function POST(request: NextRequest) {
     }
 
     // Prevent duplicate invites to same email
-    const normalizedEmails = emails.map((e: string) => e.trim().toLowerCase());
     const { data: existingInvites } = await (svc as AnySupabase)
       .from("referrals")
       .select("referred_email")
       .eq("referrer_id", user.id)
-      .in("referred_email", normalizedEmails);
+      .in("referred_email", validEmails);
 
     const alreadyInvited = new Set((existingInvites || []).map((r: any) => r.referred_email));
-    const newEmails = normalizedEmails.filter((e: string) => !alreadyInvited.has(e));
+    const newEmails = validEmails.filter((e: string) => !alreadyInvited.has(e));
 
     if (newEmails.length === 0) {
       return NextResponse.json(
@@ -132,18 +142,7 @@ export async function POST(request: NextRequest) {
     const referralCode = profile.referral_code || profile.username;
     const inviterName = profile.full_name || profile.username || "Someone";
 
-    // Validate emails and create referrals
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    const validEmails = newEmails.filter((e: string) => emailRegex.test(e));
-
-    if (validEmails.length === 0) {
-      return NextResponse.json(
-        { error: "No valid email addresses provided" },
-        { status: 400 }
-      );
-    }
-
-    const referralRows = validEmails.map((email: string) => ({
+    const referralRows = newEmails.map((email: string) => ({
       referrer_id: user.id,
       referred_email: email.trim().toLowerCase(),
       referral_code: referralCode,
@@ -161,7 +160,7 @@ export async function POST(request: NextRequest) {
 
     const emailContent = referralInviteEmail({ inviterName, referralCode });
     const emailResults = await Promise.all(
-      validEmails.map((email: string) =>
+      newEmails.map((email: string) =>
         sendEmail({ to: email, ...emailContent })
       )
     );
@@ -169,8 +168,8 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       message: failedEmailCount > 0
-        ? `${validEmails.length} invite(s) created; ${failedEmailCount} email(s) failed to send`
-        : `${validEmails.length} invite(s) created and sent`,
+        ? `${newEmails.length} invite(s) created; ${failedEmailCount} email(s) failed to send`
+        : `${newEmails.length} invite(s) created and sent`,
       data: referrals,
       email_delivery_failed: failedEmailCount,
     });


### PR DESCRIPTION
## Summary

- fixes #143
- validates normalized invite email syntax before rate-limit and duplicate checks
- uses only valid invite recipients for throttle math, duplicate lookup, inserts, and email sends
- adds regression coverage for invalid batches that previously returned a misleading rate-limit error

## Why

The referral invite API applied hourly/daily invite limits before proving that any submitted email was usable. A batch of invalid email strings could return `429 Too many invites` instead of a 400 validation error.

## Validation

- `pnpm test:run src/app/api/referrals/route.test.ts`
- `pnpm exec eslint src/app/api/referrals/route.ts src/app/api/referrals/route.test.ts`
- `pnpm type-check`
- `git diff --check`

Payment for the active uGig affiliate testing bounty can go to SOL: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`.

Payment fallback: PayPal cultofrozen@gmail.com