### PR TITLE
Fix affiliate category None option

### DIFF
--- a/src/app/affiliates/[slug]/edit/page.tsx
+++ b/src/app/affiliates/[slug]/edit/page.tsx
@@ -233,12 +233,15 @@ export default function EditOfferPage() {
 
           <div className="space-y-2">
             <Label htmlFor="category">Category</Label>
-            <Select value={form.category} onValueChange={(v) => updateForm("category", v)}>
+            <Select
+              value={form.category || "none"}
+              onValueChange={(v) => updateForm("category", v === "none" ? "" : v)}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Select..." />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">None</SelectItem>
+                <SelectItem value="none">None</SelectItem>
                 {SKILL_CATEGORIES.map((cat) => (
                   <SelectItem key={cat} value={cat}>
                     {cat.charAt(0).toUpperCase() + cat.slice(1)}

--- a/src/app/affiliates/new/NewOfferClient.tsx
+++ b/src/app/affiliates/new/NewOfferClient.tsx
@@ -225,12 +225,15 @@ export default function NewOfferClient() {
 
           <div className="space-y-2">
             <Label htmlFor="category">Category</Label>
-            <Select value={form.category} onValueChange={(v) => updateForm("category", v)}>
+            <Select
+              value={form.category || "none"}
+              onValueChange={(v) => updateForm("category", v === "none" ? "" : v)}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Select..." />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">None</SelectItem>
+                <SelectItem value="none">None</SelectItem>
                 {SKILL_CATEGORIES.map((cat) => (
                   <SelectItem key={cat} value={cat}>
                     {cat.charAt(0).toUpperCase() + cat.slice(1)}


### PR DESCRIPTION
## Summary
- replace the empty-string affiliate category SelectItem with a non-empty `none` sentinel
- map the sentinel back to the existing empty category value before create/edit submit
- apply the fix to both new offer and edit offer forms

Closes #151.

This is for the active uGig affiliate/invite testing task: 4741218f-a723-46bb-82cb-6516120331ae.

Payment address for the uGig SOL bounty, if accepted: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`

## Validation
- `pnpm exec eslint 'src/app/affiliates/new/NewOfferClient.tsx' 'src/app/affiliates/[slug]/edit/page.tsx'`\n- `pnpm type-check`\n- `git diff --check -- 'src/app/affiliates/new/NewOfferClient.tsx' 'src/app/affiliates/[slug]/edit/page.tsx'`

Payment fallback: PayPal cultofrozen@gmail.com