### PR TITLE
Fallback affiliate tracking link copy

### DIFF
--- a/src/app/affiliates/[slug]/OfferDetailClient.test.tsx
+++ b/src/app/affiliates/[slug]/OfferDetailClient.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import OfferDetailClient from "./OfferDetailClient";
+
+const mockPush = vi.fn();
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ slug: "offer-slug" }),
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/ui/MarkdownContent", () => ({
+  MarkdownContent: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalExecCommand = document.execCommand;
+
+const offer = {
+  id: "offer-1",
+  slug: "offer-slug",
+  title: "AI Prompt Pack",
+  description: "Useful prompts",
+  product_type: "skill",
+  product_url: "https://example.com/product",
+  price_sats: 5000,
+  commission_rate: 0.2,
+  commission_type: "percentage",
+  commission_flat_sats: 0,
+  cookie_days: 30,
+  settlement_delay_days: 7,
+  promo_text: null,
+  total_affiliates: 2,
+  total_conversions: 3,
+  total_revenue_sats: 15000,
+  category: "ai",
+  tags: ["prompts"],
+  created_at: "2026-05-21T00:00:00Z",
+  seller_id: "seller-1",
+  profiles: { username: "seller", avatar_url: null },
+  skill_listings: null,
+};
+
+function mockClipboard(writeText?: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  });
+}
+
+function mockExecCommand(copyResult: boolean) {
+  document.execCommand = vi.fn(() => copyResult);
+}
+
+function mockApi() {
+  mockFetch.mockImplementation((input: RequestInfo | URL) => {
+    const url = input.toString();
+
+    if (url === "/api/rates/btc") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ rate: 100000 }),
+      });
+    }
+
+    if (url === "/api/auth/session") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ user: { id: "buyer-1" } }),
+      });
+    }
+
+    if (url.startsWith("/api/affiliates/offers?")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ offers: [{ id: "offer-1" }] }),
+      });
+    }
+
+    if (url === "/api/affiliates/offers/offer-1") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ offer }),
+      });
+    }
+
+    if (url === "/api/affiliates/offers/offer-1/apply") {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            tracking_url: "https://ugig.net/ref/track-123",
+          }),
+      });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+async function applyForOffer(user: ReturnType<typeof userEvent.setup>) {
+  render(<OfferDetailClient />);
+
+  await user.click(await screen.findByRole("button", { name: /become an affiliate/i }));
+  await screen.findByDisplayValue("https://ugig.net/ref/track-123");
+
+  return user;
+}
+
+describe("OfferDetailClient tracking link copy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi();
+    mockClipboard(vi.fn().mockResolvedValue(undefined));
+    mockExecCommand(true);
+  });
+
+  afterEach(() => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+    }
+    document.execCommand = originalExecCommand;
+  });
+
+  it("falls back to a textarea copy when Clipboard API writes are blocked", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    mockClipboard(writeText);
+    mockExecCommand(true);
+
+    await applyForOffer(user);
+
+    await user.click(screen.getByRole("button", { name: /copy/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument();
+    });
+
+    expect(writeText).toHaveBeenCalledWith("https://ugig.net/ref/track-123");
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(screen.queryByText(/copy failed/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a manual-copy error when all tracking-link copy paths fail", async () => {
+    const user = userEvent.setup();
+    mockClipboard(undefined);
+    mockExecCommand(false);
+
+    await applyForOffer(user);
+
+    await user.click(screen.getByRole("button", { name: /copy/i }));
+
+    expect(
+      await screen.findByText("Copy failed. Select the tracking link and copy it manually.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+  });
+});

--- a/src/app/affiliates/[slug]/OfferDetailClient.tsx
+++ b/src/app/affiliates/[slug]/OfferDetailClient.tsx
@@ -40,6 +40,38 @@ function formatSats(sats: number): string {
   return sats.toLocaleString();
 }
 
+function copyWithTextarea(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the DOM fallback when clipboard writes are blocked.
+  }
+
+  return copyWithTextarea(text);
+}
+
 export default function OfferDetailClient() {
   const { slug } = useParams<{ slug: string }>();
   const router = useRouter();
@@ -48,6 +80,8 @@ export default function OfferDetailClient() {
   const [applying, setApplying] = useState(false);
   const [applied, setApplied] = useState(false);
   const [trackingUrl, setTrackingUrl] = useState("");
+  const [copiedTrackingUrl, setCopiedTrackingUrl] = useState(false);
+  const [copyError, setCopyError] = useState("");
   const [error, setError] = useState("");
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [btcUsd, setBtcUsd] = useState<number | null>(null);
@@ -55,14 +89,18 @@ export default function OfferDetailClient() {
   useEffect(() => {
     fetch("/api/rates/btc")
       .then((r) => r.json())
-      .then((d) => { if (d.rate) setBtcUsd(d.rate); })
+      .then((d) => {
+        if (d.rate) setBtcUsd(d.rate);
+      })
       .catch(() => {});
   }, []);
 
   useEffect(() => {
     fetch("/api/auth/session")
       .then((r) => r.json())
-      .then((d) => { if (d.user?.id) setCurrentUserId(d.user.id); })
+      .then((d) => {
+        if (d.user?.id) setCurrentUserId(d.user.id);
+      })
       .catch(() => {});
   }, []);
 
@@ -80,7 +118,9 @@ export default function OfferDetailClient() {
         }
         if (!cancelled) setLoading(false);
       });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [slug]);
 
   async function handleApply() {
@@ -113,6 +153,20 @@ export default function OfferDetailClient() {
     setApplying(false);
   }
 
+  async function handleCopyTrackingUrl() {
+    setCopyError("");
+
+    const copied = await copyText(trackingUrl);
+    if (!copied) {
+      setCopiedTrackingUrl(false);
+      setCopyError("Copy failed. Select the tracking link and copy it manually.");
+      return;
+    }
+
+    setCopiedTrackingUrl(true);
+    setTimeout(() => setCopiedTrackingUrl(false), 2000);
+  }
+
   if (loading) {
     return (
       <main className="flex-1 container mx-auto px-4 py-8 max-w-5xl">
@@ -132,9 +186,10 @@ export default function OfferDetailClient() {
     );
   }
 
-  const commissionDisplay = offer.commission_type === "flat"
-    ? `${formatSats(offer.commission_flat_sats)} sats per sale`
-    : `${Math.round(offer.commission_rate * 100)}% per sale`;
+  const commissionDisplay =
+    offer.commission_type === "flat"
+      ? `${formatSats(offer.commission_flat_sats)} sats per sale`
+      : `${Math.round(offer.commission_rate * 100)}% per sale`;
 
   return (
     <main className="flex-1 container mx-auto px-4 py-8">
@@ -154,15 +209,14 @@ export default function OfferDetailClient() {
             <div>
               <div className="flex items-start gap-3 mb-2">
                 <h1 className="text-3xl font-bold">{offer.title}</h1>
-                <Badge
-                  variant="outline"
-                  className="capitalize shrink-0 mt-1"
-                >
+                <Badge variant="outline" className="capitalize shrink-0 mt-1">
                   {offer.product_type}
                 </Badge>
                 {currentUserId && currentUserId === offer.seller_id && (
                   <Link href={`/affiliates/${slug}/edit`}>
-                    <Button variant="outline" size="sm" className="shrink-0 mt-0.5">Edit</Button>
+                    <Button variant="outline" size="sm" className="shrink-0 mt-0.5">
+                      Edit
+                    </Button>
                   </Link>
                 )}
               </div>
@@ -177,7 +231,10 @@ export default function OfferDetailClient() {
                   >
                     <Avatar className="h-5 w-5">
                       {offer.profiles.avatar_url ? (
-                        <AvatarImage src={offer.profiles.avatar_url} alt={offer.profiles.username} />
+                        <AvatarImage
+                          src={offer.profiles.avatar_url}
+                          alt={offer.profiles.username}
+                        />
                       ) : null}
                       <AvatarFallback className="text-[10px]">
                         {offer.profiles.username[0]?.toUpperCase() || "?"}
@@ -195,10 +252,7 @@ export default function OfferDetailClient() {
                 <h2 className="text-sm font-medium text-muted-foreground mb-2">Tags</h2>
                 <div className="flex flex-wrap gap-2">
                   {offer.tags.map((tag) => (
-                    <Link
-                      key={tag}
-                      href={`/affiliates?tag=${encodeURIComponent(tag)}`}
-                    >
+                    <Link key={tag} href={`/affiliates?tag=${encodeURIComponent(tag)}`}>
                       <Badge
                         variant="secondary"
                         className="cursor-pointer hover:bg-secondary/80 transition-colors"
@@ -225,9 +279,7 @@ export default function OfferDetailClient() {
                 <span>{formatSats(offer.total_revenue_sats)} sats volume</span>
               )}
               {offer.cookie_days > 0 && (
-                <span className="flex items-center gap-1.5">
-                  🍪 {offer.cookie_days}-day cookie
-                </span>
+                <span className="flex items-center gap-1.5">🍪 {offer.cookie_days}-day cookie</span>
               )}
               <span className="flex items-center gap-1.5">
                 <Calendar className="h-4 w-4" />
@@ -285,24 +337,29 @@ export default function OfferDetailClient() {
                   if (offer.commission_type === "percentage" && offer.price_sats > 0) {
                     const usd = (offer.price_sats * offer.commission_rate).toFixed(2);
                     return (
-                      <p className="text-sm text-muted-foreground mt-1">
-                        ≈ ${usd} USD per sale
-                      </p>
+                      <p className="text-sm text-muted-foreground mt-1">≈ ${usd} USD per sale</p>
                     );
                   }
-                  if (offer.commission_type === "flat" && offer.commission_flat_sats > 0 && btcUsd) {
+                  if (
+                    offer.commission_type === "flat" &&
+                    offer.commission_flat_sats > 0 &&
+                    btcUsd
+                  ) {
                     const usd = ((offer.commission_flat_sats / 1e8) * btcUsd).toFixed(2);
                     return (
-                      <p className="text-sm text-muted-foreground mt-1">
-                        ≈ ${usd} USD per sale
-                      </p>
+                      <p className="text-sm text-muted-foreground mt-1">≈ ${usd} USD per sale</p>
                     );
                   }
                   return null;
                 })()}
                 {offer.price_sats > 0 && (
                   <p className="text-sm text-muted-foreground mt-1">
-                    Product price: ${Number(offer.price_sats).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USD
+                    Product price: $
+                    {Number(offer.price_sats).toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}{" "}
+                    USD
                   </p>
                 )}
               </div>
@@ -335,30 +392,21 @@ export default function OfferDetailClient() {
                           className="text-xs font-mono"
                           onClick={(e) => (e.target as HTMLInputElement).select()}
                         />
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => navigator.clipboard.writeText(trackingUrl)}
-                        >
-                          Copy
+                        <Button size="sm" variant="outline" onClick={handleCopyTrackingUrl}>
+                          {copiedTrackingUrl ? "Copied!" : "Copy"}
                         </Button>
                       </div>
+                      {copyError && <p className="text-xs text-red-500 mt-1">{copyError}</p>}
                     </div>
                   )}
                 </div>
               ) : (
-                <Button
-                  className="w-full"
-                  onClick={handleApply}
-                  disabled={applying}
-                >
+                <Button className="w-full" onClick={handleApply} disabled={applying}>
                   {applying ? "Applying..." : "Become an Affiliate"}
                 </Button>
               )}
 
-              {error && (
-                <p className="text-sm text-red-500 mt-2">{error}</p>
-              )}
+              {error && <p className="text-sm text-red-500 mt-2">{error}</p>}
             </div>
 
             {offer.product_url && (
@@ -372,7 +420,9 @@ export default function OfferDetailClient() {
                   try {
                     const parts = new URL(offer.product_url).hostname.split(".");
                     return parts.length > 2 ? parts.slice(-2).join(".") : parts.join(".");
-                  } catch { return "View Product"; }
+                  } catch {
+                    return "View Product";
+                  }
                 })()}
                 <ExternalLink className="h-3 w-3 opacity-50" />
               </a>


### PR DESCRIPTION
## Summary
- add a Clipboard API fallback for the affiliate offer tracking-link Copy button
- only show the copied state after a copy path succeeds
- show a manual-copy error when Clipboard API and textarea fallback both fail
- add component coverage for the apply-then-copy success fallback and full copy failure paths

Fixes #155

## Validation
- ./node_modules/.bin/vitest run 'src/app/affiliates/[slug]/OfferDetailClient.test.tsx'
- ./node_modules/.bin/eslint 'src/app/affiliates/[slug]/OfferDetailClient.tsx' 'src/app/affiliates/[slug]/OfferDetailClient.test.tsx'
- ./node_modules/.bin/prettier --check 'src/app/affiliates/[slug]/OfferDetailClient.tsx' 'src/app/affiliates/[slug]/OfferDetailClient.test.tsx'
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- 'src/app/affiliates/[slug]/OfferDetailClient.tsx' 'src/app/affiliates/[slug]/OfferDetailClient.test.tsx'

uGig gig: https://ugig.net/gig/cmexbmp260001ju04n3qmkdko