### PR TITLE
Handle unavailable referral storage

### DIFF
--- a/src/components/referral/ReferralTracker.test.tsx
+++ b/src/components/referral/ReferralTracker.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SignupForm } from "@/components/auth/SignupForm";
+import { clearStoredReferral, getStoredReferral, storeReferral } from "./ReferralTracker";
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+
+function restoreLocalStorage() {
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(window, "localStorage", originalLocalStorageDescriptor);
+  }
+}
+
+function replaceLocalStorage(storage: Storage) {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}
+
+function blockLocalStorageAccess() {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    get() {
+      throw new Error("Storage blocked");
+    },
+  });
+}
+
+describe("referral storage helpers", () => {
+  beforeEach(() => {
+    restoreLocalStorage();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("stores, reads, and clears referral codes when storage is available", () => {
+    storeReferral("alice123");
+
+    expect(getStoredReferral()).toBe("alice123");
+
+    clearStoredReferral();
+
+    expect(getStoredReferral()).toBeNull();
+  });
+
+  it("treats unavailable localStorage as non-fatal", () => {
+    blockLocalStorageAccess();
+
+    expect(() => storeReferral("alice123")).not.toThrow();
+    expect(getStoredReferral()).toBeNull();
+    expect(() => clearStoredReferral()).not.toThrow();
+  });
+
+  it("treats localStorage method failures as non-fatal", () => {
+    const storage = {
+      length: 0,
+      clear: vi.fn(),
+      getItem: vi.fn(() => {
+        throw new Error("read denied");
+      }),
+      key: vi.fn(),
+      removeItem: vi.fn(() => {
+        throw new Error("remove denied");
+      }),
+      setItem: vi.fn(() => {
+        throw new Error("write denied");
+      }),
+    } as unknown as Storage;
+    replaceLocalStorage(storage);
+
+    expect(() => storeReferral("alice123")).not.toThrow();
+    expect(getStoredReferral()).toBeNull();
+    expect(() => clearStoredReferral()).not.toThrow();
+  });
+});
+
+describe("SignupForm referrals", () => {
+  beforeEach(() => {
+    restoreLocalStorage();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    window.localStorage.clear();
+  });
+
+  it("uses the server-provided referral code when localStorage is unavailable", () => {
+    blockLocalStorageAccess();
+
+    render(<SignupForm referralCode="alice123" />);
+
+    expect(screen.getByText("Referred by")).toBeInTheDocument();
+    expect(screen.getByText("alice123")).toBeInTheDocument();
+  });
+});

--- a/src/components/referral/ReferralTracker.tsx
+++ b/src/components/referral/ReferralTracker.tsx
@@ -5,6 +5,27 @@ import { useSearchParams } from "next/navigation";
 
 const REFERRAL_KEY = "ugig_referral_code";
 
+function getReferralStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function storeReferral(ref: string): void {
+  const storage = getReferralStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(REFERRAL_KEY, ref);
+  } catch {
+    // Referral storage is best-effort; signup can still use the server ref param.
+  }
+}
+
 /**
  * Captures ?ref= param from any page URL and stores it in localStorage.
  * Drop this component into the root layout so referrals persist across navigation.
@@ -15,7 +36,7 @@ export function ReferralTracker() {
   useEffect(() => {
     const ref = searchParams.get("ref");
     if (ref) {
-      localStorage.setItem(REFERRAL_KEY, ref);
+      storeReferral(ref);
     }
   }, [searchParams]);
 
@@ -24,12 +45,24 @@ export function ReferralTracker() {
 
 /** Read the stored referral code (call from signup form, etc.) */
 export function getStoredReferral(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(REFERRAL_KEY);
+  const storage = getReferralStorage();
+  if (!storage) return null;
+
+  try {
+    return storage.getItem(REFERRAL_KEY);
+  } catch {
+    return null;
+  }
 }
 
 /** Clear stored referral after successful signup */
 export function clearStoredReferral(): void {
-  if (typeof window === "undefined") return;
-  localStorage.removeItem(REFERRAL_KEY);
+  const storage = getReferralStorage();
+  if (!storage) return;
+
+  try {
+    storage.removeItem(REFERRAL_KEY);
+  } catch {
+    // Clearing should never block account creation success.
+  }
 }


### PR DESCRIPTION
## Summary
- guard referral localStorage access behind best-effort helpers
- keep referral capture, reads, and clears non-fatal when storage is unavailable or rejects calls
- add jsdom regression coverage for normal storage, blocked storage, method failures, and server-provided signup refs

Fixes #125

## Validation
- ./node_modules/.bin/vitest run src/components/referral/ReferralTracker.test.tsx
- ./node_modules/.bin/eslint src/components/referral/ReferralTracker.tsx src/components/referral/ReferralTracker.test.tsx
- ./node_modules/.bin/prettier --check src/components/referral/ReferralTracker.tsx src/components/referral/ReferralTracker.test.tsx
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- src/components/referral/ReferralTracker.tsx src/components/referral/ReferralTracker.test.tsx

uGig gig: https://ugig.net/gig/cmexbmp260001ju04n3qmkdko