### PR TITLE
Validate affiliate apply offer ids

### DIFF
--- a/src/app/api/affiliates/apply/route.test.ts
+++ b/src/app/api/affiliates/apply/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+function makeRequest(body: unknown, headers: HeadersInit = {}) {
+  return new NextRequest("http://localhost/api/affiliates/apply", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      cookie: "session=abc",
+      authorization: "Bearer token",
+      ...headers,
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/affiliates/apply", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects malformed request bodies before proxying", async () => {
+    const res = await POST(makeRequest("{bad-json"));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "offer_id must be a non-empty string",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string offer ids before proxying", async () => {
+    for (const offer_id of [123, ["offer-1"], { id: "offer-1" }, true, "   "]) {
+      vi.mocked(fetch).mockClear();
+
+      const res = await POST(makeRequest({ offer_id }));
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: "offer_id must be a non-empty string",
+      });
+      expect(fetch).not.toHaveBeenCalled();
+    }
+  });
+
+  it("trims and forwards valid string offer ids with auth headers", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 201 }));
+
+    const res = await POST(
+      makeRequest({
+        offer_id: " offer/with spaces ",
+        note: "joining",
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost/api/affiliates/offers/offer%2Fwith%20spaces/apply",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer token",
+          cookie: "session=abc",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          offer_id: "offer/with spaces",
+          note: "joining",
+        }),
+      }
+    );
+  });
+});

--- a/src/app/api/affiliates/apply/route.ts
+++ b/src/app/api/affiliates/apply/route.ts
@@ -7,15 +7,12 @@ import { safeParseBody } from "@/lib/sanitize";
  */
 export async function POST(request: NextRequest) {
   try {
-    const body = await safeParseBody<{ offer_id?: string }>(request);
-    if (!body || !body.offer_id) {
-      return NextResponse.json(
-        { error: "offer_id is required in request body" },
-        { status: 400 }
-      );
+    const body = await safeParseBody<Record<string, unknown>>(request);
+    if (!body || typeof body.offer_id !== "string" || !body.offer_id.trim()) {
+      return NextResponse.json({ error: "offer_id must be a non-empty string" }, { status: 400 });
     }
 
-    const offerId = body.offer_id;
+    const offerId = body.offer_id.trim();
     const url = new URL(`/api/affiliates/offers/${encodeURIComponent(offerId)}/apply`, request.url);
 
     // Forward auth headers
@@ -29,15 +26,12 @@ export async function POST(request: NextRequest) {
     const res = await fetch(url.toString(), {
       method: "POST",
       headers: forwardHeaders,
-      body: JSON.stringify(body),
+      body: JSON.stringify({ ...body, offer_id: offerId }),
     });
 
     const data = await res.json().catch(() => ({ error: "Upstream error" }));
     return NextResponse.json(data, { status: res.status });
   } catch {
-    return NextResponse.json(
-      { error: "An unexpected error occurred" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- require the compatibility `POST /api/affiliates/apply` wrapper to receive a non-empty string `offer_id`
- trim valid IDs before building the proxied offer-apply URL
- keep auth header forwarding unchanged for valid requests
- add route coverage for malformed JSON, non-string IDs, blank IDs, and valid proxy forwarding

Fixes #219

## Validation
- `./node_modules/.bin/vitest run src/app/api/affiliates/apply/route.test.ts`
- `./node_modules/.bin/eslint src/app/api/affiliates/apply/route.ts src/app/api/affiliates/apply/route.test.ts`
- `./node_modules/.bin/prettier --check src/app/api/affiliates/apply/route.ts src/app/api/affiliates/apply/route.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check -- src/app/api/affiliates/apply/route.ts src/app/api/affiliates/apply/route.test.ts`

uGig task: https://ugig.net/gigs/4741218f-a723-46bb-82cb-6516120331ae

No payout details included; those can be provided after acceptance.