### PR TITLE
Handle malformed wallet withdrawal bodies

### DIFF
--- a/src/app/api/wallet/withdraw/route.test.ts
+++ b/src/app/api/wallet/withdraw/route.test.ts
@@ -56,6 +56,14 @@ function makeRequest(body: any) {
   }) as any;
 }
 
+function makeRawRequest(body: string) {
+  return new Request("http://localhost/api/wallet/withdraw", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  }) as any;
+}
+
 describe("POST /api/wallet/withdraw", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -91,6 +99,24 @@ describe("POST /api/wallet/withdraw", () => {
     mockGetAuthContext.mockResolvedValue(null);
     const res = await POST(makeRequest({ amount_sats: 100, destination: "user@wallet.com" }));
     expect(res.status).toBe(401);
+  });
+
+  it("rejects malformed JSON without starting withdrawal lookup", async () => {
+    const res = await POST(makeRawRequest("{not valid json"));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid request body");
+    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-object JSON bodies without starting withdrawal lookup", async () => {
+    const res = await POST(makeRequest(null));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid request body");
+    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
   });
 
   it("rejects missing fields", async () => {
@@ -130,6 +156,15 @@ describe("POST /api/wallet/withdraw", () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.error).toMatch(/whole number/i);
+  });
+
+  it("rejects non-string destinations", async () => {
+    const res = await POST(makeRequest({ amount_sats: 100, destination: 123 }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/destination must be a string/i);
+    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
   });
 
   it("rejects invalid destination", async () => {

--- a/src/app/api/wallet/withdraw/route.ts
+++ b/src/app/api/wallet/withdraw/route.ts
@@ -9,6 +9,23 @@ const MAX_WITHDRAW = 100000;
 const DAILY_WITHDRAW_LIMIT = 500000;
 const HOURLY_WITHDRAW_LIMIT = 3;
 
+type WithdrawRequestBody = {
+  amount_sats?: unknown;
+  destination?: unknown;
+};
+
+async function parseWithdrawRequestBody(request: NextRequest): Promise<WithdrawRequestBody | null> {
+  try {
+    const body = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return null;
+    }
+    return body as WithdrawRequestBody;
+  } catch {
+    return null;
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const auth = await getAuthContext(request);
@@ -16,13 +33,21 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { amount_sats, destination } = await request.json();
+    const body = await parseWithdrawRequestBody(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const { amount_sats, destination } = body;
 
     if (!amount_sats || !destination) {
       return NextResponse.json({ error: "amount_sats and destination are required" }, { status: 400 });
     }
-    if (!Number.isInteger(amount_sats)) {
+    if (typeof amount_sats !== "number" || !Number.isInteger(amount_sats)) {
       return NextResponse.json({ error: "Amount must be a whole number" }, { status: 400 });
+    }
+    if (typeof destination !== "string") {
+      return NextResponse.json({ error: "Destination must be a string" }, { status: 400 });
     }
     if (amount_sats < MIN_WITHDRAW || amount_sats > MAX_WITHDRAW) {
       return NextResponse.json({


### PR DESCRIPTION
## Summary
- return 400 Invalid request body for malformed or non-object wallet withdraw JSON
- validate destination type before wallet lookup/payment logic
- add route regression coverage proving malformed bodies stop before withdrawal lookup

Fixes #184

## uGig task
Submitted for the active uGig repo testing task: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

No payout details included; those can be provided after acceptance.

## Tests
- ./node_modules/.bin/vitest run src/app/api/wallet/withdraw/route.test.ts
- ./node_modules/.bin/eslint src/app/api/wallet/withdraw/route.ts src/app/api/wallet/withdraw/route.test.ts
- ./node_modules/.bin/tsc --noEmit
- git diff --check -- src/app/api/wallet/withdraw/route.ts src/app/api/wallet/withdraw/route.test.ts