### PR TITLE
Handle malformed wallet deposit bodies

### DIFF
--- a/src/app/api/wallet/deposit/route.test.ts
+++ b/src/app/api/wallet/deposit/route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: any[]) => mockGetAuthContext(...args),
+}));
+
+const mockCreateServiceClient = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => mockCreateServiceClient(),
+}));
+
+const mockGetUserLnWallet = vi.fn();
+const mockCreateInvoice = vi.fn();
+const mockGetLnBalance = vi.fn();
+vi.mock("@/lib/lightning/wallet-utils", () => ({
+  getUserLnWallet: (...args: any[]) => mockGetUserLnWallet(...args),
+  createInvoice: (...args: any[]) => mockCreateInvoice(...args),
+  getLnBalance: (...args: any[]) => mockGetLnBalance(...args),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: any) {
+  return new Request("http://localhost/api/wallet/deposit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+function makeRawRequest(body: string) {
+  return new Request("http://localhost/api/wallet/deposit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  }) as any;
+}
+
+describe("POST /api/wallet/deposit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({ user: { id: "user-12345678" } });
+    mockGetUserLnWallet.mockResolvedValue({
+      invoice_key: "invoice-key-123",
+    });
+    mockCreateInvoice.mockResolvedValue({
+      payment_request: "lnbc123",
+      payment_hash: "hash-123",
+    });
+    mockGetLnBalance.mockResolvedValue(250);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ amount_sats: 100 }));
+
+    expect(res.status).toBe(401);
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed JSON without creating an invoice", async () => {
+    const res = await POST(makeRawRequest("{not valid json"));
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid request body");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+    expect(mockCreateInvoice).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-object JSON bodies without creating an invoice", async () => {
+    const res = await POST(makeRequest(null));
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid request body");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+    expect(mockCreateInvoice).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-integer amounts without wallet lookup", async () => {
+    const res = await POST(makeRequest({ amount_sats: 100.5 }));
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid amount (1-1,000,000 sats)");
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
+  });
+
+  it("creates an invoice for a valid deposit amount", async () => {
+    const walletSelectSingle = vi.fn().mockResolvedValue({
+      data: { id: "wallet-1", balance_sats: 250 },
+    });
+    const walletEq = vi.fn().mockReturnValue({ single: walletSelectSingle });
+    const walletSelect = vi.fn().mockReturnValue({ eq: walletEq });
+    const transactionInsert = vi.fn().mockResolvedValue({ data: null });
+    const admin = {
+      from: vi.fn((table: string) => {
+        if (table === "wallets") {
+          return {
+            select: walletSelect,
+            insert: vi.fn().mockResolvedValue({ data: null }),
+          };
+        }
+        if (table === "wallet_transactions") {
+          return { insert: transactionInsert };
+        }
+        return {};
+      }),
+    };
+    mockCreateServiceClient.mockReturnValue(admin);
+
+    const res = await POST(makeRequest({ amount_sats: 100 }));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({
+      ok: true,
+      payment_request: "lnbc123",
+      payment_hash: "hash-123",
+      amount_sats: 100,
+    });
+    expect(mockCreateInvoice).toHaveBeenCalledWith(
+      "invoice-key-123",
+      100,
+      "ugig.net deposit (user-123)",
+    );
+    expect(transactionInsert).toHaveBeenCalledWith({
+      user_id: "user-12345678",
+      type: "deposit",
+      amount_sats: 100,
+      balance_after: 250,
+      bolt11: "lnbc123",
+      payment_hash: "hash-123",
+      status: "pending",
+    });
+  });
+});

--- a/src/app/api/wallet/deposit/route.ts
+++ b/src/app/api/wallet/deposit/route.ts
@@ -3,6 +3,22 @@ import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { getUserLnWallet, createInvoice, getLnBalance } from "@/lib/lightning/wallet-utils";
 
+type DepositRequestBody = {
+  amount_sats?: unknown;
+};
+
+async function parseDepositRequestBody(request: NextRequest): Promise<DepositRequestBody | null> {
+  try {
+    const body = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return null;
+    }
+    return body as DepositRequestBody;
+  } catch {
+    return null;
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const auth = await getAuthContext(request);
@@ -10,8 +26,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { amount_sats } = await request.json();
-    if (!amount_sats || amount_sats <= 0 || amount_sats > 1000000) {
+    const body = await parseDepositRequestBody(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const { amount_sats } = body;
+    if (
+      typeof amount_sats !== "number" ||
+      !Number.isInteger(amount_sats) ||
+      amount_sats <= 0 ||
+      amount_sats > 1000000
+    ) {
       return NextResponse.json({ error: "Invalid amount (1-1,000,000 sats)" }, { status: 400 });
     }
 


### PR DESCRIPTION
## Summary
- return 400 Invalid request body for malformed or non-object wallet deposit JSON
- require `amount_sats` to be a whole-number sat amount before wallet/invoice work
- add route tests for malformed JSON, non-object JSON, invalid amounts, unauthenticated requests, and valid invoice creation

Fixes #186

## uGig task
Submitted for the active uGig repo testing task: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

No payout details included; those can be provided after acceptance.

## Tests
- ./node_modules/.bin/vitest run src/app/api/wallet/deposit/route.test.ts
- ./node_modules/.bin/eslint src/app/api/wallet/deposit/route.ts src/app/api/wallet/deposit/route.test.ts
- ./node_modules/.bin/tsc --noEmit
- git diff --check -- src/app/api/wallet/deposit/route.ts src/app/api/wallet/deposit/route.test.ts