### PR TITLE
fix: disable copy button while referral link is loading

### DIFF
--- a/src/app/dashboard/referrals/page.test.tsx
+++ b/src/app/dashboard/referrals/page.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ReferralsPage from "./page";
+
+// Mock fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Mock clipboard
+const mockWriteText = vi.fn(() => Promise.resolve());
+Object.assign(navigator, {
+  clipboard: { writeText: mockWriteText },
+});
+
+function mockCodeResponse(link = "", code = "") {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ link, code }),
+  };
+}
+
+function mockReferralsResponse() {
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        data: [],
+        stats: { total_invited: 0, total_registered: 0, conversion_rate: 0 },
+      }),
+  };
+}
+
+describe("ReferralsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state on Copy button while referral link is loading", async () => {
+    // Make the code fetch never resolve to simulate loading
+    let resolveCode: (v: unknown) => void;
+    const codePromise = new Promise((r) => {
+      resolveCode = r;
+    });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/referrals/code")) return codePromise;
+      return Promise.resolve(mockReferralsResponse());
+    });
+
+    render(<ReferralsPage />);
+
+    // While loading, the button should say "Loading..." and be disabled
+    const loadingButton = screen.getByRole("button", { name: /loading/i });
+    expect(loadingButton).toBeDisabled();
+
+    // Now resolve the code fetch with a link
+    resolveCode!(mockCodeResponse("https://example.com/ref/abc123", "abc123"));
+
+    // After loading, button should show "Copy" and be enabled
+    await waitFor(() => {
+      const copyButton = screen.getByRole("button", { name: /copy/i });
+      expect(copyButton).not.toBeDisabled();
+    });
+  });
+
+  it("disables Copy button when referral link is empty after loading", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/referrals/code"))
+        return Promise.resolve(mockCodeResponse("", ""));
+      return Promise.resolve(mockReferralsResponse());
+    });
+
+    render(<ReferralsPage />);
+
+    // After loading completes with empty link, Copy should still be disabled
+    await waitFor(() => {
+      const copyButton = screen.getByRole("button", { name: /copy/i });
+      expect(copyButton).toBeDisabled();
+    });
+  });
+
+  it("copies referral link successfully after link loads", async () => {
+    const testLink = "https://example.com/ref/testcode";
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/referrals/code"))
+        return Promise.resolve(mockCodeResponse(testLink, "testcode"));
+      return Promise.resolve(mockReferralsResponse());
+    });
+
+    render(<ReferralsPage />);
+
+    // Wait for Copy button to become enabled
+    const copyButton = await screen.findByRole("button", { name: /copy/i });
+    expect(copyButton).not.toBeDisabled();
+
+    await userEvent.click(copyButton);
+
+    expect(mockWriteText).toHaveBeenCalledWith(testLink);
+  });
+});

--- a/src/app/dashboard/referrals/page.tsx
+++ b/src/app/dashboard/referrals/page.tsx
@@ -43,6 +43,7 @@ export default function ReferralsPage() {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [loadingLink, setLoadingLink] = useState(true);
   const initialized = useRef(false);
 
   useEffect(() => {
@@ -53,6 +54,7 @@ export default function ReferralsPage() {
         setReferralLink(data.link);
         setReferralCode(data.code);
       }
+      setLoadingLink(false);
     });
     loadReferrals().then((data) => {
       if (data) {
@@ -63,6 +65,7 @@ export default function ReferralsPage() {
   }, []);
 
   const copyLink = async () => {
+    if (!referralLink) return;
     await navigator.clipboard.writeText(referralLink);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
@@ -166,10 +169,11 @@ export default function ReferralsPage() {
           />
           <button
             onClick={copyLink}
-            className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors text-sm"
+            disabled={loadingLink || !referralLink}
+            className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors text-sm disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Copy className="h-4 w-4" />
-            {copied ? "Copied!" : "Copy"}
+            {loadingLink ? "Loading..." : copied ? "Copied!" : "Copy"}
           </button>
         </div>
         <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Fix for #133 — Referral copy button copies empty link before invite link loads

### Problem
On the Invite Friends dashboard, the referral link starts as an empty string until `/api/referrals/code` returns. The Copy button is enabled during that loading window, so a quick click can copy an empty string and show the user a successful copy state even though no invite link was copied.

### Changes
- **Add `loadingLink` state** — starts as `true`, set to `false` after `loadCode()` completes (regardless of success/failure)
- **Disable the Copy button** when `loadingLink` is true or `referralLink` is empty (`disabled={loadingLink || !referralLink}`)
- **Show loading text** — button displays "Loading..." while the link is being fetched
- **Add handler guard** in `copyLink` — early return if `referralLink` is empty, preventing clipboard write of empty string
- **Add disabled styles** — `disabled:opacity-50 disabled:cursor-not-allowed` for clear visual feedback
- **Add regression tests** — 3 tests covering loading state, empty link after load, and successful copy

### Testing
All 3 new tests pass:
- ✅ Shows loading state on Copy button while referral link is loading  
- ✅ Disables Copy button when referral link is empty after loading
- ✅ Copies referral link successfully after link loads

Fixes #133