### PR TITLE
fix(affiliates): add Clipboard API fallback for copy buttons (#153)

### DIFF
--- a/src/app/dashboard/affiliates/DashboardClient.tsx
+++ b/src/app/dashboard/affiliates/DashboardClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { SatsFiatHint } from "@/components/ui/SatsAmount";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import {
   Tabs,
   TabsContent,
@@ -105,11 +106,13 @@ function CopyButton({ text, label, stopPropagation }: { text: string; label?: st
       size="sm"
       variant="outline"
       title={label}
-      onClick={(e) => {
+      onClick={async (e) => {
         if (stopPropagation) e.preventDefault();
-        navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        const ok = await copyToClipboard(text);
+        if (ok) {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        }
       }}
     >
       {copied ? (

--- a/src/lib/copy-to-clipboard.ts
+++ b/src/lib/copy-to-clipboard.ts
@@ -1,0 +1,37 @@
+/**
+ * Copy text to clipboard with fallback for environments where
+ * navigator.clipboard is unavailable or blocked.
+ *
+ * Uses the modern Clipboard API when available, falling back to
+ * a hidden textarea + document.execCommand("copy") pattern.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  // Try modern Clipboard API first
+  if (navigator?.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied or other error — fall through to fallback
+    }
+  }
+
+  // Fallback: hidden textarea + execCommand
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    // Position off-screen to avoid visual flash
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.top = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Fix for #153 — Clipboard API fallback for affiliate dashboard copy buttons

### Bug
The `CopyButton` component calls `navigator.clipboard.writeText()` directly. In browsers or embedded contexts where the Clipboard API is unavailable or blocked by permissions, copying fails silently. The UI also flips to the "Copied!" state immediately without waiting for the copy to succeed.

### Fix
1. **New utility** `src/lib/copy-to-clipboard.ts`:
   - Tries `navigator.clipboard.writeText()` first (modern API)
   - Falls back to hidden textarea + `document.execCommand("copy")` when Clipboard API is unavailable or throws
   - Returns `true`/`false` to indicate success
2. **DashboardClient CopyButton** updated:
   - Now `await`s the copy result
   - Only shows "Copied!" state on successful copy
   - No more false-positive feedback

### Bounty
💎 uGig Affiliate Testing Bounty
SOL payment address: `0xadf380b5048e9730af0957fd39d5ef1de374475d`
⭐ Starred profullstack/ugig.net ✅