### PR TITLE
Recover referral invite form after send failures

### DIFF
--- a/src/app/dashboard/referrals/page.test.tsx
+++ b/src/app/dashboard/referrals/page.test.tsx
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ReferralsPage from "./page";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalExecCommand = document.execCommand;
 
 function mockInitialLoads() {
   mockFetch
@@ -22,10 +24,30 @@ function mockInitialLoads() {
     });
 }
 
+function mockClipboard(writeText?: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  });
+}
+
+function mockExecCommand(copyResult: boolean) {
+  document.execCommand = vi.fn(() => copyResult);
+}
+
 describe("ReferralsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInitialLoads();
+    mockClipboard(vi.fn().mockResolvedValue(undefined));
+    mockExecCommand(true);
+  });
+
+  afterEach(() => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+    }
+    document.execCommand = originalExecCommand;
   });
 
   it("recovers when sending referral invites fails at the network layer", async () => {
@@ -69,5 +91,41 @@ describe("ReferralsPage", () => {
     });
 
     expect(screen.getByRole("button", { name: /send invites/i })).toBeEnabled();
+  });
+
+  it("falls back to a textarea copy when Clipboard API writes are blocked", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    mockClipboard(writeText);
+    mockExecCommand(true);
+
+    render(<ReferralsPage />);
+
+    await screen.findByDisplayValue("https://ugig.net/invite/alice");
+    await user.click(screen.getByRole("button", { name: /copy/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument();
+    });
+
+    expect(writeText).toHaveBeenCalledWith("https://ugig.net/invite/alice");
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(screen.queryByText(/copy failed/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a manual-copy error when all copy paths fail", async () => {
+    const user = userEvent.setup();
+    mockClipboard(undefined);
+    mockExecCommand(false);
+
+    render(<ReferralsPage />);
+
+    await screen.findByDisplayValue("https://ugig.net/invite/alice");
+    await user.click(screen.getByRole("button", { name: /copy/i }));
+
+    expect(
+      await screen.findByText("Copy failed. Select the link and copy it manually.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
   });
 });

--- a/src/app/dashboard/referrals/page.test.tsx
+++ b/src/app/dashboard/referrals/page.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ReferralsPage from "./page";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function mockInitialLoads() {
+  mockFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ link: "https://ugig.net/invite/alice", code: "alice" }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [],
+          stats: { total_invited: 0, total_registered: 0, conversion_rate: 0 },
+        }),
+    });
+}
+
+describe("ReferralsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitialLoads();
+  });
+
+  it("recovers when sending referral invites fails at the network layer", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockRejectedValueOnce(new Error("network unavailable"));
+
+    render(<ReferralsPage />);
+
+    await user.type(
+      screen.getByPlaceholderText("Enter email addresses separated by commas or new lines"),
+      "friend@example.com"
+    );
+    await user.click(screen.getByRole("button", { name: /send invites/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to send invites")).toBeInTheDocument();
+    });
+
+    const button = screen.getByRole("button", { name: /send invites/i });
+    expect(button).toBeEnabled();
+    expect(screen.queryByRole("button", { name: /sending/i })).not.toBeInTheDocument();
+  });
+
+  it("recovers when the invite API returns a non-JSON error response", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.reject(new Error("not json")),
+    });
+
+    render(<ReferralsPage />);
+
+    await user.type(
+      screen.getByPlaceholderText("Enter email addresses separated by commas or new lines"),
+      "friend@example.com"
+    );
+    await user.click(screen.getByRole("button", { name: /send invites/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to send invites")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: /send invites/i })).toBeEnabled();
+  });
+});

--- a/src/app/dashboard/referrals/page.tsx
+++ b/src/app/dashboard/referrals/page.tsx
@@ -29,6 +29,38 @@ async function loadCode() {
   return null;
 }
 
+function copyWithTextarea(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the DOM fallback for blocked clipboard writes.
+  }
+
+  return copyWithTextarea(text);
+}
+
 export default function ReferralsPage() {
   const [referralLink, setReferralLink] = useState("");
   const [referralCode, setReferralCode] = useState("");
@@ -40,6 +72,7 @@ export default function ReferralsPage() {
   });
   const [emails, setEmails] = useState("");
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -63,7 +96,15 @@ export default function ReferralsPage() {
   }, []);
 
   const copyLink = async () => {
-    await navigator.clipboard.writeText(referralLink);
+    setCopyError(null);
+
+    const copiedLink = await copyText(referralLink);
+    if (!copiedLink) {
+      setCopied(false);
+      setCopyError("Copy failed. Select the link and copy it manually.");
+      return;
+    }
+
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -179,6 +220,7 @@ export default function ReferralsPage() {
             {copied ? "Copied!" : "Copy"}
           </button>
         </div>
+        {copyError && <p className="text-sm text-destructive">{copyError}</p>}
         <p className="text-xs text-muted-foreground">
           Your referral code: <span className="font-mono font-medium">{referralCode}</span>
         </p>

--- a/src/app/dashboard/referrals/page.tsx
+++ b/src/app/dashboard/referrals/page.tsx
@@ -84,18 +84,21 @@ export default function ReferralsPage() {
       return;
     }
 
-    const res = await fetch("/api/referrals", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ emails: emailList }),
-    });
+    try {
+      const res = await fetch("/api/referrals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emails: emailList }),
+      });
 
-    const data = await res.json();
+      const data = await res.json().catch(() => null);
 
-    if (!res.ok) {
-      setError(data.error);
-    } else {
-      setSuccess(data.message);
+      if (!res.ok) {
+        setError(data?.error || "Failed to send invites");
+        return;
+      }
+
+      setSuccess(data?.message || "Invites sent");
       setEmails("");
       loadReferrals().then((d) => {
         if (d) {
@@ -103,8 +106,11 @@ export default function ReferralsPage() {
           setStats(d.stats);
         }
       });
+    } catch {
+      setError("Failed to send invites");
+    } finally {
+      setSending(false);
     }
-    setSending(false);
   };
 
   const statusBadge = (status: string) => {
@@ -125,7 +131,8 @@ export default function ReferralsPage() {
       <div>
         <h1 className="text-2xl font-bold">Invite Friends</h1>
         <p className="text-muted-foreground mt-1">
-          Share your referral link and earn ⚡ 25 sats for each friend who signs up. They get 25 sats too!
+          Share your referral link and earn ⚡ 25 sats for each friend who signs up. They get 25
+          sats too!
         </p>
       </div>
 
@@ -187,12 +194,8 @@ export default function ReferralsPage() {
           rows={3}
           className="w-full bg-muted/50 border border-border rounded-md px-3 py-2 text-sm resize-none"
         />
-        {error && (
-          <p className="text-sm text-destructive">{error}</p>
-        )}
-        {success && (
-          <p className="text-sm text-green-600 dark:text-green-400">{success}</p>
-        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {success && <p className="text-sm text-green-600 dark:text-green-400">{success}</p>}
         <button
           onClick={sendInvites}
           disabled={sending}
@@ -232,9 +235,7 @@ export default function ReferralsPage() {
                       {new Date(r.created_at).toLocaleDateString()}
                     </td>
                     <td className="px-4 py-3 text-muted-foreground">
-                      {r.registered_at
-                        ? new Date(r.registered_at).toLocaleDateString()
-                        : "—"}
+                      {r.registered_at ? new Date(r.registered_at).toLocaleDateString() : "—"}
                     </td>
                   </tr>
                 ))}
@@ -243,6 +244,6 @@ export default function ReferralsPage() {
           </div>
         )}
       </div>
-        </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- recover the referral invite form after network failures or non-JSON error responses
- add Clipboard API fallback copying for the referral link button
- show a manual-copy error when both clipboard paths fail
- add component regression coverage for send failures and copy fallback/failure paths

Fixes #131
Fixes #129

## Validation
- ./node_modules/.bin/vitest run src/app/dashboard/referrals/page.test.tsx
- ./node_modules/.bin/eslint src/app/dashboard/referrals/page.tsx src/app/dashboard/referrals/page.test.tsx
- ./node_modules/.bin/prettier --check src/app/dashboard/referrals/page.tsx src/app/dashboard/referrals/page.test.tsx
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- src/app/dashboard/referrals/page.tsx src/app/dashboard/referrals/page.test.tsx

uGig gig: https://ugig.net/gig/cmexbmp260001ju04n3qmkdko