### PR TITLE
Block paid affiliate conversion edits

### DIFF
--- a/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { GET, POST } from "./route";
+import { GET, POST, PUT } from "./route";
 import { NextRequest } from "next/server";
 
 // Mock auth
@@ -23,20 +23,23 @@ vi.mock("@/lib/affiliates/commission", () => ({
 }));
 
 function makeGetRequest(id: string) {
-  return new NextRequest(
-    `http://localhost/api/affiliates/offers/${id}/conversions`
-  );
+  return new NextRequest(`http://localhost/api/affiliates/offers/${id}/conversions`);
 }
 
 function makePostRequest(id: string, body: Record<string, unknown>) {
-  return new NextRequest(
-    `http://localhost/api/affiliates/offers/${id}/conversions`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    }
-  );
+  return new NextRequest(`http://localhost/api/affiliates/offers/${id}/conversions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePutRequest(id: string, body: Record<string, unknown>) {
+  return new NextRequest(`http://localhost/api/affiliates/offers/${id}/conversions`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 }
 
 function makeParams(id: string) {
@@ -245,14 +248,11 @@ describe("POST /api/affiliates/offers/[id]/conversions", () => {
     expect(body.conversion.note).toBe("Gumroad purchase #123");
 
     // Verify recordConversion was called with correct params
-    expect(mockRecordConversion).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        offerId: "offer-1",
-        affiliateId: "aff-1",
-        saleAmountSats: 10000,
-      }
-    );
+    expect(mockRecordConversion).toHaveBeenCalledWith(expect.anything(), {
+      offerId: "offer-1",
+      affiliateId: "aff-1",
+      saleAmountSats: 10000,
+    });
   });
 
   it("rejects if affiliate is not approved", async () => {
@@ -320,5 +320,43 @@ describe("POST /api/affiliates/offers/[id]/conversions", () => {
     expect(res2.status).toBe(400);
     const body2 = await res2.json();
     expect(body2.error).toBe("sale_amount_sats must be a positive number");
+  });
+});
+
+describe("PUT /api/affiliates/offers/[id]/conversions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects marking a conversion paid without the payout endpoint", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+          commission_rate: 0.1,
+          commission_type: "percentage",
+          commission_flat_sats: 0,
+        });
+      }
+      return chainable([]);
+    });
+
+    const res = await PUT(
+      makePutRequest("offer-1", {
+        conversion_id: "conv-1",
+        status: "paid",
+      }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Use the payout endpoint to mark conversions paid");
+    expect(mockFrom).not.toHaveBeenCalledWith("affiliate_conversions");
   });
 });

--- a/src/app/api/affiliates/offers/[id]/conversions/route.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.ts
@@ -3,16 +3,12 @@ import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { recordConversion } from "@/lib/affiliates/commission";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 
 /**
  * GET /api/affiliates/offers/[id]/conversions - List conversions for an offer (seller only)
  */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const auth = await getAuthContext(request);
@@ -41,7 +37,8 @@ export async function GET(
     let conversions: any[] = [];
     const { data: convData, error: convErr } = await (admin as AnySupabase)
       .from("affiliate_conversions")
-      .select(`
+      .select(
+        `
         id,
         affiliate_id,
         sale_amount_sats,
@@ -51,7 +48,8 @@ export async function GET(
         note,
         created_at,
         profiles!affiliate_conversions_affiliate_id_fkey(username)
-      `)
+      `
+      )
       .eq("offer_id", id)
       .order("created_at", { ascending: false });
 
@@ -59,7 +57,9 @@ export async function GET(
       // FK join might not exist — retry without join
       const { data: fallbackData } = await (admin as AnySupabase)
         .from("affiliate_conversions")
-        .select("id, affiliate_id, sale_amount_sats, commission_sats, status, source, note, created_at")
+        .select(
+          "id, affiliate_id, sale_amount_sats, commission_sats, status, source, note, created_at"
+        )
         .eq("offer_id", id)
         .order("created_at", { ascending: false });
       conversions = fallbackData || [];
@@ -93,20 +93,14 @@ export async function GET(
 
     return NextResponse.json({ conversions: list });
   } catch {
-    return NextResponse.json(
-      { error: "An unexpected error occurred" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }
 }
 
 /**
  * POST /api/affiliates/offers/[id]/conversions - Record a manual conversion (seller only)
  */
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const auth = await getAuthContext(request);
@@ -135,10 +129,7 @@ export async function POST(
     const { affiliate_id, sale_amount_sats, note } = body;
 
     if (!affiliate_id || typeof affiliate_id !== "string") {
-      return NextResponse.json(
-        { error: "affiliate_id is required" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "affiliate_id is required" }, { status: 400 });
     }
 
     if (!sale_amount_sats || typeof sale_amount_sats !== "number" || sale_amount_sats <= 0) {
@@ -196,10 +187,7 @@ export async function POST(
       },
     });
   } catch {
-    return NextResponse.json(
-      { error: "An unexpected error occurred" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }
 }
 
@@ -207,10 +195,7 @@ export async function POST(
  * PUT /api/affiliates/offers/[id]/conversions - Update a conversion (seller only)
  * Body: { conversion_id, sale_amount_sats?, note?, status? }
  */
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const auth = await getAuthContext(request);
@@ -239,7 +224,13 @@ export async function PUT(
 
     const updateData: Record<string, unknown> = {};
     if (typeof note === "string") updateData.note = note.trim();
-    if (typeof status === "string" && ["pending", "paid", "clawed_back"].includes(status)) {
+    if (status === "paid") {
+      return NextResponse.json(
+        { error: "Use the payout endpoint to mark conversions paid" },
+        { status: 400 }
+      );
+    }
+    if (typeof status === "string" && ["pending", "clawed_back"].includes(status)) {
       updateData.status = status;
     }
     if (typeof sale_amount_sats === "number" && sale_amount_sats > 0) {


### PR DESCRIPTION
Fixes #205.

## Summary
- reject `status: "paid"` in the generic affiliate conversion edit endpoint
- preserve normal pending/clawback status edits plus note and amount edits
- add regression coverage proving the edit path does not touch conversions when a caller tries to mark one paid

## uGig task
Submitted for the active uGig repo testing task: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

No payout details included; those can be provided after acceptance.

## Verification
- `./node_modules/.bin/vitest run 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'`
- `./node_modules/.bin/eslint 'src/app/api/affiliates/offers/[id]/conversions/route.ts' 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'`
- `./node_modules/.bin/prettier --check 'src/app/api/affiliates/offers/[id]/conversions/route.ts' 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- 'src/app/api/affiliates/offers/[id]/conversions/route.ts' 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'`
