### PR TITLE
Validate affiliate conversion note type

### DIFF
--- a/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.test.ts
@@ -321,4 +321,35 @@ describe("POST /api/affiliates/offers/[id]/conversions", () => {
     const body2 = await res2.json();
     expect(body2.error).toBe("sale_amount_sats must be a positive number");
   });
+
+  it("rejects non-string notes before recording a conversion", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-seller", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "user-seller",
+        });
+      }
+      return chainable([]);
+    });
+
+    const res = await POST(
+      makePostRequest("offer-1", {
+        affiliate_id: "aff-1",
+        sale_amount_sats: 5000,
+        note: { text: "paid elsewhere" },
+      }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("note must be a string");
+    expect(mockFrom).not.toHaveBeenCalledWith("affiliate_applications");
+    expect(mockRecordConversion).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/affiliates/offers/[id]/conversions/route.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/route.ts
@@ -3,7 +3,6 @@ import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { recordConversion } from "@/lib/affiliates/commission";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 
 /**
@@ -148,6 +147,10 @@ export async function POST(
       );
     }
 
+    if (note !== undefined && note !== null && typeof note !== "string") {
+      return NextResponse.json({ error: "note must be a string" }, { status: 400 });
+    }
+
     // Verify the affiliate is approved for this offer
     const { data: application } = await (admin as AnySupabase)
       .from("affiliate_applications")
@@ -192,7 +195,7 @@ export async function POST(
         commission_sats: result.commission_sats,
         settles_at: result.settles_at,
         source: "manual",
-        note: note?.trim() || null,
+        note: typeof note === "string" ? note.trim() || null : null,
       },
     });
   } catch {


### PR DESCRIPTION
Fixes #208.

## Summary
- reject non-string manual conversion notes before affiliate lookup or conversion recording side effects
- keep valid string notes trimmed in the response and treat omitted notes as null
- add regression coverage proving object notes return 400 and do not call `recordConversion`

## uGig task
Submitted for the active uGig repo testing task: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

No payout details included; those can be provided after acceptance.

## Verification
- `./node_modules/.bin/vitest run 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'`
- `./node_modules/.bin/eslint 'src/app/api/affiliates/offers/[id]/conversions/route.ts' 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- 'src/app/api/affiliates/offers/[id]/conversions/route.ts' 'src/app/api/affiliates/offers/[id]/conversions/route.test.ts'`
