### PR TITLE
Require visitor match for affiliate attribution cookies

### DIFF
--- a/src/lib/affiliates/tracking.test.ts
+++ b/src/lib/affiliates/tracking.test.ts
@@ -156,6 +156,85 @@ describe("findAttribution", () => {
     });
   });
 
+  it("requires the same visitor when attributing with a tracking-code cookie", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T12:00:00Z"));
+
+    const admin = makeAffiliateSupabase({
+      application: {
+        affiliate_id: "aff-1",
+        tracking_code: "alice-abc123",
+        status: "approved",
+        offer_id: "offer-1",
+      },
+      offer: { id: "offer-1", cookie_days: 30 },
+      clicks: [
+        {
+          id: "other-visitor-click",
+          offer_id: "offer-1",
+          affiliate_id: "aff-1",
+          tracking_code: "alice-abc123",
+          visitor_id: "visitor-other",
+          created_at: "2026-05-20T06:00:00Z",
+        },
+      ],
+    });
+
+    const result = await findAttribution(admin as any, {
+      offerId: "offer-1",
+      trackingCode: "alice-abc123",
+      visitorId: "visitor-current",
+    });
+
+    expect(result).toEqual({ affiliated: false });
+  });
+
+  it("credits the matching visitor when tracking-code attribution has a visitor id", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T12:00:00Z"));
+
+    const admin = makeAffiliateSupabase({
+      application: {
+        affiliate_id: "aff-1",
+        tracking_code: "alice-abc123",
+        status: "approved",
+        offer_id: "offer-1",
+      },
+      offer: { id: "offer-1", cookie_days: 30 },
+      clicks: [
+        {
+          id: "older-other-visitor-click",
+          offer_id: "offer-1",
+          affiliate_id: "aff-1",
+          tracking_code: "alice-abc123",
+          visitor_id: "visitor-other",
+          created_at: "2026-05-20T07:00:00Z",
+        },
+        {
+          id: "matching-visitor-click",
+          offer_id: "offer-1",
+          affiliate_id: "aff-1",
+          tracking_code: "alice-abc123",
+          visitor_id: "visitor-current",
+          created_at: "2026-05-20T06:00:00Z",
+        },
+      ],
+    });
+
+    const result = await findAttribution(admin as any, {
+      offerId: "offer-1",
+      trackingCode: "alice-abc123",
+      visitorId: "visitor-current",
+    });
+
+    expect(result).toEqual({
+      affiliated: true,
+      affiliate_id: "aff-1",
+      click_id: "matching-visitor-click",
+      tracking_code: "alice-abc123",
+    });
+  });
+
   it("does not credit an expired tracking-code cookie", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-20T12:00:00Z"));

--- a/src/lib/affiliates/tracking.ts
+++ b/src/lib/affiliates/tracking.ts
@@ -179,15 +179,21 @@ export async function findAttribution(
     if (app) {
       const windowStart = await getAttributionWindowStart(admin, offerId);
 
-      // Require a real click inside the offer's attribution window.
-      const { data: clicks } = await (admin as AnySupabase)
+      // Require a real click inside the offer's attribution window. When the
+      // caller has a visitor id, the click must belong to that same visitor.
+      let clickQuery = (admin as AnySupabase)
         .from("affiliate_clicks")
         .select("id")
         .eq("tracking_code", trackingCode)
         .eq("offer_id", offerId)
         .gte("created_at", windowStart)
-        .order("created_at", { ascending: false })
-        .limit(1);
+        .order("created_at", { ascending: false });
+
+      if (visitorId) {
+        clickQuery = clickQuery.eq("visitor_id", visitorId);
+      }
+
+      const { data: clicks } = await clickQuery.limit(1);
 
       if (!clicks || clicks.length === 0) {
         return { affiliated: false };
@@ -212,14 +218,13 @@ export async function findAttribution(
     .select("id, affiliate_id, tracking_code")
     .eq("offer_id", offerId)
     .gte("created_at", windowStart)
-    .order("created_at", { ascending: false })
-    .limit(1);
+    .order("created_at", { ascending: false });
 
   if (visitorId) {
     query = query.eq("visitor_id", visitorId);
   }
 
-  const { data: clicks } = await query;
+  const { data: clicks } = await query.limit(1);
 
   if (clicks && clicks.length > 0) {
     return {


### PR DESCRIPTION
Fixes #199.

## Summary
- require tracking-code attribution to match the same `visitor_id` when one is available
- keep the existing in-window click requirement for tracking-code lookups without a visitor id
- move fallback visitor filtering before `limit(1)` so the latest matching visitor click is selected
- add regression coverage for mismatched and matching visitor-id cookie attribution

## Validation
- `./node_modules/.bin/vitest run src/lib/affiliates/tracking.test.ts`
- `./node_modules/.bin/eslint src/lib/affiliates/tracking.ts src/lib/affiliates/tracking.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/prettier --check src/lib/affiliates/tracking.ts src/lib/affiliates/tracking.test.ts`
- `git diff --check -- src/lib/affiliates/tracking.ts src/lib/affiliates/tracking.test.ts`