### PR TITLE
Add affiliate dashboard copy fallback

### DIFF
--- a/src/app/dashboard/affiliates/DashboardClient.tsx
+++ b/src/app/dashboard/affiliates/DashboardClient.tsx
@@ -46,6 +46,31 @@ function formatSats(sats: number): string {
   return sats.toLocaleString();
 }
 
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the textarea fallback below.
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
 function StatCard({
   label,
   value,
@@ -105,11 +130,15 @@ function CopyButton({ text, label, stopPropagation }: { text: string; label?: st
       size="sm"
       variant="outline"
       title={label}
-      onClick={(e) => {
-        if (stopPropagation) e.preventDefault();
-        navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+      onClick={async (e) => {
+        if (stopPropagation) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+        if (await copyText(text)) {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        }
       }}
     >
       {copied ? (


### PR DESCRIPTION
## Summary
- add a resilient affiliate dashboard copy helper with Clipboard API and textarea fallback paths
- await the copy result before showing the copied state
- stop click propagation for share-copy buttons inside seller offer links

Closes #153.

This is for the active uGig affiliate/invite testing task: 4741218f-a723-46bb-82cb-6516120331ae.

Payment address for the uGig SOL bounty, if accepted: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`

## Validation
- `pnpm exec eslint src/app/dashboard/affiliates/DashboardClient.tsx`
- `pnpm type-check`
- `git diff --check -- src/app/dashboard/affiliates/DashboardClient.tsx`

Payment fallback: PayPal cultofrozen@gmail.com