### PR TITLE
Handle affiliate click tracking failures

### DIFF
--- a/src/app/api/affiliates/click/route.test.ts
+++ b/src/app/api/affiliates/click/route.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "./route";
+import { NextRequest } from "next/server";
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  }),
+}));
+
+const mockRecordClick = vi.fn();
+vi.mock("@/lib/affiliates/tracking", () => ({
+  recordClick: (...args: unknown[]) => mockRecordClick(...args),
+}));
+
+function makeRequest(ref = "alice-abc123") {
+  return new NextRequest(`https://ugig.net/api/affiliates/click?ugig_ref=${ref}`, {
+    headers: {
+      cookie: "ugig_visitor=visitor-1",
+    },
+  });
+}
+
+function chainable(data: unknown, error: unknown = null) {
+  const result = { data, error };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop) {
+      if (prop === "then") return undefined;
+      if (prop === "data") return data;
+      if (prop === "error") return error;
+      return () => new Proxy(result, handler);
+    },
+  };
+  return new Proxy(result, handler);
+}
+
+describe("GET /api/affiliates/click", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("still redirects to the offer when click tracking fails", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_applications") {
+        return chainable({
+          offer_id: "offer-1",
+          affiliate_offers: {
+            product_url: "https://example.com/product",
+            slug: "test-offer",
+            listing_id: null,
+            cookie_days: 30,
+            skill_listings: null,
+          },
+        });
+      }
+      return chainable(null);
+    });
+    mockRecordClick.mockRejectedValue(new Error("click insert failed"));
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const res = await GET(makeRequest());
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toBe("https://example.com/product");
+      expect(mockRecordClick).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          trackingCode: "alice-abc123",
+          visitorId: "visitor-1",
+        })
+      );
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "Failed to record affiliate click",
+        expect.any(Error)
+      );
+    } finally {
+      consoleWarn.mockRestore();
+    }
+  });
+});

--- a/src/app/api/affiliates/click/route.ts
+++ b/src/app/api/affiliates/click/route.ts
@@ -45,14 +45,18 @@ export async function GET(request: NextRequest) {
       request.headers.get("x-real-ip") ||
       "unknown";
 
-    await recordClick(admin, {
-      trackingCode: ref,
-      visitorId,
-      ip,
-      userAgent: request.headers.get("user-agent") || undefined,
-      referer: request.headers.get("referer") || undefined,
-      landedUrl: request.url,
-    });
+    try {
+      await recordClick(admin, {
+        trackingCode: ref,
+        visitorId,
+        ip,
+        userAgent: request.headers.get("user-agent") || undefined,
+        referer: request.headers.get("referer") || undefined,
+        landedUrl: request.url,
+      });
+    } catch (error) {
+      console.warn("Failed to record affiliate click", error);
+    }
 
     // Determine redirect URL
     const offer = app.affiliate_offers;


### PR DESCRIPTION
## Summary

- makes affiliate click recording best-effort so tracking storage failures do not break redirects
- keeps logging a warning when `recordClick` fails for observability
- adds regression coverage for the tracking failure redirect path

## Root cause

`GET /api/affiliates/click` awaited `recordClick` inside the route-level `try`. Any tracking insert failure bubbled to the outer catch and redirected a valid affiliate link to `/affiliates` instead of the offer destination.

## Validation

- `./node_modules/.bin/vitest run 'src/app/api/affiliates/click/route.test.ts'`
- `./node_modules/.bin/eslint 'src/app/api/affiliates/click/route.ts' 'src/app/api/affiliates/click/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- 'src/app/api/affiliates/click/route.ts' 'src/app/api/affiliates/click/route.test.ts'`

Fixes #210

Related paid testing gig: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae
