### PR TITLE
Handle affiliate apply notification failures

### DIFF
--- a/src/app/api/affiliates/offers/[id]/apply/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/apply/route.test.ts
@@ -54,6 +54,54 @@ describe("POST /api/affiliates/offers/[id]/apply", () => {
     });
   });
 
+  it("returns the existing tracking link when the affiliate already applied", async () => {
+    const tableCalls: Record<string, number> = {};
+
+    mockFrom.mockImplementation((table: string) => {
+      tableCalls[table] = (tableCalls[table] || 0) + 1;
+
+      if (table === "affiliate_offers") {
+        return mockQuery({
+          data: {
+            id: "offer-1",
+            seller_id: "seller-user",
+            status: "active",
+            slug: "test-offer",
+          },
+          error: null,
+        });
+      }
+
+      if (table === "affiliate_applications") {
+        return mockQuery({
+          data: {
+            id: "application-1",
+            status: "approved",
+            tracking_code: "alice-test-offer",
+          },
+          error: null,
+        });
+      }
+
+      return mockQuery({ data: null, error: null });
+    });
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe("Already approved");
+    expect(body.application).toMatchObject({
+      id: "application-1",
+      status: "approved",
+      tracking_code: "alice-test-offer",
+    });
+    expect(body.tracking_code).toBe("alice-test-offer");
+    expect(body.tracking_url).toBe("https://ugig.net/ref/alice-test-offer");
+    expect(mockFrom).not.toHaveBeenCalledWith("profiles");
+    expect(mockFrom).not.toHaveBeenCalledWith("notifications");
+  });
+
   it("still returns the approved application when seller notification insert fails", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const tableCalls: Record<string, number> = {};

--- a/src/app/api/affiliates/offers/[id]/apply/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/apply/route.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(() => ({ allowed: true })),
+  rateLimitExceeded: vi.fn(),
+  getRateLimitIdentifier: vi.fn(() => "affiliate-apply-test"),
+}));
+
+vi.mock("@/lib/affiliates/tracking", () => ({
+  generateTrackingCode: vi.fn(() => "alice-test-offer"),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: Record<string, unknown> = {}) {
+  return new NextRequest("http://localhost/api/affiliates/offers/offer-1/apply", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeParams(id = "offer-1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+function mockQuery(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const method of ["select", "insert", "update", "eq", "single"]) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  (chain.single as ReturnType<typeof vi.fn>).mockResolvedValue(result);
+  return chain;
+}
+
+describe("POST /api/affiliates/offers/[id]/apply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "affiliate-user", authMethod: "session" },
+    });
+  });
+
+  it("still returns the approved application when seller notification insert fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const tableCalls: Record<string, number> = {};
+
+    mockFrom.mockImplementation((table: string) => {
+      tableCalls[table] = (tableCalls[table] || 0) + 1;
+
+      if (table === "affiliate_offers" && tableCalls[table] === 1) {
+        return mockQuery({
+          data: {
+            id: "offer-1",
+            seller_id: "seller-user",
+            status: "active",
+            slug: "test-offer",
+          },
+          error: null,
+        });
+      }
+
+      if (table === "affiliate_offers") {
+        return mockQuery({
+          data: { total_affiliates: 2 },
+          error: null,
+        });
+      }
+
+      if (table === "affiliate_applications" && tableCalls[table] === 1) {
+        return mockQuery({ data: null, error: null });
+      }
+
+      if (table === "affiliate_applications") {
+        return mockQuery({
+          data: {
+            id: "application-1",
+            offer_id: "offer-1",
+            affiliate_id: "affiliate-user",
+            tracking_code: "alice-test-offer",
+            status: "approved",
+          },
+          error: null,
+        });
+      }
+
+      if (table === "profiles") {
+        return mockQuery({
+          data: { username: "alice" },
+          error: null,
+        });
+      }
+
+      if (table === "notifications") {
+        return {
+          insert: vi.fn().mockRejectedValue(new Error("notification write failed")),
+        };
+      }
+
+      return mockQuery({ data: null, error: null });
+    });
+
+    const res = await POST(makeRequest({ note: "Interested" }), makeParams());
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.application.id).toBe("application-1");
+    expect(body.tracking_code).toBe("alice-test-offer");
+    expect(body.tracking_url).toContain("/ref/alice-test-offer");
+    expect(mockFrom).toHaveBeenCalledWith("notifications");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Failed to create affiliate application notification",
+      expect.any(Error)
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/app/api/affiliates/offers/[id]/apply/route.ts
+++ b/src/app/api/affiliates/offers/[id]/apply/route.ts
@@ -41,16 +41,22 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     // Check if already applied
     const { data: existing } = await (admin as AnySupabase)
       .from("affiliate_applications")
-      .select("id, status")
+      .select("id, status, tracking_code")
       .eq("offer_id", id)
       .eq("affiliate_id", auth.user.id)
       .single();
 
     if (existing) {
+      const trackingUrl = existing.tracking_code
+        ? `${process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"}/ref/${existing.tracking_code}`
+        : null;
+
       return NextResponse.json(
         {
           error: `Already ${existing.status}`,
           application: existing,
+          tracking_code: existing.tracking_code || null,
+          tracking_url: trackingUrl,
         },
         { status: 409 }
       );

--- a/src/app/api/affiliates/offers/[id]/apply/route.ts
+++ b/src/app/api/affiliates/offers/[id]/apply/route.ts
@@ -3,18 +3,13 @@ import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, rateLimitExceeded, getRateLimitIdentifier } from "@/lib/rate-limit";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 import { generateTrackingCode } from "@/lib/affiliates/tracking";
-
 
 /**
  * POST /api/affiliates/offers/[id]/apply - Apply to become an affiliate for an offer
  */
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const auth = await getAuthContext(request);
@@ -52,10 +47,13 @@ export async function POST(
       .single();
 
     if (existing) {
-      return NextResponse.json({
-        error: `Already ${existing.status}`,
-        application: existing,
-      }, { status: 409 });
+      return NextResponse.json(
+        {
+          error: `Already ${existing.status}`,
+          application: existing,
+        },
+        { status: 409 }
+      );
     }
 
     // Get affiliate's username for tracking code
@@ -114,21 +112,32 @@ export async function POST(
     }
 
     // Notify seller
-    await (admin as AnySupabase)
-      .from("notifications")
-      .insert({
-        user_id: offer.seller_id,
-        type: "affiliate_application",
-        title: "New affiliate joined! 🤝",
-        body: `${profile?.username || "Someone"} is now promoting your offer`,
-        data: { offer_id: id, application_id: application.id },
-      });
+    try {
+      const { error: notificationError } = await (admin as AnySupabase)
+        .from("notifications")
+        .insert({
+          user_id: offer.seller_id,
+          type: "affiliate_application",
+          title: "New affiliate joined! 🤝",
+          body: `${profile?.username || "Someone"} is now promoting your offer`,
+          data: { offer_id: id, application_id: application.id },
+        });
 
-    return NextResponse.json({
-      application,
-      tracking_code: trackingCode,
-      tracking_url: `${process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"}/ref/${trackingCode}`,
-    }, { status: 201 });
+      if (notificationError) {
+        console.warn("Failed to create affiliate application notification", notificationError);
+      }
+    } catch (notificationError) {
+      console.warn("Failed to create affiliate application notification", notificationError);
+    }
+
+    return NextResponse.json(
+      {
+        application,
+        tracking_code: trackingCode,
+        tracking_url: `${process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"}/ref/${trackingCode}`,
+      },
+      { status: 201 }
+    );
   } catch {
     return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }


### PR DESCRIPTION
## Summary

- Treat affiliate application seller notifications as best-effort after an application is created.
- Return the existing tracking code and tracking URL when an affiliate reapplies to an offer they already joined.
- Log notification insert errors or thrown failures instead of returning a 500 after the application is already approved.
- Add route regression coverage for a rejected notification insert and repeat-apply tracking link response.

Fixes #179
Fixes #160

## Verification

- `./node_modules/.bin/vitest run 'src/app/api/affiliates/offers/[id]/apply/route.test.ts'`
- `./node_modules/.bin/prettier --check 'src/app/api/affiliates/offers/[id]/apply/route.ts' 'src/app/api/affiliates/offers/[id]/apply/route.test.ts'`
- `./node_modules/.bin/eslint 'src/app/api/affiliates/offers/[id]/apply/route.ts' 'src/app/api/affiliates/offers/[id]/apply/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- 'src/app/api/affiliates/offers/[id]/apply/route.ts' 'src/app/api/affiliates/offers/[id]/apply/route.test.ts'`
