### PR TITLE
Fix duplicate referral invites

### DIFF
--- a/src/app/api/referrals/route.test.ts
+++ b/src/app/api/referrals/route.test.ts
@@ -191,6 +191,73 @@ describe("POST /api/referrals", () => {
     });
   });
 
+  it("deduplicates repeated emails in a single invite request", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+
+    let insertedRows: Array<{ referred_email: string }> = [];
+    const mockSelectChain = {
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { referral_code: "testuser", username: "testuser", full_name: "Test User" },
+          error: null,
+        }),
+      }),
+    };
+    const mockInsertChain = {
+      select: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          data: insertedRows.map((row, index) => ({
+            id: `ref${index + 1}`,
+            referred_email: row.referred_email,
+            status: "pending",
+          })),
+          error: null,
+        })
+      ),
+    };
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "profiles") return { select: () => mockSelectChain };
+      if (table === "referrals") {
+        return {
+          insert: (rows: Array<{ referred_email: string }>) => {
+            insertedRows = rows;
+            return mockInsertChain;
+          },
+        };
+      }
+      return {};
+    });
+
+    const res = await POST(
+      makePostRequest({
+        emails: [" Friend@Test.com ", "friend@test.com", "other@test.com"],
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(insertedRows.map((row) => row.referred_email)).toEqual([
+      "friend@test.com",
+      "other@test.com",
+    ]);
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect(mockSendEmail).toHaveBeenNthCalledWith(1, {
+      to: "friend@test.com",
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+    expect(mockSendEmail).toHaveBeenNthCalledWith(2, {
+      to: "other@test.com",
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+  });
+
   it("should keep created invites when email delivery fails", async () => {
     mockGetAuthContext.mockResolvedValue({
       user: { id: "user1" },

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -36,10 +36,7 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch {
-    return NextResponse.json(
-      { error: "An unexpected error occurred" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }
 }
 
@@ -56,17 +53,11 @@ export async function POST(request: NextRequest) {
     const { emails } = body;
 
     if (!emails || !Array.isArray(emails) || emails.length === 0) {
-      return NextResponse.json(
-        { error: "Please provide an array of emails" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Please provide an array of emails" }, { status: 400 });
     }
 
     if (emails.length > 20) {
-      return NextResponse.json(
-        { error: "Maximum 20 invites at a time" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Maximum 20 invites at a time" }, { status: 400 });
     }
 
     // Spam throttling: max 50 invites per day, max 10 per hour
@@ -81,10 +72,7 @@ export async function POST(request: NextRequest) {
       .gte("created_at", oneHourAgo);
 
     if ((hourlyCount ?? 0) + emails.length > 10) {
-      return NextResponse.json(
-        { error: "Too many invites. Max 10 per hour." },
-        { status: 429 }
-      );
+      return NextResponse.json({ error: "Too many invites. Max 10 per hour." }, { status: 429 });
     }
 
     const { count: dailyCount } = await (svc as AnySupabase)
@@ -100,8 +88,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Prevent duplicate invites to same email
-    const normalizedEmails = emails.map((e: string) => e.trim().toLowerCase());
+    // Prevent duplicate invites to same email. De-dupe the current request first so
+    // users do not create/send duplicate invites when the same address appears
+    // multiple times with different casing or whitespace.
+    const normalizedEmails = Array.from(new Set(emails.map((e: string) => e.trim().toLowerCase())));
     const { data: existingInvites } = await (svc as AnySupabase)
       .from("referrals")
       .select("referred_email")
@@ -137,10 +127,7 @@ export async function POST(request: NextRequest) {
     const validEmails = newEmails.filter((e: string) => emailRegex.test(e));
 
     if (validEmails.length === 0) {
-      return NextResponse.json(
-        { error: "No valid email addresses provided" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "No valid email addresses provided" }, { status: 400 });
     }
 
     const referralRows = validEmails.map((email: string) => ({
@@ -161,23 +148,19 @@ export async function POST(request: NextRequest) {
 
     const emailContent = referralInviteEmail({ inviterName, referralCode });
     const emailResults = await Promise.all(
-      validEmails.map((email: string) =>
-        sendEmail({ to: email, ...emailContent })
-      )
+      validEmails.map((email: string) => sendEmail({ to: email, ...emailContent }))
     );
     const failedEmailCount = emailResults.filter((result) => !result.success).length;
 
     return NextResponse.json({
-      message: failedEmailCount > 0
-        ? `${validEmails.length} invite(s) created; ${failedEmailCount} email(s) failed to send`
-        : `${validEmails.length} invite(s) created and sent`,
+      message:
+        failedEmailCount > 0
+          ? `${validEmails.length} invite(s) created; ${failedEmailCount} email(s) failed to send`
+          : `${validEmails.length} invite(s) created and sent`,
       data: referrals,
       email_delivery_failed: failedEmailCount,
     });
   } catch {
-    return NextResponse.json(
-      { error: "An unexpected error occurred" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary\n- De-duplicate Invite Friends email addresses within a single request after trimming/lowercasing\n- Prevent duplicate referral rows and duplicate outgoing invite emails for the same address/casing in one batch\n- Add a regression test for repeated email inputs\n\n## Verification\n- pnpm exec vitest run src/app/api/referrals/route.test.ts\n- pnpm type-check