### PR TITLE
Handle malformed auth recovery request bodies

### DIFF
--- a/src/app/api/auth/confirmed/route.test.ts
+++ b/src/app/api/auth/confirmed/route.test.ts
@@ -64,6 +64,16 @@ function makeRequest(body: unknown, secret: string | null = "test-webhook-secret
   });
 }
 
+function makeRawRequest(body: string, secret: string | null = "test-webhook-secret"): NextRequest {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (secret !== null) headers["authorization"] = `Bearer ${secret}`;
+  return new NextRequest("http://localhost/api/auth/confirmed", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
 function confirmationPayload(overrides?: {
   userId?: string;
   email?: string;
@@ -180,6 +190,15 @@ describe("POST /api/auth/confirmed", () => {
       );
       expect(res.status).toBe(400);
     });
+
+    it("returns 400 for malformed JSON without sending email", async () => {
+      const res = await POST(makeRawRequest("{"));
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toBe("Invalid request body");
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
   });
 
   describe("DID auto-generation", () => {
@@ -194,7 +213,6 @@ describe("POST /api/auth/confirmed", () => {
 
       // Should have called update on profiles to store the DID
       expect(mockUpdate).toHaveBeenCalled();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const updateArg = (mockUpdate.mock.calls as any)[0]?.[0] as Record<string, unknown>;
       expect(updateArg).toHaveProperty("did");
       expect(updateArg.did).toMatch(/^did:key:z/);
@@ -211,7 +229,6 @@ describe("POST /api/auth/confirmed", () => {
 
       await POST(makeRequest(confirmationPayload()));
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const did = ((mockUpdate.mock.calls as any)[0]?.[0] as Record<string, unknown>)?.did as string;
       // did:key:z<base58btc-encoded multicodec>
       expect(did).toMatch(/^did:key:z[1-9A-HJ-NP-Za-km-z]+$/);

--- a/src/app/api/auth/confirmed/route.ts
+++ b/src/app/api/auth/confirmed/route.ts
@@ -19,6 +19,19 @@ import { createServiceClient } from "@/lib/supabase/service";
 import { sendEmail, welcomeEmail } from "@/lib/email";
 import { generateAndStoreDid } from "@/lib/auth/did";
 import { createUserLnWallet } from "@/lib/lightning/create-wallet";
+import { safeParseBody } from "@/lib/sanitize";
+
+type AuthWebhookPayload = {
+  type?: string;
+  record?: {
+    email_confirmed_at?: string | null;
+    id?: string;
+    email?: string;
+  };
+  old_record?: {
+    email_confirmed_at?: string | null;
+  };
+};
 
 function safeCompare(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
@@ -40,7 +53,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json();
+    const body = await safeParseBody<AuthWebhookPayload>(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
     // Supabase auth webhook payload
     const { type, record } = body;

--- a/src/app/api/auth/forgot-password/route.test.ts
+++ b/src/app/api/auth/forgot-password/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+const mockResetPasswordForEmail = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: {
+        resetPasswordForEmail: mockResetPasswordForEmail,
+      },
+    }),
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/forgot-password", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeRawRequest(body: string) {
+  return new NextRequest("http://localhost/api/auth/forgot-password", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/auth/forgot-password", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  it("sends a reset link for a valid email", async () => {
+    mockResetPasswordForEmail.mockResolvedValue({ error: null });
+
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.message).toContain("password reset link");
+    expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
+      "test@example.com",
+      expect.objectContaining({ redirectTo: "https://ugig.net/auth/confirm" })
+    );
+  });
+
+  it("returns 400 for invalid email", async () => {
+    const res = await POST(makeRequest({ email: "invalid" }));
+    expect(res.status).toBe(400);
+    expect(mockResetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed JSON without sending a reset link", async () => {
+    const res = await POST(makeRawRequest("{"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid request body");
+    expect(mockResetPasswordForEmail).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { safeParseBody } from "@/lib/sanitize";
 import { forgotPasswordSchema } from "@/lib/validations";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await safeParseBody(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
     const validationResult = forgotPasswordSchema.safeParse(body);
 
     if (!validationResult.success) {

--- a/src/app/api/auth/resend-confirmation/route.test.ts
+++ b/src/app/api/auth/resend-confirmation/route.test.ts
@@ -27,6 +27,14 @@ function makeRequest(body: Record<string, unknown>) {
   });
 }
 
+function makeRawRequest(body: string) {
+  return new NextRequest("http://localhost/api/auth/resend-confirmation", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 describe("POST /api/auth/resend-confirmation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -54,5 +62,13 @@ describe("POST /api/auth/resend-confirmation", () => {
   it("should return 400 for invalid email", async () => {
     const res = await POST(makeRequest({ email: "not-valid" }));
     expect(res.status).toBe(400);
+  });
+
+  it("should return 400 for malformed JSON without resending", async () => {
+    const res = await POST(makeRawRequest("{"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid request body");
+    expect(mockResend).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/auth/resend-confirmation/route.ts
+++ b/src/app/api/auth/resend-confirmation/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { checkRateLimit, rateLimitExceeded, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { safeParseBody } from "@/lib/sanitize";
 import { z } from "zod";
 
 const resendSchema = z.object({
@@ -13,7 +14,11 @@ export async function POST(request: NextRequest) {
     const rl = checkRateLimit(identifier, "auth");
     if (!rl.allowed) return rateLimitExceeded(rl);
 
-    const body = await request.json();
+    const body = await safeParseBody(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
     const validationResult = resendSchema.safeParse(body);
 
     if (!validationResult.success) {

--- a/src/app/api/auth/reset-password/route.test.ts
+++ b/src/app/api/auth/reset-password/route.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+const mockUpdateUser = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: {
+        updateUser: mockUpdateUser,
+      },
+    }),
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/reset-password", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeRawRequest(body: string) {
+  return new NextRequest("http://localhost/api/auth/reset-password", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/auth/reset-password", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates the password for a valid request", async () => {
+    mockUpdateUser.mockResolvedValue({ error: null });
+
+    const res = await POST(makeRequest({ password: "Valid-password-123" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.message).toBe("Password updated successfully");
+    expect(mockUpdateUser).toHaveBeenCalledWith({ password: "Valid-password-123" });
+  });
+
+  it("returns 400 for an invalid password", async () => {
+    const res = await POST(makeRequest({ password: "short" }));
+    expect(res.status).toBe(400);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed JSON without updating the password", async () => {
+    const res = await POST(makeRawRequest("{"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid request body");
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { safeParseBody } from "@/lib/sanitize";
 import { resetPasswordSchema } from "@/lib/validations";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await safeParseBody(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
     const validationResult = resetPasswordSchema.safeParse(body);
 
     if (!validationResult.success) {


### PR DESCRIPTION
## Summary
- Reuse `safeParseBody` in forgot-password, reset-password, resend-confirmation, and auth-confirmed routes so malformed/empty/non-object JSON returns 400 instead of falling into 500 handlers.
- Keep the auth-confirmed webhook secret check before body parsing.
- Add regression tests proving malformed JSON does not call Supabase or send email side effects.

Fixes #192

## Verification
- `./node_modules/.bin/vitest run src/app/api/auth/forgot-password/route.test.ts src/app/api/auth/reset-password/route.test.ts src/app/api/auth/resend-confirmation/route.test.ts src/app/api/auth/confirmed/route.test.ts`
- `./node_modules/.bin/eslint src/app/api/auth/forgot-password/route.ts src/app/api/auth/reset-password/route.ts src/app/api/auth/resend-confirmation/route.ts src/app/api/auth/confirmed/route.ts src/app/api/auth/forgot-password/route.test.ts src/app/api/auth/reset-password/route.test.ts src/app/api/auth/resend-confirmation/route.test.ts src/app/api/auth/confirmed/route.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- src/app/api/auth/forgot-password/route.ts src/app/api/auth/reset-password/route.ts src/app/api/auth/resend-confirmation/route.ts src/app/api/auth/confirmed/route.ts src/app/api/auth/forgot-password/route.test.ts src/app/api/auth/reset-password/route.test.ts src/app/api/auth/resend-confirmation/route.test.ts src/app/api/auth/confirmed/route.test.ts`