### PR TITLE
Validate referral invite request bodies

### DIFF
--- a/src/app/api/referrals/route.test.ts
+++ b/src/app/api/referrals/route.test.ts
@@ -34,7 +34,15 @@ const mockSupabase = {
   })),
 };
 
-function makeServiceClientWithNoExistingReferrals() {
+function makeServiceClientWithReferralCounts({
+  hourlyCount = 0,
+  dailyCount = 0,
+  existingInvites = [],
+}: {
+  hourlyCount?: number;
+  dailyCount?: number;
+  existingInvites?: Array<{ referred_email: string }>;
+} = {}) {
   let referralsQueryCount = 0;
 
   return {
@@ -43,16 +51,20 @@ function makeServiceClientWithNoExistingReferrals() {
         eq: vi.fn().mockReturnValue({
           gte: vi.fn().mockImplementation(() => {
             referralsQueryCount += 1;
-            if (referralsQueryCount <= 2) {
-              return Promise.resolve({ count: 0, error: null });
-            }
-            return Promise.resolve({ data: [], error: null });
+            return Promise.resolve({
+              count: referralsQueryCount === 1 ? hourlyCount : dailyCount,
+              error: null,
+            });
           }),
-          in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          in: vi.fn().mockResolvedValue({ data: existingInvites, error: null }),
         }),
       }),
     })),
   };
+}
+
+function makeServiceClientWithNoExistingReferrals() {
+  return makeServiceClientWithReferralCounts();
 }
 
 function makeGetRequest() {
@@ -63,6 +75,14 @@ function makePostRequest(body: Record<string, unknown>) {
   return new NextRequest("http://localhost/api/referrals", {
     method: "POST",
     body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeRawPostRequest(body: string) {
+  return new NextRequest("http://localhost/api/referrals", {
+    method: "POST",
+    body,
     headers: { "Content-Type": "application/json" },
   });
 }
@@ -134,6 +154,32 @@ describe("POST /api/referrals", () => {
     expect(body.error).toContain("array of emails");
   });
 
+  it("should return 400 for malformed JSON", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+
+    const res = await POST(makeRawPostRequest("{"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("array of emails");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 for non-string email entries", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+
+    const res = await POST(makePostRequest({ emails: [123, "friend@test.com"] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("email strings");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+  });
+
   it("should return 400 for too many emails", async () => {
     mockGetAuthContext.mockResolvedValue({
       user: { id: "user1" },
@@ -145,6 +191,20 @@ describe("POST /api/referrals", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toContain("Maximum 20");
+  });
+
+  it("should return 400 before side effects when inviting only your own email", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1", email: "Owner@Test.com" },
+      supabase: mockSupabase,
+    });
+
+    const res = await POST(makePostRequest({ emails: [" owner@test.com "] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("own email");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
   });
 
   it("should create referrals for valid emails", async () => {
@@ -191,6 +251,69 @@ describe("POST /api/referrals", () => {
     });
   });
 
+  it("should deduplicate normalized emails before creating referrals", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+
+    let insertedRows: Array<{ referred_email: string }> = [];
+    const mockSelectChain = {
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { referral_code: "testuser", username: "testuser", full_name: "Test User" },
+          error: null,
+        }),
+      }),
+    };
+    const mockInsertChain = {
+      select: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          data: insertedRows.map((row, index) => ({
+            id: `ref${index + 1}`,
+            referred_email: row.referred_email,
+            status: "pending",
+          })),
+          error: null,
+        })
+      ),
+    };
+    const mockInsertRows = vi.fn().mockImplementation((rows) => {
+      insertedRows = rows;
+      return mockInsertChain;
+    });
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "profiles") return { select: () => mockSelectChain };
+      if (table === "referrals") return { insert: mockInsertRows };
+      return {};
+    });
+
+    const res = await POST(makePostRequest({
+      emails: ["Friend@Test.com", " friend@test.com ", "other@test.com"],
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain("2 invite(s) created and sent");
+    expect(insertedRows.map((row) => row.referred_email)).toEqual([
+      "friend@test.com",
+      "other@test.com",
+    ]);
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect(mockSendEmail).toHaveBeenNthCalledWith(1, {
+      to: "friend@test.com",
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+    expect(mockSendEmail).toHaveBeenNthCalledWith(2, {
+      to: "other@test.com",
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+  });
+
   it("should keep created invites when email delivery fails", async () => {
     mockGetAuthContext.mockResolvedValue({
       user: { id: "user1" },
@@ -230,28 +353,71 @@ describe("POST /api/referrals", () => {
     });
   });
 
-  it("should return 400 for invalid emails only", async () => {
+  it("should return 400 before side effects for invalid emails only", async () => {
     mockGetAuthContext.mockResolvedValue({
       user: { id: "user1" },
       supabase: mockSupabase,
-    });
-
-    const mockSelectChain = {
-      eq: vi.fn().mockReturnValue({
-        single: vi.fn().mockResolvedValue({
-          data: { referral_code: "testuser", username: "testuser" },
-          error: null,
-        }),
-      }),
-    };
-    mockSupabase.from.mockImplementation((table: string) => {
-      if (table === "profiles") return { select: () => mockSelectChain };
-      return {};
     });
 
     const res = await POST(makePostRequest({ emails: ["not-an-email", "also-bad"] }));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toContain("No valid email");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("should not count invalid email syntax against invite limits", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+    mockCreateServiceClient.mockReturnValue(makeServiceClientWithReferralCounts({
+      hourlyCount: 9,
+    }));
+    mockReferralInviteEmail.mockReturnValue({
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+    mockSendEmail.mockResolvedValue({ success: true });
+
+    let insertedRows: Array<{ referred_email: string }> = [];
+    const mockSelectChain = {
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { referral_code: "testuser", username: "testuser", full_name: "Test User" },
+          error: null,
+        }),
+      }),
+    };
+    const mockInsertChain = {
+      select: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          data: insertedRows.map((row, index) => ({
+            id: `ref${index + 1}`,
+            referred_email: row.referred_email,
+            status: "pending",
+          })),
+          error: null,
+        })
+      ),
+    };
+    const mockInsertRows = vi.fn().mockImplementation((rows) => {
+      insertedRows = rows;
+      return mockInsertChain;
+    });
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "profiles") return { select: () => mockSelectChain };
+      if (table === "referrals") return { insert: mockInsertRows };
+      return {};
+    });
+
+    const res = await POST(makePostRequest({ emails: ["not-an-email", "friend@test.com"] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain("1 invite(s) created and sent");
+    expect(insertedRows.map((row) => row.referred_email)).toEqual(["friend@test.com"]);
   });
 });

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { referralInviteEmail, sendEmail } from "@/lib/email";
+import { safeParseBody } from "@/lib/sanitize";
 import { createServiceClient } from "@/lib/supabase/service";
 
 type AnySupabase = any;
@@ -52,8 +53,8 @@ export async function POST(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
-    const { emails } = body;
+    const body = await safeParseBody<{ emails?: unknown }>(request);
+    const emails = body?.emails;
 
     if (!emails || !Array.isArray(emails) || emails.length === 0) {
       return NextResponse.json(
@@ -69,6 +70,39 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (!emails.every((email): email is string => typeof email === "string")) {
+      return NextResponse.json(
+        { error: "Please provide an array of email strings" },
+        { status: 400 }
+      );
+    }
+
+    const normalizedEmails = emails.map((e) => e.trim().toLowerCase());
+    const uniqueEmails = Array.from(new Set(normalizedEmails));
+    const currentUserEmail = typeof user.email === "string"
+      ? user.email.trim().toLowerCase()
+      : null;
+    const inviteEmails = currentUserEmail
+      ? uniqueEmails.filter((email) => email !== currentUserEmail)
+      : uniqueEmails;
+
+    if (inviteEmails.length === 0) {
+      return NextResponse.json(
+        { error: "You cannot invite your own email address" },
+        { status: 400 }
+      );
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const validInviteEmails = inviteEmails.filter((e: string) => emailRegex.test(e));
+
+    if (validInviteEmails.length === 0) {
+      return NextResponse.json(
+        { error: "No valid email addresses provided" },
+        { status: 400 }
+      );
+    }
+
     // Spam throttling: max 50 invites per day, max 10 per hour
     const svc = createServiceClient();
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
@@ -80,7 +114,7 @@ export async function POST(request: NextRequest) {
       .eq("referrer_id", user.id)
       .gte("created_at", oneHourAgo);
 
-    if ((hourlyCount ?? 0) + emails.length > 10) {
+    if ((hourlyCount ?? 0) + validInviteEmails.length > 10) {
       return NextResponse.json(
         { error: "Too many invites. Max 10 per hour." },
         { status: 429 }
@@ -93,7 +127,7 @@ export async function POST(request: NextRequest) {
       .eq("referrer_id", user.id)
       .gte("created_at", oneDayAgo);
 
-    if ((dailyCount ?? 0) + emails.length > 50) {
+    if ((dailyCount ?? 0) + validInviteEmails.length > 50) {
       return NextResponse.json(
         { error: "Daily invite limit reached. Max 50 per day." },
         { status: 429 }
@@ -101,15 +135,14 @@ export async function POST(request: NextRequest) {
     }
 
     // Prevent duplicate invites to same email
-    const normalizedEmails = emails.map((e: string) => e.trim().toLowerCase());
     const { data: existingInvites } = await (svc as AnySupabase)
       .from("referrals")
       .select("referred_email")
       .eq("referrer_id", user.id)
-      .in("referred_email", normalizedEmails);
+      .in("referred_email", validInviteEmails);
 
     const alreadyInvited = new Set((existingInvites || []).map((r: any) => r.referred_email));
-    const newEmails = normalizedEmails.filter((e: string) => !alreadyInvited.has(e));
+    const newEmails = validInviteEmails.filter((e: string) => !alreadyInvited.has(e));
 
     if (newEmails.length === 0) {
       return NextResponse.json(
@@ -132,17 +165,7 @@ export async function POST(request: NextRequest) {
     const referralCode = profile.referral_code || profile.username;
     const inviterName = profile.full_name || profile.username || "Someone";
 
-    // Validate emails and create referrals
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    const validEmails = newEmails.filter((e: string) => emailRegex.test(e));
-
-    if (validEmails.length === 0) {
-      return NextResponse.json(
-        { error: "No valid email addresses provided" },
-        { status: 400 }
-      );
-    }
-
+    const validEmails = newEmails;
     const referralRows = validEmails.map((email: string) => ({
       referrer_id: user.id,
       referred_email: email.trim().toLowerCase(),


### PR DESCRIPTION
## Summary

Fixes #167. Fixes #194. Fixes #195. Fixes #196. Fixes #197.

- Parse referral invite request bodies with the existing safe body parser so malformed or empty JSON stays on the 400 validation path.
- Reject `emails` arrays containing non-string values before rate-limit, database, or email side effects.
- Deduplicate normalized email addresses in one request before quota checks, existing-invite checks, database inserts, and outbound email sends.
- Reject self-invites before rate-limit, database, or email side effects.
- Validate email syntax before rate-limit and duplicate-invite checks so invalid entries do not consume quota or trigger service-side work.
- Add regression coverage for malformed JSON, non-string email entries, duplicate normalized emails, own-email invite attempts, and invalid email quota handling.

## Verification

- `./node_modules/.bin/vitest run src/app/api/referrals/route.test.ts`
- `./node_modules/.bin/eslint src/app/api/referrals/route.ts src/app/api/referrals/route.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- src/app/api/referrals/route.ts src/app/api/referrals/route.test.ts`
