### PR TITLE
Handle malformed affiliate conversion bodies

### DIFF
--- a/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { GET, POST } from "./route";
+import { DELETE, GET, POST, PUT } from "./route";
 import { NextRequest } from "next/server";
 
 // Mock auth
@@ -44,6 +44,17 @@ function makeRawPostRequest(id: string, body: string) {
     `http://localhost/api/affiliates/offers/${id}/conversions`,
     {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    }
+  );
+}
+
+function makeRawRequest(id: string, method: "PUT" | "DELETE", body: string) {
+  return new NextRequest(
+    `http://localhost/api/affiliates/offers/${id}/conversions`,
+    {
+      method,
       headers: { "Content-Type": "application/json" },
       body,
     }
@@ -357,5 +368,72 @@ describe("POST /api/affiliates/offers/[id]/conversions", () => {
     expect(res.status).toBe(400);
     expect(body.error).toBe("Invalid request body");
     expect(mockRecordConversion).not.toHaveBeenCalled();
+  });
+});
+
+describe("PUT /api/affiliates/offers/[id]/conversions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for malformed JSON request bodies", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+          commission_rate: 0.2,
+          commission_type: "percentage",
+          commission_flat_sats: 0,
+        });
+      }
+      throw new Error(`Unexpected table query: ${table}`);
+    });
+
+    const res = await PUT(
+      makeRawRequest("offer-1", "PUT", "{not valid json"),
+      makeParams("offer-1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid request body");
+    expect(mockFrom).not.toHaveBeenCalledWith("affiliate_conversions");
+  });
+});
+
+describe("DELETE /api/affiliates/offers/[id]/conversions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for malformed JSON request bodies", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+        });
+      }
+      throw new Error(`Unexpected table query: ${table}`);
+    });
+
+    const res = await DELETE(
+      makeRawRequest("offer-1", "DELETE", "{not valid json"),
+      makeParams("offer-1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid request body");
+    expect(mockFrom).not.toHaveBeenCalledWith("affiliate_conversions");
   });
 });

--- a/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
@@ -39,6 +39,17 @@ function makePostRequest(id: string, body: Record<string, unknown>) {
   );
 }
 
+function makeRawPostRequest(id: string, body: string) {
+  return new NextRequest(
+    `http://localhost/api/affiliates/offers/${id}/conversions`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    }
+  );
+}
+
 function makeParams(id: string) {
   return { params: Promise.resolve({ id }) };
 }
@@ -320,5 +331,31 @@ describe("POST /api/affiliates/offers/[id]/conversions", () => {
     expect(res2.status).toBe(400);
     const body2 = await res2.json();
     expect(body2.error).toBe("sale_amount_sats must be a positive number");
+  });
+
+  it("returns 400 for malformed JSON request bodies", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+        });
+      }
+      return chainable([]);
+    });
+
+    const res = await POST(
+      makeRawPostRequest("offer-1", "{not valid json"),
+      makeParams("offer-1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid request body");
+    expect(mockRecordConversion).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/affiliates/offers/[id]/conversions/route.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { recordConversion } from "@/lib/affiliates/commission";
+import { safeParseBody } from "@/lib/sanitize";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
@@ -131,7 +132,15 @@ export async function POST(
       return NextResponse.json({ error: "Not authorized" }, { status: 403 });
     }
 
-    const body = await request.json();
+    const body = await safeParseBody<{
+      affiliate_id?: unknown;
+      sale_amount_sats?: unknown;
+      note?: unknown;
+    }>(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
     const { affiliate_id, sale_amount_sats, note } = body;
 
     if (!affiliate_id || typeof affiliate_id !== "string") {
@@ -177,8 +186,9 @@ export async function POST(
 
     // Update source and note on the created conversion
     const updateData: Record<string, unknown> = { source: "manual" };
-    if (note && typeof note === "string") {
-      updateData.note = note.trim();
+    const noteText = typeof note === "string" ? note.trim() : null;
+    if (noteText) {
+      updateData.note = noteText;
     }
 
     await (admin as AnySupabase)
@@ -192,7 +202,7 @@ export async function POST(
         commission_sats: result.commission_sats,
         settles_at: result.settles_at,
         source: "manual",
-        note: note?.trim() || null,
+        note: noteText,
       },
     });
   } catch {

--- a/src/app/api/affiliates/offers/[id]/conversions/route.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.ts
@@ -240,7 +240,15 @@ export async function PUT(
       return NextResponse.json({ error: "Not authorized" }, { status: 403 });
     }
 
-    const body = await request.json();
+    const body = await safeParseBody<{
+      conversion_id?: unknown;
+      sale_amount_sats?: unknown;
+      note?: unknown;
+      status?: unknown;
+    }>(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
     const { conversion_id, sale_amount_sats, note, status } = body;
 
     if (!conversion_id) {
@@ -305,7 +313,10 @@ export async function DELETE(
       return NextResponse.json({ error: "Not authorized" }, { status: 403 });
     }
 
-    const body = await request.json();
+    const body = await safeParseBody<{ conversion_id?: unknown }>(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
     const { conversion_id } = body;
 
     if (!conversion_id) {


### PR DESCRIPTION
## Summary
- parse manual affiliate conversion bodies with safeParseBody
- return 400 Invalid request body for malformed JSON instead of falling through to the generic 500 handler
- cover malformed JSON with a regression test that verifies recordConversion is not called

Fixes #159

## Verification
- corepack pnpm vitest run 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'\n- corepack pnpm type-check\n- git diff --check -- 'src/app/api/affiliates/offers/[id]/conversions/route.ts' 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'