### PR TITLE
Sync affiliate counts on application status changes

### DIFF
--- a/src/app/api/affiliates/offers/[id]/applications/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/applications/route.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PATCH } from "./route";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  }),
+}));
+
+type QueryResult = {
+  data: unknown;
+  error: { message: string } | null;
+};
+
+const updates: Array<{ table: string; payload: Record<string, unknown> }> = [];
+const inserts: Array<{ table: string; payload: unknown }> = [];
+
+function makePatchRequest(id: string, body: Record<string, unknown>) {
+  return new NextRequest(`http://localhost/api/affiliates/offers/${id}/applications`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function query(table: string, result: QueryResult) {
+  const builder: Record<string, unknown> = {};
+  builder.select = vi.fn(() => builder);
+  builder.eq = vi.fn(() => builder);
+  builder.order = vi.fn(() => builder);
+  builder.update = vi.fn((payload: Record<string, unknown>) => {
+    updates.push({ table, payload });
+    return builder;
+  });
+  builder.insert = vi.fn((payload: unknown) => {
+    inserts.push({ table, payload });
+    return builder;
+  });
+  builder.single = vi.fn(async () => result);
+  builder.then = (
+    resolve: (value: QueryResult) => unknown,
+    reject?: (reason: unknown) => unknown
+  ) => Promise.resolve(result).then(resolve, reject);
+  return builder;
+}
+
+function mockPatchQueries(options: {
+  totalAffiliates: number;
+  previousStatus: string;
+  nextStatus: string;
+}) {
+  let offerCalls = 0;
+  let applicationCalls = 0;
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "affiliate_offers") {
+      if (offerCalls++ === 0) {
+        return query(table, {
+          data: {
+            id: "offer-1",
+            seller_id: "user-seller",
+            total_affiliates: options.totalAffiliates,
+          },
+          error: null,
+        });
+      }
+      return query(table, { data: null, error: null });
+    }
+
+    if (table === "affiliate_applications") {
+      if (applicationCalls++ === 0) {
+        return query(table, {
+          data: {
+            id: "app-1",
+            status: options.previousStatus,
+          },
+          error: null,
+        });
+      }
+      return query(table, {
+        data: {
+          id: "app-1",
+          affiliate_id: "affiliate-1",
+          status: options.nextStatus,
+        },
+        error: null,
+      });
+    }
+
+    if (table === "notifications") {
+      return query(table, { data: null, error: null });
+    }
+
+    return query(table, { data: null, error: null });
+  });
+}
+
+describe("PATCH /api/affiliates/offers/[id]/applications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updates.length = 0;
+    inserts.length = 0;
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+  });
+
+  it("increments total_affiliates when approving a non-approved application", async () => {
+    mockPatchQueries({
+      totalAffiliates: 2,
+      previousStatus: "pending",
+      nextStatus: "approved",
+    });
+
+    const res = await PATCH(
+      makePatchRequest("offer-1", {
+        application_id: "app-1",
+        action: "approve",
+      }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(200);
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: "affiliate_offers",
+          payload: expect.objectContaining({ total_affiliates: 3 }),
+        }),
+      ])
+    );
+  });
+
+  it("decrements total_affiliates when rejecting an approved application", async () => {
+    mockPatchQueries({
+      totalAffiliates: 2,
+      previousStatus: "approved",
+      nextStatus: "rejected",
+    });
+
+    const res = await PATCH(
+      makePatchRequest("offer-1", {
+        application_id: "app-1",
+        action: "reject",
+      }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(200);
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: "affiliate_offers",
+          payload: expect.objectContaining({ total_affiliates: 1 }),
+        }),
+      ])
+    );
+  });
+
+  it("does not decrement total_affiliates below zero", async () => {
+    mockPatchQueries({
+      totalAffiliates: 0,
+      previousStatus: "approved",
+      nextStatus: "rejected",
+    });
+
+    const res = await PATCH(
+      makePatchRequest("offer-1", {
+        application_id: "app-1",
+        action: "reject",
+      }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(200);
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: "affiliate_offers",
+          payload: expect.objectContaining({ total_affiliates: 0 }),
+        }),
+      ])
+    );
+  });
+
+  it("leaves total_affiliates unchanged when the status is unchanged", async () => {
+    mockPatchQueries({
+      totalAffiliates: 2,
+      previousStatus: "approved",
+      nextStatus: "approved",
+    });
+
+    const res = await PATCH(
+      makePatchRequest("offer-1", {
+        application_id: "app-1",
+        action: "approve",
+      }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(200);
+    expect(updates.some((update) => update.table === "affiliate_offers")).toBe(false);
+  });
+});

--- a/src/app/api/affiliates/offers/[id]/applications/route.ts
+++ b/src/app/api/affiliates/offers/[id]/applications/route.ts
@@ -2,17 +2,39 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 
+async function updateAffiliateCountForStatusChange(
+  admin: AnySupabase,
+  offerId: string,
+  currentCount: number | null | undefined,
+  previousStatus: string | null,
+  nextStatus: string
+) {
+  if (previousStatus === nextStatus) return;
+
+  const delta = nextStatus === "approved" ? 1 : previousStatus === "approved" ? -1 : 0;
+  if (delta === 0) return;
+
+  const totalAffiliates = Math.max(0, (currentCount || 0) + delta);
+
+  const { error } = await admin
+    .from("affiliate_offers")
+    .update({
+      total_affiliates: totalAffiliates,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", offerId);
+
+  if (error) {
+    console.warn("Failed to update affiliate count", error);
+  }
+}
 
 /**
  * GET /api/affiliates/offers/[id]/applications - List affiliates for an offer (seller only)
  */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const auth = await getAuthContext(request);
@@ -25,7 +47,7 @@ export async function GET(
     // Verify seller ownership
     const { data: offer } = await (admin as AnySupabase)
       .from("affiliate_offers")
-      .select("id, seller_id")
+      .select("id, seller_id, total_affiliates")
       .eq("id", id)
       .single();
 
@@ -35,10 +57,12 @@ export async function GET(
 
     const { data: applications, error } = await (admin as AnySupabase)
       .from("affiliate_applications")
-      .select(`
+      .select(
+        `
         *,
         profiles!affiliate_applications_affiliate_id_fkey(username, avatar_url)
-      `)
+      `
+      )
       .eq("offer_id", id)
       .order("created_at", { ascending: false });
 
@@ -55,10 +79,7 @@ export async function GET(
 /**
  * PATCH /api/affiliates/offers/[id]/applications - Approve/reject an application
  */
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const auth = await getAuthContext(request);
@@ -70,7 +91,10 @@ export async function PATCH(
     const { application_id, action } = body;
 
     if (!application_id || !["approve", "reject"].includes(action)) {
-      return NextResponse.json({ error: "application_id and action (approve|reject) required" }, { status: 400 });
+      return NextResponse.json(
+        { error: "application_id and action (approve|reject) required" },
+        { status: 400 }
+      );
     }
 
     const admin = createServiceClient();
@@ -84,6 +108,19 @@ export async function PATCH(
 
     if (!offer || offer.seller_id !== auth.user.id) {
       return NextResponse.json({ error: "Not found or not authorized" }, { status: 404 });
+    }
+
+    const { data: existingApplication, error: existingApplicationError } = await (
+      admin as AnySupabase
+    )
+      .from("affiliate_applications")
+      .select("id, status")
+      .eq("id", application_id)
+      .eq("offer_id", id)
+      .single();
+
+    if (existingApplicationError || !existingApplication) {
+      return NextResponse.json({ error: "Application not found" }, { status: 404 });
     }
 
     const status = action === "approve" ? "approved" : "rejected";
@@ -107,19 +144,29 @@ export async function PATCH(
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
+    await updateAffiliateCountForStatusChange(
+      admin,
+      id,
+      offer.total_affiliates,
+      typeof existingApplication.status === "string" ? existingApplication.status : null,
+      status
+    );
+
     // Notify affiliate
     const notificationType = status === "approved" ? "affiliate_approved" : "affiliate_rejected";
-    await (admin as AnySupabase)
-      .from("notifications")
-      .insert({
-        user_id: application.affiliate_id,
-        type: notificationType,
-        title: status === "approved" ? "Affiliate application approved! 🎉" : "Affiliate application declined",
-        body: status === "approved"
+    await (admin as AnySupabase).from("notifications").insert({
+      user_id: application.affiliate_id,
+      type: notificationType,
+      title:
+        status === "approved"
+          ? "Affiliate application approved! 🎉"
+          : "Affiliate application declined",
+      body:
+        status === "approved"
           ? `You've been approved to promote this offer. Your tracking link is ready!`
           : "Your affiliate application was not approved.",
-        data: { offer_id: id, application_id },
-      });
+      data: { offer_id: id, application_id },
+    });
 
     return NextResponse.json({ application });
   } catch {


### PR DESCRIPTION
Fixes #201.

## Summary

- track the previous affiliate application status before approve/reject updates
- increment `total_affiliates` when an application becomes approved
- decrement `total_affiliates` when an approved application is rejected, clamped at zero
- add focused PATCH route tests for increment, decrement, clamping, and no-op same-status transitions

## Validation

- `./node_modules/.bin/vitest run src/app/api/affiliates/offers/[id]/applications/route.test.ts`
- `./node_modules/.bin/eslint src/app/api/affiliates/offers/[id]/applications/route.ts src/app/api/affiliates/offers/[id]/applications/route.test.ts`
- `./node_modules/.bin/prettier --check src/app/api/affiliates/offers/[id]/applications/route.ts src/app/api/affiliates/offers/[id]/applications/route.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- src/app/api/affiliates/offers/[id]/applications/route.ts src/app/api/affiliates/offers/[id]/applications/route.test.ts`
