### PR TITLE
Guard manual affiliate payouts by settlement date

### DIFF
--- a/src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+import { NextRequest } from "next/server";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  }),
+}));
+
+const mockGetUserLnWallet = vi.fn();
+const mockInternalTransfer = vi.fn();
+vi.mock("@/lib/lightning/wallet-utils", () => ({
+  getUserLnWallet: (...args: unknown[]) => mockGetUserLnWallet(...args),
+  internalTransfer: (...args: unknown[]) => mockInternalTransfer(...args),
+}));
+
+function makePostRequest(id: string, body: Record<string, unknown>) {
+  return new NextRequest(
+    `http://localhost/api/affiliates/offers/${id}/conversions/pay`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function chainable(data: unknown, error: unknown = null) {
+  const obj: Record<string, unknown> = { data, error };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop) {
+      if (prop === "then") return undefined;
+      if (prop === "data") return data;
+      if (prop === "error") return error;
+      return () => new Proxy(obj, handler);
+    },
+  };
+  return new Proxy(obj, handler);
+}
+
+describe("POST /api/affiliates/offers/[id]/conversions/pay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects pending conversions before their settlement date", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "seller-1", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "seller-1",
+        });
+      }
+      if (table === "affiliate_conversions") {
+        return chainable({
+          id: "conv-1",
+          affiliate_id: "affiliate-1",
+          commission_sats: 500,
+          status: "pending",
+          settles_at: "2999-01-01T00:00:00.000Z",
+        });
+      }
+      return chainable(null);
+    });
+
+    const res = await POST(
+      makePostRequest("offer-1", { conversion_id: "conv-1" }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Conversion has not settled yet",
+    });
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
+    expect(mockInternalTransfer).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/affiliates/offers/[id]/conversions/pay/route.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/pay/route.ts
@@ -3,7 +3,6 @@ import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { getUserLnWallet, internalTransfer } from "@/lib/lightning/wallet-utils";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 
 /**
@@ -45,7 +44,7 @@ export async function POST(
     // Get the conversion
     const { data: conv } = await (admin as AnySupabase)
       .from("affiliate_conversions")
-      .select("id, affiliate_id, commission_sats, status")
+      .select("id, affiliate_id, commission_sats, status, settles_at")
       .eq("id", conversion_id)
       .eq("offer_id", id)
       .single();
@@ -60,6 +59,10 @@ export async function POST(
 
     if (conv.status === "clawed_back") {
       return NextResponse.json({ error: "Cannot pay a clawed back conversion" }, { status: 400 });
+    }
+
+    if (conv.settles_at && new Date(conv.settles_at) > new Date()) {
+      return NextResponse.json({ error: "Conversion has not settled yet" }, { status: 400 });
     }
 
     if (conv.commission_sats <= 0) {


### PR DESCRIPTION
## Summary

- rejects manual affiliate payout requests when the conversion has not reached `settles_at`
- performs the settlement-date guard before wallet lookups or Lightning transfer calls
- adds route coverage for the unsettled pending-conversion path

## Root cause

The auto-payout cron filters pending conversions with `.lte("settles_at", now)`, but `POST /api/affiliates/offers/[id]/conversions/pay` did not load or check `settles_at`. A seller could manually pay a pending commission before the configured settlement delay elapsed.

## Validation

- `./node_modules/.bin/vitest run 'src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts'`
- `./node_modules/.bin/eslint 'src/app/api/affiliates/offers/[id]/conversions/pay/route.ts' 'src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- 'src/app/api/affiliates/offers/[id]/conversions/pay/route.ts' 'src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts'`

Fixes #212

Related paid testing gig: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae
