### PR TITLE
Handle malformed affiliate application bodies

### DIFF
--- a/src/app/api/affiliates/offers/[id]/applications/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/applications/route.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { PATCH } from "./route";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  }),
+}));
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function makePatchRequest(body: BodyInit, contentType = "application/json") {
+  return new NextRequest(
+    "http://localhost/api/affiliates/offers/offer-1/applications",
+    {
+      method: "PATCH",
+      headers: { "content-type": contentType },
+      body,
+    }
+  );
+}
+
+describe("PATCH /api/affiliates/offers/[id]/applications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "seller-1", authMethod: "session" },
+    });
+  });
+
+  it("returns 400 for malformed JSON before touching application updates", async () => {
+    const res = await PATCH(makePatchRequest("{not valid json"), makeParams("offer-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid request body");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-object JSON bodies", async () => {
+    const res = await PATCH(makePatchRequest("[]"), makeParams("offer-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid request body");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("approves an application and sends an approval notification", async () => {
+    const updatedApplication = {
+      id: "app-1",
+      offer_id: "offer-1",
+      affiliate_id: "affiliate-1",
+      status: "approved",
+      profiles: { username: "alice" },
+    };
+    let updatePayload: Record<string, unknown> | undefined;
+    let notificationPayload: Record<string, unknown> | undefined;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { id: "offer-1", seller_id: "seller-1" },
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+
+      if (table === "affiliate_applications") {
+        return {
+          update: (payload: Record<string, unknown>) => {
+            updatePayload = payload;
+            return {
+              eq: () => ({
+                eq: () => ({
+                  select: () => ({
+                    single: () =>
+                      Promise.resolve({
+                        data: updatedApplication,
+                        error: null,
+                      }),
+                  }),
+                }),
+              }),
+            };
+          },
+        };
+      }
+
+      if (table === "notifications") {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            notificationPayload = payload;
+            return Promise.resolve({ data: null, error: null });
+          },
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    const res = await PATCH(
+      makePatchRequest(
+        JSON.stringify({ application_id: "app-1", action: "approve" })
+      ),
+      makeParams("offer-1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.application).toEqual(updatedApplication);
+    expect(updatePayload).toMatchObject({ status: "approved" });
+    expect(updatePayload?.approved_at).toEqual(expect.any(String));
+    expect(notificationPayload).toMatchObject({
+      user_id: "affiliate-1",
+      type: "affiliate_approved",
+      data: { offer_id: "offer-1", application_id: "app-1" },
+    });
+  });
+});

--- a/src/app/api/affiliates/offers/[id]/applications/route.ts
+++ b/src/app/api/affiliates/offers/[id]/applications/route.ts
@@ -2,9 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 
+async function readJsonObject(request: NextRequest) {
+  try {
+    const body = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return null;
+    }
+    return body as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * GET /api/affiliates/offers/[id]/applications - List affiliates for an offer (seller only)
@@ -66,8 +76,13 @@ export async function PATCH(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json();
-    const { application_id, action } = body;
+    const body = await readJsonObject(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const application_id = typeof body.application_id === "string" ? body.application_id : "";
+    const action = typeof body.action === "string" ? body.action : "";
 
     if (!application_id || !["approve", "reject"].includes(action)) {
       return NextResponse.json({ error: "application_id and action (approve|reject) required" }, { status: 400 });


### PR DESCRIPTION
## Summary
- return `400 { "error": "Invalid request body" }` when the affiliate application status endpoint receives malformed or non-object JSON
- keep invalid field validation separate from parse failures
- add route regression coverage for malformed JSON, non-object JSON, and the valid approval/notification path

Fixes #163

## uGig bounty
Submitted for the active uGig affiliate-program testing task: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

SOL payout address: `27sdMYXofqoM9qR13bZhccRNYeEgYn5EoHXTSJn4QWKP`

## Tests
- `pnpm test:run 'src/app/api/affiliates/offers/[id]/applications/route.test.ts'`
- `pnpm exec eslint 'src/app/api/affiliates/offers/[id]/applications/route.ts' 'src/app/api/affiliates/offers/[id]/applications/route.test.ts'`
- `pnpm type-check`
- `git diff --check -- 'src/app/api/affiliates/offers/[id]/applications/route.ts' 'src/app/api/affiliates/offers/[id]/applications/route.test.ts'`

Payment fallback: PayPal cultofrozen@gmail.com