### PR TITLE
Handle malformed wallet zap bodies

### DIFF
--- a/src/app/api/wallet/zap/route.test.ts
+++ b/src/app/api/wallet/zap/route.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+const mockCreateServiceClient = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => mockCreateServiceClient(),
+}));
+
+const mockGetUserLnWallet = vi.fn();
+const mockGetLnBalance = vi.fn();
+const mockInternalTransfer = vi.fn();
+const mockSyncBalanceCache = vi.fn();
+vi.mock("@/lib/lightning/wallet-utils", () => ({
+  getUserLnWallet: (...args: unknown[]) => mockGetUserLnWallet(...args),
+  getLnBalance: (...args: unknown[]) => mockGetLnBalance(...args),
+  internalTransfer: (...args: unknown[]) => mockInternalTransfer(...args),
+  syncBalanceCache: (...args: unknown[]) => mockSyncBalanceCache(...args),
+}));
+
+const mockGetUserDid = vi.fn();
+const mockOnZapSent = vi.fn();
+const mockOnZapReceived = vi.fn();
+vi.mock("@/lib/reputation-hooks", () => ({
+  getUserDid: (...args: unknown[]) => mockGetUserDid(...args),
+  onZapSent: (...args: unknown[]) => mockOnZapSent(...args),
+  onZapReceived: (...args: unknown[]) => mockOnZapReceived(...args),
+}));
+
+import { POST } from "./route";
+
+const USER_ID = "00000000-0000-4000-8000-000000000001";
+
+function makeRequest(body: string) {
+  return new NextRequest("http://localhost/api/wallet/zap", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+}
+
+function makeJsonRequest(body: unknown) {
+  return makeRequest(JSON.stringify(body));
+}
+
+describe("POST /api/wallet/zap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({ user: { id: USER_ID } });
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await POST(makeJsonRequest({}));
+
+    expect(res.status).toBe(401);
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed JSON before wallet work", async () => {
+    const res = await POST(makeRequest("{not valid json"));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid request body" });
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
+    expect(mockInternalTransfer).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-object JSON before wallet work", async () => {
+    const res = await POST(makeJsonRequest("not an object"));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid request body" });
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
+  });
+
+  it("keeps valid JSON on the existing validation path", async () => {
+    const res = await POST(
+      makeJsonRequest({
+        recipient_id: USER_ID,
+        amount_sats: 10,
+        target_type: "post",
+        target_id: "post-1",
+      })
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Cannot zap yourself" });
+    expect(mockCreateServiceClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/wallet/zap/route.ts
+++ b/src/app/api/wallet/zap/route.ts
@@ -4,6 +4,7 @@ import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { PLATFORM_FEE_RATE, PLATFORM_WALLET_USER_ID } from "@/lib/constants";
 import { getUserDid, onZapSent, onZapReceived } from "@/lib/reputation-hooks";
+import { safeParseBody } from "@/lib/sanitize";
 import {
   getUserLnWallet,
   getLnBalance,
@@ -29,7 +30,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const rawBody = await request.json();
+    const rawBody = await safeParseBody(request);
+    if (!rawBody) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
     const parsed = zapRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });


### PR DESCRIPTION
## Summary
- return 400 Invalid request body for malformed or non-object wallet zap JSON
- keep valid JSON payloads on the existing Zod validation path
- add route tests proving malformed bodies stop before service-client, wallet, or transfer work

Fixes #188

## uGig task
Submitted for the active uGig repo testing task: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

No payout details included; those can be provided after acceptance.

## Tests
- ./node_modules/.bin/vitest run src/app/api/wallet/zap/route.test.ts
- ./node_modules/.bin/eslint src/app/api/wallet/zap/route.ts src/app/api/wallet/zap/route.test.ts
- ./node_modules/.bin/tsc --noEmit
- git diff --check -- src/app/api/wallet/zap/route.ts src/app/api/wallet/zap/route.test.ts