### PR TITLE
fix: affiliate tracking URLs use dynamic origin instead of hardcoded domain

### DIFF
--- a/src/app/api/affiliates/click/route.ts
+++ b/src/app/api/affiliates/click/route.ts
@@ -1,3 +1,4 @@
+import { getAppUrl } from "@/lib/app-url";
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { recordClick } from "@/lib/affiliates/tracking";
@@ -61,13 +62,13 @@ export async function GET(request: NextRequest) {
     if (offer.product_url) {
       redirectUrl = offer.product_url;
     } else if (offer.listing_id && offer.skill_listings?.slug) {
-      redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"}/skills/${offer.skill_listings.slug}`;
+      redirectUrl = `${getAppUrl(request)}/skills/${offer.skill_listings.slug}`;
     } else {
-      redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"}/affiliates/${offer.slug}`;
+      redirectUrl = `${getAppUrl(request)}/affiliates/${offer.slug}`;
     }
 
     // Add ref param to destination for client-side cookie tracking (internal URLs only)
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
+    const appUrl = getAppUrl(request);
     const dest = new URL(redirectUrl);
     if (dest.origin === new URL(appUrl).origin) {
       dest.searchParams.set("ugig_ref", ref);

--- a/src/app/api/affiliates/offers/[id]/affiliates/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/affiliates/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GET } from "./route";
 import { NextRequest } from "next/server";
 
@@ -16,9 +16,9 @@ vi.mock("@/lib/supabase/service", () => ({
   }),
 }));
 
-function makeRequest(id: string) {
+function makeRequest(id: string, origin = "http://localhost") {
   return new NextRequest(
-    `http://localhost/api/affiliates/offers/${id}/affiliates`
+    `${origin}/api/affiliates/offers/${id}/affiliates`
   );
 }
 
@@ -45,8 +45,15 @@ function chainable(data: unknown, error: unknown = null) {
 }
 
 describe("GET /api/affiliates/offers/[id]/affiliates", () => {
+  let originalAppUrl: string | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
   });
 
   it("returns 401 for unauthenticated requests", async () => {
@@ -91,6 +98,7 @@ describe("GET /api/affiliates/offers/[id]/affiliates", () => {
   });
 
   it("returns affiliate list with stats for owner", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://ugig.net";
     mockGetAuthContext.mockResolvedValue({
       user: { id: "user-seller", authMethod: "session" },
     });
@@ -218,5 +226,114 @@ describe("GET /api/affiliates/offers/[id]/affiliates", () => {
     const body = await res.json();
     expect(body.affiliates).toEqual([]);
     expect(body.offer.title).toBe("Empty Offer");
+  })
+  // Regression test for #135: tracking URLs should use the request origin
+  // when NEXT_PUBLIC_APP_URL is not configured
+    // Regression test for #135: tracking URLs should respect NEXT_PUBLIC_APP_URL
+  // instead of using a hardcoded origin
+  it("uses NEXT_PUBLIC_APP_URL as origin for tracking URL instead of hardcoded domain", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "http://staging.example.com";
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+          title: "Test Offer",
+          slug: "test-offer",
+          status: "active",
+          commission_rate: 0.1,
+          commission_type: "percentage",
+          commission_flat_sats: 0,
+          total_clicks: 0,
+          total_conversions: 0,
+          total_revenue_sats: 0,
+          total_commissions_sats: 0,
+        });
+      }
+
+      if (table === "affiliate_applications") {
+        return chainable([
+          {
+            id: "app-1",
+            affiliate_id: "aff-1",
+            status: "approved",
+            tracking_code: "alice-abc123",
+            created_at: "2026-01-15T00:00:00Z",
+            approved_at: "2026-01-16T00:00:00Z",
+            profiles: { username: "alice", avatar_url: null },
+          },
+        ]);
+      }
+
+      if (table === "affiliate_clicks") return chainable([]);
+      if (table === "affiliate_conversions") return chainable([]);
+      return chainable([]);
+    });
+
+    const res = await GET(makeRequest("offer-1"), makeParams("offer-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.affiliates[0].tracking_url).toBe(
+      "http://staging.example.com/api/affiliates/click?ugig_ref=alice-abc123"
+    );
   });
+
+  it("prefers NEXT_PUBLIC_APP_URL over request origin in tracking URL", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://custom.example.com";
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+          title: "Test Offer",
+          slug: "test-offer",
+          status: "active",
+          commission_rate: 0.1,
+          commission_type: "percentage",
+          commission_flat_sats: 0,
+          total_clicks: 0,
+          total_conversions: 0,
+          total_revenue_sats: 0,
+          total_commissions_sats: 0,
+        });
+      }
+
+      if (table === "affiliate_applications") {
+        return chainable([
+          {
+            id: "app-1",
+            affiliate_id: "aff-1",
+            status: "approved",
+            tracking_code: "alice-abc123",
+            created_at: "2026-01-15T00:00:00Z",
+            approved_at: "2026-01-16T00:00:00Z",
+            profiles: { username: "alice", avatar_url: null },
+          },
+        ]);
+      }
+
+      if (table === "affiliate_clicks") return chainable([]);
+      if (table === "affiliate_conversions") return chainable([]);
+      return chainable([]);
+    });
+
+    const res = await GET(
+      makeRequest("offer-1", "http://localhost"),
+      makeParams("offer-1")
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.affiliates[0].tracking_url).toBe(
+      "https://custom.example.com/api/affiliates/click?ugig_ref=alice-abc123"
+    );
+  });
+
 });

--- a/src/app/api/affiliates/offers/[id]/affiliates/route.ts
+++ b/src/app/api/affiliates/offers/[id]/affiliates/route.ts
@@ -1,3 +1,4 @@
+import { getAppUrl } from "@/lib/app-url";
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
@@ -159,7 +160,7 @@ export async function GET(
           tracking_code: app.tracking_code,
           tracking_url:
             app.status === "approved" && app.tracking_code
-              ? `https://ugig.net/api/affiliates/click?ugig_ref=${app.tracking_code}`
+              ? `${getAppUrl(request)}/api/affiliates/click?ugig_ref=${app.tracking_code}`
               : null,
           clicks_30d: clicksByAffiliate[app.affiliate_id] || 0,
           conversions: convStats.count,

--- a/src/app/api/affiliates/offers/[id]/apply/route.ts
+++ b/src/app/api/affiliates/offers/[id]/apply/route.ts
@@ -1,3 +1,4 @@
+import { getAppUrl } from "@/lib/app-url";
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
@@ -127,7 +128,7 @@ export async function POST(
     return NextResponse.json({
       application,
       tracking_code: trackingCode,
-      tracking_url: `${process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net"}/ref/${trackingCode}`,
+      tracking_url: `${getAppUrl(request)}/ref/${trackingCode}`,
     }, { status: 201 });
   } catch {
     return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });

--- a/src/app/api/referrals/code/route.test.ts
+++ b/src/app/api/referrals/code/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GET } from "./route";
 import { NextRequest } from "next/server";
 
@@ -12,8 +12,15 @@ function makeRequest() {
 }
 
 describe("GET /api/referrals/code", () => {
+  let originalAppUrl: string | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -23,6 +30,7 @@ describe("GET /api/referrals/code", () => {
   });
 
   it("should return referral code and link", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://ugig.net";
     const mockSupabase = {
       from: () => ({
         select: () => ({
@@ -68,5 +76,32 @@ describe("GET /api/referrals/code", () => {
 
     const res = await GET(makeRequest());
     expect(res.status).toBe(404);
+  });
+  // Regression test for #135: referral link should use configured app URL
+  it("should use NEXT_PUBLIC_APP_URL as origin for referral link", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "http://staging.example.com";
+    const mockSupabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            single: () =>
+              Promise.resolve({
+                data: { referral_code: "janedoe", username: "janedoe" },
+                error: null,
+              }),
+          }),
+        }),
+      }),
+    };
+
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user2" },
+      supabase: mockSupabase,
+    });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.link).toBe("http://staging.example.com/?ref=janedoe");
   });
 });

--- a/src/app/api/referrals/code/route.ts
+++ b/src/app/api/referrals/code/route.ts
@@ -1,3 +1,4 @@
+import { getAppUrl } from "@/lib/app-url";
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 
@@ -25,7 +26,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       code,
-      link: `https://ugig.net/?ref=${code}`,
+      link: `${getAppUrl(request)}/?ref=${code}`,
     });
   } catch {
     return NextResponse.json(

--- a/src/app/ref/[code]/route.ts
+++ b/src/app/ref/[code]/route.ts
@@ -1,3 +1,4 @@
+import { getAppUrl } from "@/lib/app-url";
 import { NextRequest, NextResponse } from "next/server";
 
 /**
@@ -9,6 +10,6 @@ export async function GET(
   { params }: { params: Promise<{ code: string }> }
 ) {
   const { code } = await params;
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
+  const baseUrl = getAppUrl(request);
   return NextResponse.redirect(`${baseUrl}/api/affiliates/click?ugig_ref=${encodeURIComponent(code)}`);
 }

--- a/src/lib/app-url.test.ts
+++ b/src/lib/app-url.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getAppUrl } from "./app-url";
+
+describe("getAppUrl", () => {
+  let originalAppUrl: string | undefined;
+
+  beforeEach(() => {
+    originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+  });
+
+  it("returns NEXT_PUBLIC_APP_URL when set", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://custom.example.com";
+    expect(getAppUrl()).toBe("https://custom.example.com");
+  });
+
+  it("strips trailing slash from NEXT_PUBLIC_APP_URL", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://custom.example.com/";
+    expect(getAppUrl()).toBe("https://custom.example.com");
+  });
+
+  it("extracts origin from request URL when env is not set", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    const req = new Request("http://staging.ugig.net/api/test");
+    expect(getAppUrl(req)).toBe("http://staging.ugig.net");
+  });
+
+  it("extracts origin from localhost request", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    const req = new Request("http://localhost:3000/api/test");
+    expect(getAppUrl(req)).toBe("http://localhost:3000");
+  });
+
+  it("prefers NEXT_PUBLIC_APP_URL over request origin", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://production.ugig.net";
+    const req = new Request("http://staging.ugig.net/api/test");
+    expect(getAppUrl(req)).toBe("https://production.ugig.net");
+  });
+
+  it("falls back to https://ugig.net when no env and no request", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    expect(getAppUrl()).toBe("https://ugig.net");
+  });
+
+  it("falls back to https://ugig.net when request URL is unparseable", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    // Passing undefined request should still work
+    expect(getAppUrl(undefined)).toBe("https://ugig.net");
+  });
+});

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve the current deployment's base URL.
+ *
+ * Priority:
+ * 1. NEXT_PUBLIC_APP_URL env var (explicit deployment origin)
+ * 2. Request origin (derived from the incoming request URL)
+ * 3. Hardcoded fallback "https://ugig.net"
+ *
+ * In API route handlers the request object is always available,
+ * so the origin is derived from `request.url` rather than guessed.
+ */
+export function getAppUrl(request?: Request): string {
+  const env = process.env.NEXT_PUBLIC_APP_URL;
+  if (env) return env.replace(/\/+$/, "");
+
+  if (request) {
+    try {
+      const { origin } = new URL(request.url);
+      if (origin && origin !== "undefined") return origin;
+    } catch {
+      // fall through
+    }
+  }
+
+  return "https://ugig.net";
+}


### PR DESCRIPTION
## Fix for #135 — Affiliate tracking URLs ignore current deployment origin

### Problem
Affiliate tracking URLs returned by the affiliate APIs used a hardcoded `https://ugig.net` origin or `process.env.NEXT_PUBLIC_APP_URL || 'https://ugig.net'` fallback. This broke affiliate testing on local/staging deployments because users received production tracking links even when interacting on another origin.

### Solution
1. **New utility** `src/lib/app-url.ts` — `getAppUrl(request)` resolves the current deployment origin with proper priority:
   - `NEXT_PUBLIC_APP_URL` env var (explicit deployment origin)
   - Request URL origin (derived from the incoming request)
   - Hardcoded fallback `https://ugig.net`

2. **Replaced** all hardcoded `https://ugig.net` and `process.env.NEXT_PUBLIC_APP_URL || 'https://ugig.net'` patterns in these API routes:
   - `src/app/api/affiliates/offers/[id]/affiliates/route.ts` — seller affiliate list (was fully hardcoded)
   - `src/app/api/affiliates/offers/[id]/apply/route.ts` — apply endpoint
   - `src/app/api/affiliates/click/route.ts` — click tracking and redirect
   - `src/app/ref/[code]/route.ts` — short ref link redirect
   - `src/app/api/referrals/code/route.ts` — referral link API

3. **Regression tests** added:
   - `src/lib/app-url.test.ts` — 7 unit tests covering env priority, request origin extraction, trailing slash strip, fallbacks
   - Affiliate list route test: verifies custom NEXT_PUBLIC_APP_URL is used for tracking URLs
   - Referral code route test: verifies custom NEXT_PUBLIC_APP_URL is used for referral links

### Testing
All 17 new and existing tests pass. TypeScript compilation clean.

Closes #135