### PR TITLE
Validate affiliate offer create field types

### DIFF
--- a/src/app/api/affiliates/offers/[id]/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/route.test.ts
@@ -209,4 +209,22 @@ describe("PATCH /api/affiliates/offers/[id]", () => {
       auto_pay: false,
     });
   });
+
+  it("sends null when clearing product_url", async () => {
+    const getUpdatePayload = mockExistingOffer();
+
+    const res = await PATCH(
+      makePatchRequest("offer1", {
+        product_url: null,
+      }),
+      makeParams("offer1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.offer.product_url).toBeNull();
+    expect(getUpdatePayload()).toMatchObject({
+      product_url: null,
+    });
+  });
 });

--- a/src/app/api/affiliates/offers/[id]/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/route.test.ts
@@ -15,14 +15,18 @@ vi.mock("@/lib/supabase/service", () => ({
   }),
 }));
 
-vi.mock("@/lib/affiliates/validation", () => ({
-  validateOfferInput: vi.fn(),
-}));
-
-import { GET } from "./route";
+import { GET, PATCH } from "./route";
 
 function makeRequest(id: string) {
   return new NextRequest(`http://localhost/api/affiliates/offers/${id}`);
+}
+
+function makePatchRequest(id: string, body: string | Record<string, unknown>) {
+  return new NextRequest(`http://localhost/api/affiliates/offers/${id}`, {
+    method: "PATCH",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 function makeParams(id: string) {
@@ -111,5 +115,98 @@ describe("GET /api/affiliates/offers/[id]", () => {
 
     const res = await GET(makeRequest("nonexistent"), makeParams("nonexistent"));
     expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/affiliates/offers/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({ user: { id: "seller1" } });
+  });
+
+  function mockExistingOffer() {
+    let updatePayload: Record<string, unknown> | null = null;
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          single: () =>
+            Promise.resolve({
+              data: { id: "offer1", seller_id: "seller1" },
+              error: null,
+            }),
+        }),
+      }),
+      update: (payload: Record<string, unknown>) => {
+        updatePayload = payload;
+        return {
+          eq: () => ({
+            select: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { id: "offer1", ...payload },
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      },
+    });
+    return () => updatePayload;
+  }
+
+  it("returns 400 for malformed JSON before updating", async () => {
+    const getUpdatePayload = mockExistingOffer();
+
+    const res = await PATCH(makePatchRequest("offer1", "{"), makeParams("offer1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("valid JSON body");
+    expect(getUpdatePayload()).toBeNull();
+  });
+
+  it("returns 400 for invalid update field types before updating", async () => {
+    const getUpdatePayload = mockExistingOffer();
+
+    const res = await PATCH(
+      makePatchRequest("offer1", {
+        title: 123,
+        product_url: { href: "https://example.com" },
+        tags: ["valid", { label: "bad" }],
+        auto_pay: "true",
+      }),
+      makeParams("offer1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("Title must be text");
+    expect(body.error).toContain("product_url must be a string");
+    expect(body.error).toContain("tags must contain only strings");
+    expect(getUpdatePayload()).toBeNull();
+  });
+
+  it("validates and sanitizes update fields before saving", async () => {
+    const getUpdatePayload = mockExistingOffer();
+
+    const res = await PATCH(
+      makePatchRequest("offer1", {
+        title: " <b>Updated Offer</b> ",
+        product_url: " https://example.com/product ",
+        tags: [" AI ", "Marketing"],
+        auto_pay: false,
+      }),
+      makeParams("offer1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.offer.title).toBe("Updated Offer");
+    expect(getUpdatePayload()).toMatchObject({
+      title: "Updated Offer",
+      product_url: "https://example.com/product",
+      tags: ["ai", "marketing"],
+      auto_pay: false,
+    });
   });
 });

--- a/src/app/api/affiliates/offers/[id]/route.ts
+++ b/src/app/api/affiliates/offers/[id]/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
+import { safeParseBody } from "@/lib/sanitize";
 import { createServiceClient } from "@/lib/supabase/service";
+import { validateOfferUpdateInput, type OfferInput } from "@/lib/affiliates/validation";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
-import { validateOfferInput } from "@/lib/affiliates/validation";
 
+type OfferUpdateBody = Partial<OfferInput> & { auto_pay?: unknown };
 
 /**
  * GET /api/affiliates/offers/[id] - Get offer details
@@ -95,26 +96,41 @@ export async function PATCH(
       return NextResponse.json({ error: "Not found or not authorized" }, { status: 404 });
     }
 
-    const body = await request.json();
+    const body = await safeParseBody<OfferUpdateBody>(request);
+    if (!body) {
+      return NextResponse.json(
+        { error: "Please provide a valid JSON body" },
+        { status: 400 }
+      );
+    }
 
-    // Partial validation — only validate provided fields
-    const updateData: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    const { auto_pay, ...offerFields } = body;
+    const validation = validateOfferUpdateInput(offerFields);
+    if (!validation.ok) {
+      return NextResponse.json(
+        { error: validation.errors.join(", ") },
+        { status: 400 }
+      );
+    }
 
-    if (body.title !== undefined) updateData.title = body.title.trim();
-    if (body.description !== undefined) updateData.description = body.description.trim();
-    if (body.product_url !== undefined) updateData.product_url = body.product_url;
-    if (body.product_type !== undefined) updateData.product_type = body.product_type;
-    if (body.price_sats !== undefined) updateData.price_sats = body.price_sats;
-    if (body.commission_rate !== undefined) updateData.commission_rate = body.commission_rate;
-    if (body.commission_type !== undefined) updateData.commission_type = body.commission_type;
-    if (body.commission_flat_sats !== undefined) updateData.commission_flat_sats = body.commission_flat_sats;
-    if (body.cookie_days !== undefined) updateData.cookie_days = body.cookie_days;
-    if (body.settlement_delay_days !== undefined) updateData.settlement_delay_days = body.settlement_delay_days;
-    if (body.promo_text !== undefined) updateData.promo_text = body.promo_text;
-    if (body.category !== undefined) updateData.category = body.category;
-    if (body.tags !== undefined) updateData.tags = body.tags;
-    if (body.status !== undefined) updateData.status = body.status;
-    if (body.auto_pay !== undefined) updateData.auto_pay = !!body.auto_pay;
+    const updateData: Record<string, unknown> = {
+      ...(validation.sanitized || {}),
+      updated_at: new Date().toISOString(),
+    };
+
+    if (auto_pay !== undefined) {
+      if (typeof auto_pay !== "boolean") {
+        return NextResponse.json(
+          { error: "auto_pay must be a boolean" },
+          { status: 400 }
+        );
+      }
+      updateData.auto_pay = auto_pay;
+    }
+
+    if (Object.keys(updateData).length === 1) {
+      return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+    }
 
     const { data: offer, error } = await (admin as AnySupabase)
       .from("affiliate_offers")

--- a/src/app/api/affiliates/offers/route.test.ts
+++ b/src/app/api/affiliates/offers/route.test.ts
@@ -126,6 +126,32 @@ describe("POST /api/affiliates/offers", () => {
     expect(body.error).toContain("product_url");
   });
 
+  it("rejects malformed field types before creating an offer", async () => {
+    mockGetAuthContext.mockResolvedValue({ user: { id: "user1" } });
+
+    const req = new NextRequest("http://localhost/api/affiliates/offers", {
+      method: "POST",
+      body: JSON.stringify({
+        title: { text: "Bad title" },
+        description: ["not text"],
+        product_url: { href: "https://example.com" },
+        tags: ["valid", { label: "invalid" }],
+        price_sats: 1000,
+        commission_type: "percentage",
+        commission_rate: 0.2,
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Title must be text");
+    expect(body.error).toContain("Description must be text");
+    expect(body.error).toContain("product_url must be a string");
+    expect(body.error).toContain("tags must contain only strings");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
   it("strips HTML from title (#26)", async () => {
     mockGetAuthContext.mockResolvedValue({ user: { id: "user1" } });
     

--- a/src/lib/affiliates/validation.test.ts
+++ b/src/lib/affiliates/validation.test.ts
@@ -59,6 +59,24 @@ describe("validateOfferInput", () => {
     expect(result.errors.some((e) => e.includes("product_url"))).toBe(true);
   });
 
+  it("rejects non-string text and URL fields without throwing", () => {
+    const result = validateOfferInput({
+      ...validInput,
+      title: { text: "Bad title" },
+      description: ["Bad description"],
+      product_url: { href: "https://example.com" },
+    } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "Title must be text",
+        "Description must be text",
+        "product_url must be a string",
+      ])
+    );
+  });
+
   it("strips HTML tags from title (#26)", () => {
     const result = validateOfferInput({
       ...validInput,
@@ -168,6 +186,22 @@ describe("validateOfferInput", () => {
     });
     expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.includes("10 tags"))).toBe(true);
+  });
+
+  it("rejects malformed tag payloads without throwing", () => {
+    expect(
+      validateOfferInput({
+        ...validInput,
+        tags: "finance",
+      } as any).errors
+    ).toContain("tags must be an array");
+
+    expect(
+      validateOfferInput({
+        ...validInput,
+        tags: ["finance", { label: "crypto" }],
+      } as any).errors
+    ).toContain("tags must contain only strings");
   });
 
   it("rejects title shorter than 3 characters", () => {

--- a/src/lib/affiliates/validation.test.ts
+++ b/src/lib/affiliates/validation.test.ts
@@ -280,4 +280,22 @@ describe("validateOfferUpdateInput", () => {
     expect(result.ok).toBe(false);
     expect(result.errors).toContain("Commission rate must be between 1% and 90%");
   });
+
+  it("keeps product_url null in sanitized updates so the column can be cleared", () => {
+    const result = validateOfferUpdateInput({
+      product_url: null,
+    } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.sanitized).toEqual({ product_url: null });
+  });
+
+  it("converts blank product_url updates to null", () => {
+    const result = validateOfferUpdateInput({
+      product_url: "   ",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.sanitized).toEqual({ product_url: null });
+  });
 });

--- a/src/lib/affiliates/validation.test.ts
+++ b/src/lib/affiliates/validation.test.ts
@@ -77,6 +77,46 @@ describe("validateOfferInput", () => {
     );
   });
 
+  it("keeps required-field validation for missing title and description", () => {
+    const result = validateOfferInput({
+      price_sats: 1000,
+      commission_type: "percentage",
+      commission_rate: 0.2,
+    } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "Title must be at least 3 characters",
+        "Description must be at least 10 characters",
+      ])
+    );
+  });
+
+  it("rejects malformed numeric and enum fields without coercing them", () => {
+    const result = validateOfferInput({
+      ...validInput,
+      price_sats: "1000",
+      commission_type: "bonus",
+      commission_rate: "0.2",
+      commission_flat_sats: "500",
+      cookie_days: "30",
+      settlement_delay_days: Number.NaN,
+    } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "price_sats must be a non-negative number",
+        "commission_type must be percentage or flat",
+        "commission_rate must be a number",
+        "commission_flat_sats must be a number",
+        "Cookie window must be 1-365 days",
+        "Settlement delay must be 1-90 days",
+      ])
+    );
+  });
+
   it("strips HTML tags from title (#26)", () => {
     const result = validateOfferInput({
       ...validInput,

--- a/src/lib/affiliates/validation.test.ts
+++ b/src/lib/affiliates/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateOfferInput, stripHtmlTags, isValidUrl } from "./validation";
+import { validateOfferInput, validateOfferUpdateInput, stripHtmlTags, isValidUrl } from "./validation";
 
 describe("stripHtmlTags", () => {
   it("removes HTML tags from strings", () => {
@@ -252,5 +252,32 @@ describe("validateOfferInput", () => {
   it("rejects description shorter than 10 characters", () => {
     const result = validateOfferInput({ ...validInput, description: "Short" });
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("validateOfferUpdateInput", () => {
+  it("allows switching an offer to flat commission with a zero percentage rate", () => {
+    const result = validateOfferUpdateInput({
+      commission_type: "flat",
+      commission_rate: 0,
+      commission_flat_sats: 500,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.sanitized).toMatchObject({
+      commission_type: "flat",
+      commission_rate: 0,
+      commission_flat_sats: 500,
+    });
+  });
+
+  it("continues to reject zero percentage commission rates", () => {
+    const result = validateOfferUpdateInput({
+      commission_type: "percentage",
+      commission_rate: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("Commission rate must be between 1% and 90%");
   });
 });

--- a/src/lib/affiliates/validation.ts
+++ b/src/lib/affiliates/validation.ts
@@ -309,8 +309,13 @@ export function validateOfferUpdateInput(
       !Number.isFinite(input.commission_rate)
     ) {
       errors.push("commission_rate must be a number");
-    } else if (input.commission_rate < 0.01 || input.commission_rate > 0.90) {
+    } else if (
+      input.commission_type !== "flat" &&
+      (input.commission_rate < 0.01 || input.commission_rate > 0.90)
+    ) {
       errors.push("Commission rate must be between 1% and 90%");
+    } else if (input.commission_type === "flat" && input.commission_rate !== 0) {
+      errors.push("commission_rate must be 0 for flat commissions");
     } else {
       sanitized.commission_rate = input.commission_rate;
     }

--- a/src/lib/affiliates/validation.ts
+++ b/src/lib/affiliates/validation.ts
@@ -24,6 +24,12 @@ export interface ValidationResult {
   sanitized?: OfferInput;
 }
 
+export interface UpdateValidationResult {
+  ok: boolean;
+  errors: string[];
+  sanitized?: Partial<OfferInput>;
+}
+
 export function stripHtmlTags(str: string): string {
   return str.replace(/<[^>]*>/g, "");
 }
@@ -41,18 +47,26 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
   const errors: string[] = [];
 
   // Strip HTML tags from title and description (#26)
-  if (typeof input.title !== "string") {
+  if (input.title !== undefined && input.title !== null && typeof input.title !== "string") {
     errors.push("Title must be text");
   } else if (input.title) {
     input.title = stripHtmlTags(input.title);
   }
-  if (typeof input.description !== "string") {
+  if (
+    input.description !== undefined &&
+    input.description !== null &&
+    typeof input.description !== "string"
+  ) {
     errors.push("Description must be text");
   } else if (input.description) {
     input.description = stripHtmlTags(input.description);
   }
 
-  if (typeof input.title === "string" && (!input.title || input.title.trim().length < 3)) {
+  if (
+    typeof input.title !== "string" ||
+    !input.title ||
+    input.title.trim().length < 3
+  ) {
     errors.push("Title must be at least 3 characters");
   }
   if (typeof input.title === "string" && input.title.length > 200) {
@@ -60,8 +74,9 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
   }
 
   if (
-    typeof input.description === "string" &&
-    (!input.description || input.description.trim().length < 10)
+    typeof input.description !== "string" ||
+    !input.description ||
+    input.description.trim().length < 10
   ) {
     errors.push("Description must be at least 10 characters");
   }
@@ -83,20 +98,52 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
     input.price_sats = 0;
   }
 
-  if (typeof input.price_sats !== "number" || input.price_sats < 0) {
+  if (
+    typeof input.price_sats !== "number" ||
+    !Number.isFinite(input.price_sats) ||
+    input.price_sats < 0
+  ) {
     errors.push("price_sats must be a non-negative number");
   }
 
   const commissionType = input.commission_type || "percentage";
 
+  if (
+    typeof commissionType !== "string" ||
+    !["percentage", "flat"].includes(commissionType)
+  ) {
+    errors.push("commission_type must be percentage or flat");
+  }
+
+  if (
+    input.commission_rate !== undefined &&
+    (typeof input.commission_rate !== "number" ||
+      !Number.isFinite(input.commission_rate))
+  ) {
+    errors.push("commission_rate must be a number");
+  }
+
+  if (
+    input.commission_flat_sats !== undefined &&
+    (typeof input.commission_flat_sats !== "number" ||
+      !Number.isFinite(input.commission_flat_sats))
+  ) {
+    errors.push("commission_flat_sats must be a number");
+  }
+
   if (commissionType === "percentage") {
     const commissionRate = input.commission_rate ?? 0.20;
-    if (commissionRate < 0.01 || commissionRate > 0.90) {
+    if (
+      typeof commissionRate === "number" &&
+      (commissionRate < 0.01 || commissionRate > 0.90)
+    ) {
       errors.push("Commission rate must be between 1% and 90%");
     }
   } else if (commissionType === "flat") {
     const flatSats = input.commission_flat_sats ?? 0;
-    if (flatSats < 0) {
+    if (typeof flatSats !== "number") {
+      // The type-specific error was already added above.
+    } else if (flatSats < 0) {
       errors.push("commission_flat_sats must be non-negative");
     } else if (flatSats < 1) {
       errors.push("Flat commission must be at least 1 sat");
@@ -104,19 +151,32 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
   }
 
   // Also reject negative commission_flat_sats even when type is percentage (#23)
-  if (input.commission_flat_sats !== undefined && input.commission_flat_sats < 0) {
+  if (
+    typeof input.commission_flat_sats === "number" &&
+    input.commission_flat_sats < 0
+  ) {
     if (!errors.some(e => e.includes("commission_flat_sats"))) {
       errors.push("commission_flat_sats must be non-negative");
     }
   }
 
   const cookieDays = input.cookie_days ?? 30;
-  if (cookieDays < 1 || cookieDays > 365) {
+  if (
+    typeof cookieDays !== "number" ||
+    !Number.isFinite(cookieDays) ||
+    cookieDays < 1 ||
+    cookieDays > 365
+  ) {
     errors.push("Cookie window must be 1-365 days");
   }
 
   const settlementDays = input.settlement_delay_days ?? 7;
-  if (settlementDays < 1 || settlementDays > 90) {
+  if (
+    typeof settlementDays !== "number" ||
+    !Number.isFinite(settlementDays) ||
+    settlementDays < 1 ||
+    settlementDays > 90
+  ) {
     errors.push("Settlement delay must be 1-90 days");
   }
 
@@ -157,4 +217,195 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
       tags: input.tags?.map((t) => t.trim().toLowerCase()).filter(Boolean) || [],
     },
   };
+}
+
+export function validateOfferUpdateInput(
+  input: Partial<OfferInput>
+): UpdateValidationResult {
+  const errors: string[] = [];
+  const sanitized: Partial<OfferInput> = {};
+
+  if (input.title !== undefined) {
+    if (typeof input.title !== "string") {
+      errors.push("Title must be text");
+    } else {
+      const title = stripHtmlTags(input.title).trim();
+      if (title.length < 3) {
+        errors.push("Title must be at least 3 characters");
+      } else if (title.length > 200) {
+        errors.push("Title must be under 200 characters");
+      } else {
+        sanitized.title = title;
+      }
+    }
+  }
+
+  if (input.description !== undefined) {
+    if (typeof input.description !== "string") {
+      errors.push("Description must be text");
+    } else {
+      const description = stripHtmlTags(input.description).trim();
+      if (description.length < 10) {
+        errors.push("Description must be at least 10 characters");
+      } else {
+        sanitized.description = description;
+      }
+    }
+  }
+
+  if (input.product_url !== undefined) {
+    if (input.product_url !== null && typeof input.product_url !== "string") {
+      errors.push("product_url must be a string");
+    } else if (input.product_url === null) {
+      sanitized.product_url = undefined;
+    } else {
+      const productUrl = input.product_url.trim();
+      if (productUrl.length === 0) {
+        sanitized.product_url = undefined;
+      } else if (!isValidUrl(productUrl)) {
+        errors.push("product_url must use http:// or https:// scheme");
+      } else {
+        sanitized.product_url = productUrl;
+      }
+    }
+  }
+
+  if (input.product_type !== undefined) {
+    if (typeof input.product_type !== "string") {
+      errors.push("Product type must be text");
+    } else if (!AFFILIATE_PRODUCT_TYPES.includes(input.product_type as any)) {
+      errors.push(`Product type must be one of: ${AFFILIATE_PRODUCT_TYPES.join(", ")}`);
+    } else {
+      sanitized.product_type = input.product_type;
+    }
+  }
+
+  if (input.price_sats !== undefined) {
+    if (
+      typeof input.price_sats !== "number" ||
+      !Number.isFinite(input.price_sats) ||
+      input.price_sats < 0
+    ) {
+      errors.push("price_sats must be a non-negative number");
+    } else {
+      sanitized.price_sats = input.price_sats;
+    }
+  }
+
+  if (input.commission_type !== undefined) {
+    if (
+      typeof input.commission_type !== "string" ||
+      !["percentage", "flat"].includes(input.commission_type)
+    ) {
+      errors.push("commission_type must be percentage or flat");
+    } else {
+      sanitized.commission_type = input.commission_type;
+    }
+  }
+
+  if (input.commission_rate !== undefined) {
+    if (
+      typeof input.commission_rate !== "number" ||
+      !Number.isFinite(input.commission_rate)
+    ) {
+      errors.push("commission_rate must be a number");
+    } else if (input.commission_rate < 0.01 || input.commission_rate > 0.90) {
+      errors.push("Commission rate must be between 1% and 90%");
+    } else {
+      sanitized.commission_rate = input.commission_rate;
+    }
+  }
+
+  if (input.commission_flat_sats !== undefined) {
+    if (
+      typeof input.commission_flat_sats !== "number" ||
+      !Number.isFinite(input.commission_flat_sats)
+    ) {
+      errors.push("commission_flat_sats must be a number");
+    } else if (input.commission_flat_sats < 0) {
+      errors.push("commission_flat_sats must be non-negative");
+    } else if (input.commission_flat_sats < 1) {
+      errors.push("Flat commission must be at least 1 sat");
+    } else {
+      sanitized.commission_flat_sats = input.commission_flat_sats;
+    }
+  }
+
+  if (input.cookie_days !== undefined) {
+    if (
+      typeof input.cookie_days !== "number" ||
+      !Number.isFinite(input.cookie_days) ||
+      input.cookie_days < 1 ||
+      input.cookie_days > 365
+    ) {
+      errors.push("Cookie window must be 1-365 days");
+    } else {
+      sanitized.cookie_days = input.cookie_days;
+    }
+  }
+
+  if (input.settlement_delay_days !== undefined) {
+    if (
+      typeof input.settlement_delay_days !== "number" ||
+      !Number.isFinite(input.settlement_delay_days) ||
+      input.settlement_delay_days < 1 ||
+      input.settlement_delay_days > 90
+    ) {
+      errors.push("Settlement delay must be 1-90 days");
+    } else {
+      sanitized.settlement_delay_days = input.settlement_delay_days;
+    }
+  }
+
+  if (input.promo_text !== undefined) {
+    if (typeof input.promo_text !== "string") {
+      errors.push("promo_text must be text");
+    } else {
+      sanitized.promo_text = stripHtmlTags(input.promo_text).trim();
+    }
+  }
+
+  if (input.category !== undefined) {
+    if (typeof input.category !== "string") {
+      errors.push("Category must be text");
+    } else if (!SKILL_CATEGORIES.includes(input.category as any)) {
+      errors.push(`Category must be one of: ${SKILL_CATEGORIES.join(", ")}`);
+    } else {
+      sanitized.category = input.category;
+    }
+  }
+
+  if (input.tags !== undefined) {
+    if (!Array.isArray(input.tags)) {
+      errors.push("tags must be an array");
+    } else if (input.tags.some((tag) => typeof tag !== "string")) {
+      errors.push("tags must contain only strings");
+    } else if (input.tags.length > 10) {
+      errors.push("Maximum 10 tags");
+    } else {
+      sanitized.tags = input.tags.map((t) => t.trim().toLowerCase()).filter(Boolean);
+    }
+  }
+
+  if (input.listing_id !== undefined) {
+    if (input.listing_id !== null && typeof input.listing_id !== "string") {
+      errors.push("listing_id must be text");
+    } else {
+      sanitized.listing_id = input.listing_id || undefined;
+    }
+  }
+
+  if (input.status !== undefined) {
+    if (typeof input.status !== "string") {
+      errors.push("status must be text");
+    } else {
+      sanitized.status = input.status;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, errors: [], sanitized };
 }

--- a/src/lib/affiliates/validation.ts
+++ b/src/lib/affiliates/validation.ts
@@ -41,26 +41,35 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
   const errors: string[] = [];
 
   // Strip HTML tags from title and description (#26)
-  if (input.title) {
+  if (typeof input.title !== "string") {
+    errors.push("Title must be text");
+  } else if (input.title) {
     input.title = stripHtmlTags(input.title);
   }
-  if (input.description) {
+  if (typeof input.description !== "string") {
+    errors.push("Description must be text");
+  } else if (input.description) {
     input.description = stripHtmlTags(input.description);
   }
 
-  if (!input.title || input.title.trim().length < 3) {
+  if (typeof input.title === "string" && (!input.title || input.title.trim().length < 3)) {
     errors.push("Title must be at least 3 characters");
   }
-  if (input.title && input.title.length > 200) {
+  if (typeof input.title === "string" && input.title.length > 200) {
     errors.push("Title must be under 200 characters");
   }
 
-  if (!input.description || input.description.trim().length < 10) {
+  if (
+    typeof input.description === "string" &&
+    (!input.description || input.description.trim().length < 10)
+  ) {
     errors.push("Description must be at least 10 characters");
   }
 
   // Normalize product_url — trim whitespace, treat blank as null (#18 - XSS prevention)
-  if (input.product_url) {
+  if (input.product_url !== undefined && input.product_url !== null && typeof input.product_url !== "string") {
+    errors.push("product_url must be a string");
+  } else if (input.product_url) {
     input.product_url = input.product_url.trim();
     if (input.product_url.length === 0) {
       input.product_url = undefined;
@@ -119,8 +128,14 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
     errors.push(`Category must be one of: ${SKILL_CATEGORIES.join(", ")}`);
   }
 
-  if (input.tags && input.tags.length > 10) {
-    errors.push("Maximum 10 tags");
+  if (input.tags !== undefined) {
+    if (!Array.isArray(input.tags)) {
+      errors.push("tags must be an array");
+    } else if (input.tags.some((tag) => typeof tag !== "string")) {
+      errors.push("tags must contain only strings");
+    } else if (input.tags.length > 10) {
+      errors.push("Maximum 10 tags");
+    }
   }
 
   if (errors.length > 0) {

--- a/src/lib/affiliates/validation.ts
+++ b/src/lib/affiliates/validation.ts
@@ -27,7 +27,7 @@ export interface ValidationResult {
 export interface UpdateValidationResult {
   ok: boolean;
   errors: string[];
-  sanitized?: Partial<OfferInput>;
+  sanitized?: Partial<Omit<OfferInput, "product_url">> & { product_url?: string | null };
 }
 
 export function stripHtmlTags(str: string): string {
@@ -257,11 +257,11 @@ export function validateOfferUpdateInput(
     if (input.product_url !== null && typeof input.product_url !== "string") {
       errors.push("product_url must be a string");
     } else if (input.product_url === null) {
-      sanitized.product_url = undefined;
+      sanitized.product_url = null;
     } else {
       const productUrl = input.product_url.trim();
       if (productUrl.length === 0) {
-        sanitized.product_url = undefined;
+        sanitized.product_url = null;
       } else if (!isValidUrl(productUrl)) {
         errors.push("product_url must use http:// or https:// scheme");
       } else {


### PR DESCRIPTION
Fixes #175. Fixes #198.

## Summary
- add runtime type checks for affiliate offer create text fields, product URLs, tags, and numeric commission fields
- keep malformed create payloads on the 400 validation path before any Supabase query/write
- validate affiliate offer update payloads before saving so bad edit bodies do not 500 or bypass create-time guards
- parse offer update JSON safely and require `auto_pay` to be a real boolean
- add regression coverage for the validation helper, `POST /api/affiliates/offers`, and `PATCH /api/affiliates/offers/[id]`

## Validation
- `./node_modules/.bin/vitest run src/lib/affiliates/validation.test.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.test.ts'`
- `./node_modules/.bin/eslint src/lib/affiliates/validation.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.ts' 'src/app/api/affiliates/offers/[id]/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- src/lib/affiliates/validation.ts 'src/app/api/affiliates/offers/[id]/route.ts' 'src/app/api/affiliates/offers/[id]/route.test.ts'`
