### PR TITLE
Escape referral invite names in email HTML

### DIFF
--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -128,4 +128,16 @@ describe("referralInviteEmail", () => {
     expect(result.text).toContain("https://ugig.net/signup?ref=codex%2Fref%20code");
     expect(result.html).toContain("Accept Invite");
   });
+
+  it("escapes inviter names in HTML while preserving readable text", () => {
+    const result = referralInviteEmail({
+      inviterName: `Alice <b>Builder</b> & "Co"`,
+      referralCode: "safe-code",
+    });
+
+    expect(result.html).toContain("Alice &lt;b&gt;Builder&lt;/b&gt; &amp; &quot;Co&quot;");
+    expect(result.html).not.toContain("Alice <b>Builder</b>");
+    expect(result.text).toContain(`Alice <b>Builder</b> & "Co" invited you`);
+    expect(result.subject).toBe(`Alice <b>Builder</b> & "Co" invited you to join ugig.net`);
+  });
 });

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -17,6 +17,15 @@ function getResendClient(): Resend | null {
   return new Resend(process.env.RESEND_API_KEY);
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 interface SendEmailParams {
   to: string;
   subject: string;
@@ -152,6 +161,7 @@ export function referralInviteEmail(params: {
   const { inviterName, referralCode } = params;
   const baseUrl = getBaseUrl();
   const signupUrl = `${baseUrl}/signup?ref=${encodeURIComponent(referralCode)}`;
+  const inviterNameHtml = escapeHtml(inviterName);
 
   const html = `
 <!DOCTYPE html>
@@ -169,7 +179,7 @@ export function referralInviteEmail(params: {
   <div style="background: #f9fafb; padding: 30px; border: 1px solid #e5e7eb; border-top: none;">
     <p style="margin-top: 0;">Hi there,</p>
 
-    <p><strong>${inviterName}</strong> invited you to join ugig.net, a marketplace for AI-assisted professionals.</p>
+    <p><strong>${inviterNameHtml}</strong> invited you to join ugig.net, a marketplace for AI-assisted professionals.</p>
 
     <a href="${signupUrl}" style="display: inline-block; background: #667eea; color: white; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500; margin-top: 10px;">
       Accept Invite


### PR DESCRIPTION
## Summary
- Escape the inviter display name before inserting it into the referral invite HTML body.
- Keep the plain-text email and subject readable with the original display name.
- Add regression coverage for names containing markup and ampersands.

Closes #221.

## Verification
- `node_modules/.bin/vitest.cmd run src/lib/email.test.ts` (11 passed)
- `git diff --check -- src/lib/email.ts src/lib/email.test.ts`