### PR TITLE
Expose affiliate commission estimates

### DIFF
--- a/src/app/api/affiliates/offers/[id]/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/route.test.ts
@@ -51,7 +51,7 @@ describe("GET /api/affiliates/offers/[id]", () => {
   it("looks up by UUID when id is a UUID (#25)", async () => {
     const uuid = "550e8400-e29b-41d4-a716-446655440000";
     const offer = { id: uuid, title: "Test", seller_id: "seller1", slug: "test" };
-    
+
     let eqColumn: string | undefined;
     mockFrom.mockReturnValue({
       select: () => ({
@@ -70,7 +70,7 @@ describe("GET /api/affiliates/offers/[id]", () => {
   it("looks up by slug when id is not a UUID (#25)", async () => {
     const slug = "my-cool-offer";
     const offer = { id: "some-uuid", title: "Test", seller_id: "seller1", slug };
-    
+
     let eqColumn: string | undefined;
     mockFrom.mockReturnValue({
       select: () => ({
@@ -93,6 +93,10 @@ describe("GET /api/affiliates/offers/[id]", () => {
       seller_id: "seller1",
       slug: "test",
       product_url: "https://secret.example.com",
+      commission_type: "percentage",
+      commission_rate: 0.2,
+      commission_flat_sats: 0,
+      price_sats: 1000,
     };
 
     mockFrom.mockReturnValue(chainable(offer));
@@ -104,6 +108,32 @@ describe("GET /api/affiliates/offers/[id]", () => {
 
     expect(res.status).toBe(200);
     expect(body.offer.product_url).toBeUndefined();
+    expect(body.offer.estimated_commission_sats).toBe(200);
+    expect(body.offer.commission_basis).toBe("listed_price");
+  });
+
+  it("marks percentage commissions without a listed price as sale amount based (#90)", async () => {
+    const offer = {
+      id: "some-uuid",
+      title: "Variable Commission",
+      seller_id: "seller1",
+      slug: "variable",
+      product_url: "https://secret.example.com",
+      commission_type: "percentage",
+      commission_rate: 0.2,
+      commission_flat_sats: 0,
+      price_sats: 0,
+    };
+
+    mockFrom.mockReturnValue(chainable(offer));
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await GET(makeRequest("variable"), makeParams("variable"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.offer.estimated_commission_sats).toBeNull();
+    expect(body.offer.commission_basis).toBe("sale_amount");
   });
 
   it("returns 404 for non-existent offer", async () => {

--- a/src/app/api/affiliates/offers/[id]/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/route.test.ts
@@ -19,10 +19,18 @@ vi.mock("@/lib/affiliates/validation", () => ({
   validateOfferInput: vi.fn(),
 }));
 
-import { GET } from "./route";
+import { GET, PATCH } from "./route";
 
 function makeRequest(id: string) {
   return new NextRequest(`http://localhost/api/affiliates/offers/${id}`);
+}
+
+function makePatchRequest(id: string, body: unknown) {
+  return new NextRequest(`http://localhost/api/affiliates/offers/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 }
 
 function makeParams(id: string) {
@@ -141,5 +149,58 @@ describe("GET /api/affiliates/offers/[id]", () => {
 
     const res = await GET(makeRequest("nonexistent"), makeParams("nonexistent"));
     expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/affiliates/offers/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "seller1", authMethod: "session" },
+    });
+  });
+
+  it("includes commission estimate fields in the updated offer response (#90)", async () => {
+    const updatedOffer = {
+      id: "offer-1",
+      seller_id: "seller1",
+      title: "Updated",
+      commission_type: "percentage",
+      commission_rate: 0.25,
+      commission_flat_sats: 0,
+      price_sats: 1000,
+    };
+
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: () => ({
+          single: () =>
+            Promise.resolve({
+              data: { id: "offer-1", seller_id: "seller1" },
+              error: null,
+            }),
+        }),
+      }),
+    });
+
+    mockFrom.mockReturnValueOnce({
+      update: () => ({
+        eq: () => ({
+          select: () => ({
+            single: () => Promise.resolve({ data: updatedOffer, error: null }),
+          }),
+        }),
+      }),
+    });
+
+    const res = await PATCH(
+      makePatchRequest("offer-1", { title: "Updated" }),
+      makeParams("offer-1")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.offer.estimated_commission_sats).toBe(250);
+    expect(body.offer.commission_basis).toBe("listed_price");
   });
 });

--- a/src/app/api/affiliates/offers/[id]/route.ts
+++ b/src/app/api/affiliates/offers/[id]/route.ts
@@ -1,20 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
+import { withCommissionEstimate } from "@/lib/affiliates/commission-estimate";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 import { validateOfferInput } from "@/lib/affiliates/validation";
-
 
 /**
  * GET /api/affiliates/offers/[id] - Get offer details
  * Supports both UUID and slug lookup (#25)
  */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const admin = createServiceClient();
@@ -24,17 +20,20 @@ export async function GET(
 
     const { data: offer, error } = await (admin as AnySupabase)
       .from("affiliate_offers")
-      .select(`
+      .select(
+        `
         *,
         profiles!affiliate_offers_seller_id_fkey(username, avatar_url),
         skill_listings(title, slug, price_sats)
-      `)
+      `
+      )
       .eq(lookupColumn, id)
       .single();
 
     if (error || !offer) {
       return NextResponse.json({ error: "Offer not found" }, { status: 404 });
     }
+    const offerWithEstimate = withCommissionEstimate(offer);
 
     // Hide product_url from unauthenticated/unauthorized users (#20)
     let auth: { user: { id: string } } | null = null;
@@ -58,11 +57,11 @@ export async function GET(
     }
 
     if (!isOwner && !isApprovedAffiliate) {
-      const { product_url, ...safeOffer } = offer;
+      const { product_url, ...safeOffer } = offerWithEstimate;
       return NextResponse.json({ offer: safeOffer });
     }
 
-    return NextResponse.json({ offer });
+    return NextResponse.json({ offer: offerWithEstimate });
   } catch {
     return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }
@@ -71,10 +70,7 @@ export async function GET(
 /**
  * PATCH /api/affiliates/offers/[id] - Update an offer (seller only)
  */
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const auth = await getAuthContext(request);
@@ -107,9 +103,11 @@ export async function PATCH(
     if (body.price_sats !== undefined) updateData.price_sats = body.price_sats;
     if (body.commission_rate !== undefined) updateData.commission_rate = body.commission_rate;
     if (body.commission_type !== undefined) updateData.commission_type = body.commission_type;
-    if (body.commission_flat_sats !== undefined) updateData.commission_flat_sats = body.commission_flat_sats;
+    if (body.commission_flat_sats !== undefined)
+      updateData.commission_flat_sats = body.commission_flat_sats;
     if (body.cookie_days !== undefined) updateData.cookie_days = body.cookie_days;
-    if (body.settlement_delay_days !== undefined) updateData.settlement_delay_days = body.settlement_delay_days;
+    if (body.settlement_delay_days !== undefined)
+      updateData.settlement_delay_days = body.settlement_delay_days;
     if (body.promo_text !== undefined) updateData.promo_text = body.promo_text;
     if (body.category !== undefined) updateData.category = body.category;
     if (body.tags !== undefined) updateData.tags = body.tags;

--- a/src/app/api/affiliates/offers/[id]/route.ts
+++ b/src/app/api/affiliates/offers/[id]/route.ts
@@ -125,7 +125,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
-    return NextResponse.json({ offer });
+    return NextResponse.json({ offer: withCommissionEstimate(offer) });
   } catch {
     return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }

--- a/src/app/api/affiliates/offers/route.test.ts
+++ b/src/app/api/affiliates/offers/route.test.ts
@@ -74,7 +74,10 @@ describe("GET /api/affiliates/offers", () => {
 
     const res = await GET(makeRequest({ sort: "commission" }));
     expect(res.status).toBe(200);
-    expect(orderSpy).toHaveBeenCalledWith("commission_flat_sats", expect.objectContaining({ ascending: false }));
+    expect(orderSpy).toHaveBeenCalledWith(
+      "commission_flat_sats",
+      expect.objectContaining({ ascending: false })
+    );
   });
 
   it("filters by search query (#21)", async () => {
@@ -97,6 +100,56 @@ describe("GET /api/affiliates/offers", () => {
 
     expect(res.status).toBe(200);
     expect(body.offers[0].product_url).toBeUndefined();
+  });
+
+  it("adds estimated commission fields to offer responses (#90)", async () => {
+    const offers = [
+      {
+        id: "flat",
+        title: "Flat Offer",
+        seller_id: "seller1",
+        commission_type: "flat",
+        commission_flat_sats: 40000,
+        commission_rate: 0,
+        price_sats: 0,
+      },
+      {
+        id: "priced",
+        title: "Priced Percentage",
+        seller_id: "seller2",
+        commission_type: "percentage",
+        commission_flat_sats: 0,
+        commission_rate: 0.2,
+        price_sats: 1000,
+      },
+      {
+        id: "variable",
+        title: "Variable Percentage",
+        seller_id: "seller3",
+        commission_type: "percentage",
+        commission_flat_sats: 0,
+        commission_rate: 0.2,
+        price_sats: 0,
+      },
+    ];
+    mockFrom.mockReturnValue(chainable(offers, null, 3));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.offers[0]).toMatchObject({
+      estimated_commission_sats: 40000,
+      commission_basis: "flat",
+    });
+    expect(body.offers[1]).toMatchObject({
+      estimated_commission_sats: 200,
+      commission_basis: "listed_price",
+    });
+    expect(body.offers[2]).toMatchObject({
+      estimated_commission_sats: null,
+      commission_basis: "sale_amount",
+    });
   });
 });
 
@@ -128,16 +181,17 @@ describe("POST /api/affiliates/offers", () => {
 
   it("strips HTML from title (#26)", async () => {
     mockGetAuthContext.mockResolvedValue({ user: { id: "user1" } });
-    
+
     const insertMock = vi.fn().mockReturnValue({
       select: () => ({
-        single: () => Promise.resolve({
-          data: { id: "new-id", slug: "test-offer", title: "Test Offer" },
-          error: null,
-        }),
+        single: () =>
+          Promise.resolve({
+            data: { id: "new-id", slug: "test-offer", title: "Test Offer" },
+            error: null,
+          }),
       }),
     });
-    
+
     mockFrom.mockReturnValue({
       select: () => ({
         eq: () => ({

--- a/src/app/api/affiliates/offers/route.ts
+++ b/src/app/api/affiliates/offers/route.ts
@@ -2,11 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, rateLimitExceeded, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { withCommissionEstimate } from "@/lib/affiliates/commission-estimate";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
 import { validateOfferInput } from "@/lib/affiliates/validation";
-
 
 function slugify(text: string): string {
   return text
@@ -35,11 +34,14 @@ export async function GET(request: NextRequest) {
 
     let query = (admin as AnySupabase)
       .from("affiliate_offers")
-      .select(`
+      .select(
+        `
         *,
         profiles!affiliate_offers_seller_id_fkey(username, avatar_url),
         skill_listings(title, slug)
-      `, { count: "exact" })
+      `,
+        { count: "exact" }
+      )
       .eq("status", "active");
 
     if (category) {
@@ -102,13 +104,14 @@ export async function GET(request: NextRequest) {
     }
 
     const sanitizedOffers = (offers || []).map((offer: any) => {
+      const offerWithEstimate = withCommissionEstimate(offer);
       const isOwner = auth && offer.seller_id === auth.user.id;
       const isApprovedAffiliate = auth && approvedOfferIds.has(offer.id);
       if (!isOwner && !isApprovedAffiliate) {
-        const { product_url, ...rest } = offer;
+        const { product_url, ...rest } = offerWithEstimate;
         return rest;
       }
-      return offer;
+      return offerWithEstimate;
     });
 
     return NextResponse.json({
@@ -185,7 +188,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
-    return NextResponse.json({ offer }, { status: 201 });
+    return NextResponse.json({ offer: withCommissionEstimate(offer) }, { status: 201 });
   } catch {
     return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }

--- a/src/lib/affiliates/commission-estimate.ts
+++ b/src/lib/affiliates/commission-estimate.ts
@@ -1,0 +1,44 @@
+export interface CommissionEstimateInput {
+  commission_type?: string | null;
+  commission_rate?: number | null;
+  commission_flat_sats?: number | null;
+  price_sats?: number | null;
+}
+
+export interface CommissionEstimate {
+  estimated_commission_sats: number | null;
+  commission_basis: "flat" | "listed_price" | "sale_amount";
+}
+
+export function getCommissionEstimate(offer: CommissionEstimateInput): CommissionEstimate {
+  if (offer.commission_type === "flat") {
+    return {
+      estimated_commission_sats: Math.max(0, Math.floor(offer.commission_flat_sats ?? 0)),
+      commission_basis: "flat",
+    };
+  }
+
+  const priceSats = offer.price_sats ?? 0;
+  const rate = offer.commission_rate ?? 0;
+
+  if (priceSats > 0 && rate > 0) {
+    return {
+      estimated_commission_sats: Math.floor(priceSats * rate),
+      commission_basis: "listed_price",
+    };
+  }
+
+  return {
+    estimated_commission_sats: null,
+    commission_basis: "sale_amount",
+  };
+}
+
+export function withCommissionEstimate<T extends CommissionEstimateInput>(
+  offer: T
+): T & CommissionEstimate {
+  return {
+    ...offer,
+    ...getCommissionEstimate(offer),
+  };
+}


### PR DESCRIPTION
## Summary
- add an `estimated_commission_sats` response field for affiliate offers
- add a `commission_basis` marker so callers can distinguish flat, listed-price percentage, and variable sale-amount percentage commissions
- return the estimate fields from offer list, detail, and create responses while preserving product URL hiding for unauthorized users

Fixes #90

Gig: https://ugig.net/gig/cmexbmp260001ju04n3qmkdko

## Validation
- `./node_modules/.bin/vitest run src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.test.ts'`
- `./node_modules/.bin/eslint src/lib/affiliates/commission-estimate.ts src/app/api/affiliates/offers/route.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.ts' 'src/app/api/affiliates/offers/[id]/route.test.ts'`
- `./node_modules/.bin/prettier --check src/lib/affiliates/commission-estimate.ts src/app/api/affiliates/offers/route.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.ts' 'src/app/api/affiliates/offers/[id]/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- src/lib/affiliates/commission-estimate.ts src/app/api/affiliates/offers/route.ts src/app/api/affiliates/offers/route.test.ts 'src/app/api/affiliates/offers/[id]/route.ts' 'src/app/api/affiliates/offers/[id]/route.test.ts'`
