### PR TITLE
Keep gig invoice payments inside uGig

### DIFF
--- a/src/app/api/gigs/[id]/invoice/route.test.ts
+++ b/src/app/api/gigs/[id]/invoice/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/coinpayportal", () => ({
   createPayment: vi.fn(),
+  resolveSupportedPaymentCurrency: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/get-user", () => ({
@@ -10,7 +11,7 @@ vi.mock("@/lib/auth/get-user", () => ({
 
 import { GET, POST } from "./route";
 import { getAuthContext } from "@/lib/auth/get-user";
-import { createPayment } from "@/lib/coinpayportal";
+import { createPayment, resolveSupportedPaymentCurrency } from "@/lib/coinpayportal";
 
 const GIG_ID = "8489a861-0999-4107-afca-2592021ac338";
 const APP_ID = "d2317730-c56a-49e9-a6e4-dc469b7605f7";
@@ -196,6 +197,7 @@ describe("POST /api/gigs/[id]/invoice", () => {
     });
 
     (getAuthContext as any).mockResolvedValue({ user: { id: WORKER_ID }, supabase: sb });
+    (resolveSupportedPaymentCurrency as any).mockResolvedValue("sol");
     (createPayment as any).mockResolvedValue({
       success: true,
       payment_id: "cp-pay-1",
@@ -228,6 +230,10 @@ describe("POST /api/gigs/[id]/invoice", () => {
         currency: "sol",
         description: "Work completed",
       })
+    );
+    expect(resolveSupportedPaymentCurrency).toHaveBeenCalledWith(
+      "SOL",
+      expect.any(Object)
     );
   });
 });

--- a/src/app/api/gigs/[id]/invoice/route.test.ts
+++ b/src/app/api/gigs/[id]/invoice/route.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/coinpayportal", () => ({
-  createInvoice: vi.fn(),
-  sendInvoice: vi.fn(),
+  createPayment: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/get-user", () => ({
@@ -11,7 +10,7 @@ vi.mock("@/lib/auth/get-user", () => ({
 
 import { GET, POST } from "./route";
 import { getAuthContext } from "@/lib/auth/get-user";
-import { createInvoice, sendInvoice } from "@/lib/coinpayportal";
+import { createPayment } from "@/lib/coinpayportal";
 
 const GIG_ID = "8489a861-0999-4107-afca-2592021ac338";
 const APP_ID = "d2317730-c56a-49e9-a6e4-dc469b7605f7";
@@ -156,9 +155,17 @@ describe("POST /api/gigs/[id]/invoice", () => {
   });
 
   it("creates invoice successfully", async () => {
-    const gig = { id: GIG_ID, title: "Test Gig", poster_id: POSTER_ID };
+    const gig = { id: GIG_ID, title: "Test Gig", poster_id: POSTER_ID, payment_coin: "SOL" };
     const application = { id: APP_ID, applicant_id: WORKER_ID, status: "accepted", proposed_rate: 150 };
-    const invoiceRecord = { id: "local-inv-1" };
+    const invoiceRecord = {
+      id: "local-inv-1",
+      metadata: {
+        payment_address: "So11111111111111111111111111111111111111112",
+        amount_crypto: 0.75,
+        payment_currency: "sol",
+        expires_at: "2026-05-22T12:00:00Z",
+      },
+    };
 
     const sb = mockSupabase({
       gigs: {
@@ -189,24 +196,16 @@ describe("POST /api/gigs/[id]/invoice", () => {
     });
 
     (getAuthContext as any).mockResolvedValue({ user: { id: WORKER_ID }, supabase: sb });
-    (createInvoice as any).mockResolvedValue({
+    (createPayment as any).mockResolvedValue({
       success: true,
-      invoice: {
-        id: "cp-inv-1",
-        status: "created",
-        amount: 150,
-        currency: "USD",
-        pay_url: null,
-      },
-    });
-    (sendInvoice as any).mockResolvedValue({
-      success: true,
-      invoice: {
-        id: "cp-inv-1",
-        status: "sent",
-        amount: 150,
-        currency: "USD",
-        pay_url: "https://coinpayportal.com/pay/cp-inv-1",
+      payment_id: "cp-pay-1",
+      address: "So11111111111111111111111111111111111111112",
+      amount_crypto: 0.75,
+      currency: "sol",
+      expires_at: "2026-05-22T12:00:00Z",
+      payment: {
+        id: "cp-pay-1",
+        payment_address: "So11111111111111111111111111111111111111112",
       },
     });
 
@@ -218,16 +217,17 @@ describe("POST /api/gigs/[id]/invoice", () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.data.invoice_id).toBe("local-inv-1");
-    expect(body.data.coinpay_invoice_id).toBe("cp-inv-1");
-    expect(body.data.pay_url).toBe("https://coinpayportal.com/pay/cp-inv-1");
+    expect(body.data.coinpay_invoice_id).toBe("cp-pay-1");
+    expect(body.data.pay_url).toBeNull();
+    expect(body.data.payment_address).toBe("So11111111111111111111111111111111111111112");
+    expect(body.data.payment_currency).toBe("sol");
 
-    expect(createInvoice).toHaveBeenCalledWith(
+    expect(createPayment).toHaveBeenCalledWith(
       expect.objectContaining({
-        amount: 150,
-        currency: "USD",
-        notes: "Work completed",
+        amount_usd: 150,
+        currency: "sol",
+        description: "Work completed",
       })
     );
-    expect(sendInvoice).toHaveBeenCalledWith("cp-inv-1");
   });
 });

--- a/src/app/api/gigs/[id]/invoice/route.ts
+++ b/src/app/api/gigs/[id]/invoice/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
-import { createPayment, type SupportedCurrency } from "@/lib/coinpayportal";
+import { createPayment, resolveSupportedPaymentCurrency } from "@/lib/coinpayportal";
 import { z } from "zod";
 
 const createInvoiceSchema = z.object({
@@ -10,30 +10,6 @@ const createInvoiceSchema = z.object({
   notes: z.string().optional(),
   due_date: z.string().optional(),
 });
-
-const COINPAY_CURRENCY_BY_COIN: Record<string, SupportedCurrency> = {
-  BTC: "btc",
-  ETH: "eth",
-  POL: "pol",
-  MATIC: "pol",
-  SOL: "sol",
-  USDC: "usdc_sol",
-  USDC_POL: "usdc_pol",
-  USDC_POLYGON: "usdc_pol",
-  USDC_SOL: "usdc_sol",
-  USDC_SOLANA: "usdc_sol",
-  USDC_ETH: "usdc_eth",
-  USDC_ETHEREUM: "usdc_eth",
-  USDT: "usdt",
-};
-
-function getPaymentCurrency(paymentCoin?: string | null): SupportedCurrency {
-  const key = (paymentCoin || "")
-    .trim()
-    .toUpperCase()
-    .replace(/[\s-]+/g, "_");
-  return COINPAY_CURRENCY_BY_COIN[key] || "usdc_sol";
-}
 
 // GET /api/gigs/[id]/invoice - Get invoices for a gig
 export async function GET(
@@ -137,11 +113,14 @@ export async function POST(
       );
     }
 
-    const paymentCurrency = getPaymentCurrency((gig as any).payment_coin);
     const appUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
     const regularBusinessId =
       process.env.COINPAY_UGIG_BUSINESS_ID ||
       process.env.COINPAY_MERCHANT_ID;
+    const paymentCurrency = await resolveSupportedPaymentCurrency(
+      (gig as any).payment_coin,
+      { business_id: regularBusinessId }
+    );
 
     // Create a direct CoinPay payment request instead of a hosted invoice. The
     // poster should see payment details inside uGig, not be redirected away.

--- a/src/app/api/gigs/[id]/invoice/route.ts
+++ b/src/app/api/gigs/[id]/invoice/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
-import { createInvoice, sendInvoice } from "@/lib/coinpayportal";
+import { createPayment, type SupportedCurrency } from "@/lib/coinpayportal";
 import { z } from "zod";
 
 const createInvoiceSchema = z.object({
@@ -10,6 +10,30 @@ const createInvoiceSchema = z.object({
   notes: z.string().optional(),
   due_date: z.string().optional(),
 });
+
+const COINPAY_CURRENCY_BY_COIN: Record<string, SupportedCurrency> = {
+  BTC: "btc",
+  ETH: "eth",
+  POL: "pol",
+  MATIC: "pol",
+  SOL: "sol",
+  USDC: "usdc_sol",
+  USDC_POL: "usdc_pol",
+  USDC_POLYGON: "usdc_pol",
+  USDC_SOL: "usdc_sol",
+  USDC_SOLANA: "usdc_sol",
+  USDC_ETH: "usdc_eth",
+  USDC_ETHEREUM: "usdc_eth",
+  USDT: "usdt",
+};
+
+function getPaymentCurrency(paymentCoin?: string | null): SupportedCurrency {
+  const key = (paymentCoin || "")
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, "_");
+  return COINPAY_CURRENCY_BY_COIN[key] || "usdc_sol";
+}
 
 // GET /api/gigs/[id]/invoice - Get invoices for a gig
 export async function GET(
@@ -76,7 +100,7 @@ export async function POST(
     // Get gig
     const { data: gig } = await supabase
       .from("gigs")
-      .select("id, title, poster_id")
+      .select("id, title, poster_id, payment_coin")
       .eq("id", gigId)
       .single();
 
@@ -113,24 +137,57 @@ export async function POST(
       );
     }
 
-    // Create invoice on CoinPayPortal
-    const invoiceResult = await createInvoice({
-      amount,
-      currency,
-      notes: notes || `Invoice for gig: ${gig.title}`,
-      due_date,
+    const paymentCurrency = getPaymentCurrency((gig as any).payment_coin);
+    const appUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
+    const regularBusinessId =
+      process.env.COINPAY_UGIG_BUSINESS_ID ||
+      process.env.COINPAY_MERCHANT_ID;
+
+    // Create a direct CoinPay payment request instead of a hosted invoice. The
+    // poster should see payment details inside uGig, not be redirected away.
+    const paymentResult = await createPayment({
+      amount_usd: amount,
+      currency: paymentCurrency,
+      description: notes || `Invoice for gig: ${gig.title}`,
+      business_id: regularBusinessId,
+      redirect_url: `${appUrl}/gigs/${gigId}?invoice=paid`,
       metadata: {
+        type: "gig_invoice",
         gig_id: gigId,
         application_id,
         worker_id: user.id,
         poster_id: gig.poster_id,
+        invoice_currency: currency,
+        payment_currency: paymentCurrency,
         platform: "ugig.net",
       },
     });
 
-    // Send the invoice to generate a payment link
-    const sendResult = await sendInvoice(invoiceResult.invoice.id);
-    const payUrl = sendResult.invoice.pay_url || invoiceResult.invoice.pay_url;
+    const cpPayment = paymentResult.payment || paymentResult;
+    const paymentId = paymentResult.payment_id || (cpPayment as any).id;
+    const paymentAddress = (cpPayment as any).payment_address || paymentResult.address || null;
+    const checkoutUrl = paymentResult.checkout_url || (cpPayment as any).checkout_url || null;
+    const amountCrypto =
+      paymentResult.amount_crypto ||
+      (cpPayment as any).amount_crypto ||
+      (cpPayment as any).crypto_amount ||
+      null;
+    const expiresAt = paymentResult.expires_at || (cpPayment as any).expires_at || null;
+    const responseCurrency = paymentResult.currency || (cpPayment as any).currency || paymentCurrency;
+
+    if (!paymentId) {
+      return NextResponse.json(
+        { error: "CoinPay did not return a payment id" },
+        { status: 502 }
+      );
+    }
+
+    if (!paymentAddress) {
+      return NextResponse.json(
+        { error: "CoinPay did not return an in-app payment address" },
+        { status: 502 }
+      );
+    }
 
     // Create local invoice record
     const { data: invoice, error } = await (supabase as any)
@@ -140,13 +197,20 @@ export async function POST(
         application_id,
         worker_id: user.id,
         poster_id: gig.poster_id,
-        coinpay_invoice_id: invoiceResult.invoice.id,
+        coinpay_invoice_id: paymentId,
         amount_usd: amount,
         currency,
         status: "sent",
-        pay_url: payUrl,
+        pay_url: null,
         notes,
         due_date: due_date || null,
+        metadata: {
+          payment_address: paymentAddress,
+          amount_crypto: amountCrypto,
+          payment_currency: responseCurrency,
+          checkout_url: checkoutUrl,
+          expires_at: expiresAt,
+        },
       })
       .select()
       .single();
@@ -180,8 +244,13 @@ export async function POST(
     return NextResponse.json({
       data: {
         invoice_id: invoice.id,
-        coinpay_invoice_id: invoiceResult.invoice.id,
-        pay_url: payUrl,
+        coinpay_invoice_id: paymentId,
+        pay_url: null,
+        payment_address: paymentAddress,
+        amount_crypto: amountCrypto,
+        payment_currency: responseCurrency,
+        expires_at: expiresAt,
+        metadata: invoice.metadata,
       },
     }, { status: 201 });
   } catch (error) {

--- a/src/app/api/payments/coinpayportal/webhook/route.test.ts
+++ b/src/app/api/payments/coinpayportal/webhook/route.test.ts
@@ -132,6 +132,51 @@ describe("POST /api/payments/coinpayportal/webhook", () => {
     expect(json.received).toBe(true);
   });
 
+  it("marks gig invoices paid when webhook payment is not in payments", async () => {
+    const payload = makeWebhookPayload("payment.confirmed", {
+      payment_id: "cp-pay-invoice-1",
+      amount_usd: 3,
+      amount_crypto: 0.02,
+      currency: "SOL",
+      status: "confirmed",
+    });
+
+    const missingPaymentChain = chainResult({
+      data: null,
+      error: { code: "PGRST116", message: "No rows" },
+    });
+    const invoiceChain = chainResult({
+      data: {
+        id: "local-inv-1",
+        gig_id: "gig-1",
+        application_id: "app-1",
+        worker_id: "worker-1",
+        poster_id: "poster-1",
+        amount_usd: 3,
+        metadata: { payment_address: "SolAddress" },
+      },
+      error: null,
+    });
+    const gigChain = chainResult({ data: { title: "Invoice fix" }, error: null });
+    const okChain = chainResult({ data: null, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "payments") return missingPaymentChain;
+      if (table === "gig_invoices") return invoiceChain;
+      if (table === "gigs") return gigChain;
+      return okChain;
+    });
+
+    const req = makeRequest(payload, WEBHOOK_SECRET);
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockFrom).toHaveBeenCalledWith("gig_invoices");
+    expect(invoiceChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "paid" })
+    );
+  });
+
   it("processes payment.forwarded webhook", async () => {
     const payload = makeWebhookPayload("payment.forwarded", {
       payment_id: "pay_456",

--- a/src/app/api/payments/coinpayportal/webhook/route.ts
+++ b/src/app/api/payments/coinpayportal/webhook/route.ts
@@ -105,11 +105,15 @@ async function handlePaymentConfirmed(
     .single();
 
   if (paymentError) {
+    const handledInvoice = await handleGigInvoicePaymentConfirmed(supabase, payload);
+    if (handledInvoice) return;
     console.error("Failed to update payment:", paymentError);
     return;
   }
 
   if (!payment) {
+    const handledInvoice = await handleGigInvoicePaymentConfirmed(supabase, payload);
+    if (handledInvoice) return;
     console.error("Payment not found:", paymentData.payment_id);
     return;
   }
@@ -238,6 +242,8 @@ async function handlePaymentForwarded(
       updated_at: new Date().toISOString(),
     })
     .eq("coinpay_payment_id", paymentData.payment_id);
+
+  await updateGigInvoicePaymentMetadata(supabase, payload, "sent");
 }
 
 async function handlePaymentExpired(
@@ -257,6 +263,11 @@ async function handlePaymentExpired(
     .select()
     .single();
 
+  if (!payment) {
+    const handledInvoice = await updateGigInvoicePaymentMetadata(supabase, payload, "expired");
+    if (handledInvoice) return;
+  }
+
   if (payment) {
     // Notify user
     await supabase.from("notifications").insert({
@@ -269,6 +280,132 @@ async function handlePaymentExpired(
       },
     });
   }
+}
+
+async function handleGigInvoicePaymentConfirmed(
+  supabase: ReturnType<typeof createServiceClient>,
+  payload: CoinPayWebhookPayload
+): Promise<boolean> {
+  const { data: paymentData } = payload;
+  const now = new Date().toISOString();
+  const { data: existingInvoice } = await (supabase as any)
+    .from("gig_invoices")
+    .select("*")
+    .eq("coinpay_invoice_id", paymentData.payment_id)
+    .single();
+
+  if (!existingInvoice) return false;
+
+  const { data: invoice } = await (supabase as any)
+    .from("gig_invoices")
+    .update({
+      status: "paid",
+      updated_at: now,
+      metadata: {
+        ...((existingInvoice.metadata || {}) as Record<string, unknown>),
+        tx_hash: paymentData.tx_hash,
+        merchant_tx_hash: paymentData.merchant_tx_hash,
+        paid_at: now,
+        payment_currency: paymentData.currency,
+        amount_crypto: paymentData.amount_crypto,
+      },
+    })
+    .eq("id", existingInvoice.id)
+    .select()
+    .single();
+
+  if (!invoice) return false;
+
+  await supabase
+    .from("applications")
+    .update({
+      status: "completed" as any,
+      updated_at: now,
+    })
+    .eq("id", invoice.application_id);
+
+  const { data: gig } = await supabase
+    .from("gigs")
+    .select("title")
+    .eq("id", invoice.gig_id)
+    .single();
+
+  await supabase.from("notifications").insert([
+    {
+      user_id: invoice.worker_id,
+      type: "payment_received",
+      title: "Invoice paid",
+      body: `$${invoice.amount_usd} invoice for "${gig?.title || "your gig"}" has been paid.`,
+      data: {
+        gig_id: invoice.gig_id,
+        invoice_id: invoice.id,
+      },
+    },
+    {
+      user_id: invoice.poster_id,
+      type: "payment_received",
+      title: "Invoice paid",
+      body: `Your $${invoice.amount_usd} invoice payment for "${gig?.title || "your gig"}" was confirmed.`,
+      data: {
+        gig_id: invoice.gig_id,
+        invoice_id: invoice.id,
+      },
+    },
+  ]);
+
+  return true;
+}
+
+async function updateGigInvoicePaymentMetadata(
+  supabase: ReturnType<typeof createServiceClient>,
+  payload: CoinPayWebhookPayload,
+  status: "sent" | "expired"
+): Promise<boolean> {
+  const { data: paymentData } = payload;
+  const { data: existingInvoice } = await (supabase as any)
+    .from("gig_invoices")
+    .select("*")
+    .eq("coinpay_invoice_id", paymentData.payment_id)
+    .single();
+
+  if (!existingInvoice) return false;
+
+  const metadata: Record<string, unknown> = {
+    ...((existingInvoice.metadata || {}) as Record<string, unknown>),
+    tx_hash: paymentData.tx_hash,
+    merchant_tx_hash: paymentData.merchant_tx_hash,
+    payment_currency: paymentData.currency,
+    amount_crypto: paymentData.amount_crypto,
+  };
+  if (status === "expired") metadata.expired_at = new Date().toISOString();
+
+  const { data: invoice } = await (supabase as any)
+    .from("gig_invoices")
+    .update({
+      status,
+      metadata,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", existingInvoice.id)
+    .select()
+    .single();
+
+  if (!invoice) return false;
+
+  if (status === "expired") {
+    await supabase.from("notifications").insert({
+      user_id: invoice.worker_id,
+      type: "payment_received",
+      title: "Invoice payment expired",
+      body: `The $${invoice.amount_usd} invoice payment request expired.`,
+      data: {
+        gig_id: invoice.gig_id,
+        invoice_id: invoice.id,
+      },
+    });
+  }
+
+  return true;
 }
 
 // ─── Escrow webhook handlers ───────────────────────────────────────────────

--- a/src/components/gigs/InvoiceButton.tsx
+++ b/src/components/gigs/InvoiceButton.tsx
@@ -6,9 +6,9 @@ import { Badge } from "@/components/ui/badge";
 import {
   FileText,
   Loader2,
-  ExternalLink,
   CheckCircle2,
   Clock,
+  Copy,
   DollarSign,
   Send,
 } from "lucide-react";
@@ -22,6 +22,12 @@ interface GigInvoice {
   notes: string | null;
   due_date: string | null;
   created_at: string;
+  metadata?: {
+    payment_address?: string | null;
+    amount_crypto?: number | string | null;
+    payment_currency?: string | null;
+    expires_at?: string | null;
+  } | null;
   worker?: { id: string; username: string; full_name?: string };
   poster?: { id: string; username: string; full_name?: string };
 }
@@ -110,6 +116,12 @@ export function InvoiceButton({
           notes: notes || null,
           due_date: dueDate || null,
           created_at: new Date().toISOString(),
+          metadata: result.data.metadata || {
+            payment_address: result.data.payment_address,
+            amount_crypto: result.data.amount_crypto,
+            payment_currency: result.data.payment_currency,
+            expires_at: result.data.expires_at,
+          },
         },
         ...prev,
       ]);
@@ -193,17 +205,45 @@ export function InvoiceButton({
               <p className="text-sm text-muted-foreground">{inv.notes}</p>
             )}
 
-            {/* Poster: show pay link */}
-            {isPoster && inv.pay_url && inv.status === "sent" && (
-              <a
-                href={inv.pay_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
-              >
-                <ExternalLink className="h-3 w-3" />
-                Pay Invoice
-              </a>
+            {/* Poster: keep payment UX inside uGig. */}
+            {isPoster && inv.status === "sent" && inv.metadata?.payment_address && (
+              <div className="rounded-md border border-border bg-muted/30 p-3 space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Payment address
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 text-xs"
+                    onClick={() =>
+                      navigator.clipboard?.writeText(
+                        inv.metadata?.payment_address || ""
+                      )
+                    }
+                  >
+                    <Copy className="h-3 w-3" />
+                    Copy
+                  </Button>
+                </div>
+                <code className="block break-all rounded bg-background px-2 py-1.5 text-xs">
+                  {inv.metadata.payment_address}
+                </code>
+                <p className="text-xs text-muted-foreground">
+                  Send{" "}
+                  {inv.metadata.amount_crypto
+                    ? `${inv.metadata.amount_crypto} ${inv.metadata.payment_currency || ""}`.trim()
+                    : inv.metadata.payment_currency || "the selected coin"}{" "}
+                  to this address.
+                </p>
+              </div>
+            )}
+
+            {isPoster && inv.status === "sent" && !inv.metadata?.payment_address && (
+              <p className="text-sm text-muted-foreground">
+                Payment details are not available. Ask the worker to resend the invoice.
+              </p>
             )}
 
             {/* Worker: show pay link status */}

--- a/src/lib/coinpayportal.test.ts
+++ b/src/lib/coinpayportal.test.ts
@@ -3,6 +3,8 @@ import crypto from "crypto";
 import {
   createInvoice,
   sendInvoice,
+  getSupportedCoins,
+  resolveSupportedPaymentCurrency,
   verifyWebhookSignature,
   SUPPORTED_CURRENCIES,
 } from "./coinpayportal";
@@ -104,6 +106,68 @@ describe("SUPPORTED_CURRENCIES", () => {
     expect(SUPPORTED_CURRENCIES.btc.symbol).toBe("BTC");
     expect(SUPPORTED_CURRENCIES.eth.name).toBe("Ethereum");
     expect(SUPPORTED_CURRENCIES.eth.symbol).toBe("ETH");
+  });
+});
+
+describe("CoinPayPortal supported coins API", () => {
+  const originalApiKey = process.env.COINPAY_API_KEY;
+  const originalMerchantId = process.env.COINPAY_MERCHANT_ID;
+
+  beforeEach(() => {
+    process.env.COINPAY_API_KEY = "cp_live_" + "a".repeat(32);
+    process.env.COINPAY_MERCHANT_ID = "biz_123";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          success: true,
+          coins: [
+            { symbol: "SOL", name: "Solana", is_active: true, has_wallet: true },
+            { symbol: "BTC", name: "Bitcoin", is_active: true, has_wallet: true },
+          ],
+        }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env.COINPAY_API_KEY;
+    } else {
+      process.env.COINPAY_API_KEY = originalApiKey;
+    }
+
+    if (originalMerchantId === undefined) {
+      delete process.env.COINPAY_MERCHANT_ID;
+    } else {
+      process.env.COINPAY_MERCHANT_ID = originalMerchantId;
+    }
+
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches active business wallet coins from CoinPayPortal", async () => {
+    await getSupportedCoins();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://coinpayportal.com/api/supported-coins?business_id=biz_123&active_only=true",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${process.env.COINPAY_API_KEY}`,
+        }),
+      })
+    );
+  });
+
+  it("resolves a preferred gig coin from active CoinPay wallets", async () => {
+    await expect(resolveSupportedPaymentCurrency("SOL")).resolves.toBe("sol");
+  });
+
+  it("rejects preferred gig coins not configured in CoinPay", async () => {
+    await expect(resolveSupportedPaymentCurrency("ETH")).rejects.toThrow(
+      "CoinPayPortal does not have an active ETH wallet configured"
+    );
   });
 });
 

--- a/src/lib/coinpayportal.test.ts
+++ b/src/lib/coinpayportal.test.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import {
   createInvoice,
   sendInvoice,
+  getBusinessWalletCurrencies,
   getSupportedCoins,
   resolveSupportedPaymentCurrency,
   verifyWebhookSignature,
@@ -126,6 +127,16 @@ describe("CoinPayPortal supported coins API", () => {
             { symbol: "SOL", name: "Solana", is_active: true, has_wallet: true },
             { symbol: "BTC", name: "Bitcoin", is_active: true, has_wallet: true },
           ],
+          businesses: [
+            {
+              id: "biz_123",
+              name: "uGig",
+              walletAddresses: {
+                SOL: "SolAddress1234567890",
+                BTC: "bc1qaddress1234567890",
+              },
+            },
+          ],
         }),
       })
     );
@@ -158,6 +169,23 @@ describe("CoinPayPortal supported coins API", () => {
         }),
       })
     );
+  });
+
+  it("fetches configured business wallet addresses from CoinPayPortal", async () => {
+    const wallets = await getBusinessWalletCurrencies();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://coinpayportal.com/api/businesses",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${process.env.COINPAY_API_KEY}`,
+        }),
+      })
+    );
+    expect(wallets).toEqual([
+      expect.objectContaining({ currency: "SOL", address: "SolAddress1234567890" }),
+      expect.objectContaining({ currency: "BTC", address: "bc1qaddress1234567890" }),
+    ]);
   });
 
   it("resolves a preferred gig coin from active CoinPay wallets", async () => {

--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -49,6 +49,27 @@ export interface CreatePaymentResponse {
   };
 }
 
+export interface SupportedCoin {
+  symbol?: string;
+  code?: string;
+  currency?: string;
+  id?: string;
+  name?: string;
+  chain?: string;
+  network?: string;
+  blockchain?: string;
+  is_active?: boolean;
+  has_wallet?: boolean;
+  [key: string]: unknown;
+}
+
+export interface SupportedCoinsResponse {
+  success: boolean;
+  coins: SupportedCoin[];
+  business_id?: string;
+  total?: number;
+}
+
 /**
  * Verify CoinPayPortal webhook signature
  * Format: X-CoinPay-Signature: t=timestamp,v1=signature
@@ -150,6 +171,131 @@ export const SUPPORTED_CURRENCIES = {
 } as const;
 
 export type SupportedCurrency = keyof typeof SUPPORTED_CURRENCIES;
+
+const SUPPORTED_CURRENCY_KEYS = Object.keys(SUPPORTED_CURRENCIES) as SupportedCurrency[];
+
+function isSupportedCurrency(value: string): value is SupportedCurrency {
+  return SUPPORTED_CURRENCY_KEYS.includes(value as SupportedCurrency);
+}
+
+function normalizeCurrencyKey(value?: string | null): string {
+  return (value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function normalizeCoinSymbol(value?: string | null): string {
+  return (value || "")
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+export function coinToPaymentCurrency(coin: SupportedCoin): SupportedCurrency | null {
+  const directCurrency =
+    normalizeCurrencyKey(coin.currency) ||
+    normalizeCurrencyKey(coin.id) ||
+    normalizeCurrencyKey(coin.code);
+  if (isSupportedCurrency(directCurrency)) return directCurrency;
+
+  const symbol =
+    normalizeCoinSymbol(coin.symbol) ||
+    normalizeCoinSymbol(coin.code) ||
+    normalizeCoinSymbol(coin.currency) ||
+    normalizeCoinSymbol(coin.id);
+  const chain =
+    normalizeCoinSymbol(coin.chain) ||
+    normalizeCoinSymbol(coin.network) ||
+    normalizeCoinSymbol(coin.blockchain);
+
+  if (symbol === "BTC") return "btc";
+  if (symbol === "ETH") return "eth";
+  if (symbol === "POL" || symbol === "MATIC") return "pol";
+  if (symbol === "SOL") return "sol";
+  if (symbol === "USDT") return "usdt";
+  if (symbol === "USDC") {
+    if (chain === "POL" || chain === "POLYGON" || chain === "MATIC") return "usdc_pol";
+    if (chain === "ETH" || chain === "ETHEREUM") return "usdc_eth";
+    return "usdc_sol";
+  }
+
+  return null;
+}
+
+function coinMatchesPreference(coin: SupportedCoin, preferredCoin: string): boolean {
+  const preferred = normalizeCoinSymbol(preferredCoin);
+  const candidates = [
+    coin.symbol,
+    coin.code,
+    coin.currency,
+    coin.id,
+    coin.name,
+  ].map(normalizeCoinSymbol);
+
+  return candidates.includes(preferred);
+}
+
+/**
+ * Fetch the business-specific active wallet coins from CoinPayPortal. This keeps
+ * invoice payment options aligned with the merchant's configured wallets.
+ */
+export async function getSupportedCoins(options: {
+  business_id?: string;
+  active_only?: boolean;
+} = {}): Promise<SupportedCoinsResponse> {
+  const apiKey = process.env.COINPAY_API_KEY;
+  const businessId = options.business_id || process.env.COINPAY_MERCHANT_ID;
+
+  if (!apiKey) {
+    throw new Error("CoinPayPortal credentials not configured");
+  }
+
+  const url = new URL(`${COINPAY_API_URL}/supported-coins`);
+  if (businessId) url.searchParams.set("business_id", businessId);
+  if (options.active_only !== false) url.searchParams.set("active_only", "true");
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: "Unknown error" }));
+    throw new Error(error.message || `Supported coins fetch failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export async function resolveSupportedPaymentCurrency(
+  preferredCoin?: string | null,
+  options: { business_id?: string } = {}
+): Promise<SupportedCurrency> {
+  const supported = await getSupportedCoins({
+    business_id: options.business_id,
+    active_only: true,
+  });
+  const coins = (supported.coins || []).filter(
+    (coin) => coin.is_active !== false && coin.has_wallet !== false
+  );
+
+  if (preferredCoin) {
+    const preferred = coins.find((coin) => coinMatchesPreference(coin, preferredCoin));
+    const currency = preferred ? coinToPaymentCurrency(preferred) : null;
+    if (currency) return currency;
+
+    throw new Error(
+      `CoinPayPortal does not have an active ${preferredCoin} wallet configured`
+    );
+  }
+
+  const firstSupported = coins.map(coinToPaymentCurrency).find(Boolean);
+  if (firstSupported) return firstSupported;
+
+  throw new Error("CoinPayPortal has no active wallet currencies configured");
+}
 
 // ─── Payment Status API ────────────────────────────────────────────────────
 

--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -70,6 +70,13 @@ export interface SupportedCoinsResponse {
   total?: number;
 }
 
+export interface BusinessWalletCurrency {
+  currency: string;
+  address: string;
+  is_active?: boolean;
+  [key: string]: unknown;
+}
+
 /**
  * Verify CoinPayPortal webhook signature
  * Format: X-CoinPay-Signature: t=timestamp,v1=signature
@@ -223,17 +230,133 @@ export function coinToPaymentCurrency(coin: SupportedCoin): SupportedCurrency | 
   return null;
 }
 
-function coinMatchesPreference(coin: SupportedCoin, preferredCoin: string): boolean {
+function coinMatchesPreference(
+  coin: SupportedCoin | BusinessWalletCurrency,
+  preferredCoin: string
+): boolean {
   const preferred = normalizeCoinSymbol(preferredCoin);
+  const record = coin as Record<string, unknown>;
   const candidates = [
-    coin.symbol,
-    coin.code,
-    coin.currency,
-    coin.id,
-    coin.name,
-  ].map(normalizeCoinSymbol);
+    record.symbol,
+    record.code,
+    record.currency,
+    record.id,
+    record.name,
+  ].map((value) => (typeof value === "string" ? normalizeCoinSymbol(value) : ""));
 
   return candidates.includes(preferred);
+}
+
+function getStringValue(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function extractWalletCurrenciesFromBusiness(
+  business: Record<string, unknown>
+): BusinessWalletCurrency[] {
+  const candidates = [
+    business.deposit_addresses,
+    business.depositAddresses,
+    business.wallet_addresses,
+    business.walletAddresses,
+    business.addresses,
+    business.wallets,
+    business.coins,
+  ];
+  const wallets = new Map<string, BusinessWalletCurrency>();
+
+  const addWallet = (currency: string | null, address: string | null, source?: Record<string, unknown>) => {
+    if (!currency || !address) return;
+    const key = normalizeCoinSymbol(currency);
+    if (!key || wallets.has(key)) return;
+    wallets.set(key, {
+      ...(source || {}),
+      currency: key,
+      address,
+      is_active:
+        source?.is_active === false ||
+        source?.active === false ||
+        source?.enabled === false
+          ? false
+          : true,
+    });
+  };
+
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+
+    if (Array.isArray(candidate)) {
+      for (const item of candidate) {
+        if (!item || typeof item !== "object") continue;
+        const record = item as Record<string, unknown>;
+        addWallet(
+          getStringValue(record, ["currency", "symbol", "coin", "chain", "network", "id"]),
+          getStringValue(record, ["address", "wallet_address", "walletAddress", "deposit_address", "depositAddress"]),
+          record
+        );
+      }
+      continue;
+    }
+
+    for (const [currency, value] of Object.entries(candidate as Record<string, unknown>)) {
+      if (typeof value === "string") {
+        addWallet(currency, value);
+      } else if (value && typeof value === "object") {
+        const record = value as Record<string, unknown>;
+        addWallet(
+          getStringValue(record, ["currency", "symbol", "coin", "chain", "network", "id"]) || currency,
+          getStringValue(record, ["address", "wallet_address", "walletAddress", "deposit_address", "depositAddress"]),
+          record
+        );
+      }
+    }
+  }
+
+  return [...wallets.values()].filter((wallet) => wallet.is_active !== false);
+}
+
+export async function getBusinessWalletCurrencies(options: {
+  business_id?: string;
+} = {}): Promise<BusinessWalletCurrency[]> {
+  const apiKey = process.env.COINPAY_API_KEY;
+  const businessId = options.business_id || process.env.COINPAY_MERCHANT_ID;
+
+  if (!apiKey || !businessId) {
+    throw new Error("CoinPayPortal credentials not configured");
+  }
+
+  const response = await fetch(`${COINPAY_API_URL}/businesses`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: "Unknown error" }));
+    throw new Error(error.message || `Business wallets fetch failed: ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    businesses?: Array<Record<string, unknown>>;
+    business?: Record<string, unknown>;
+  };
+  const businesses = data.businesses || (data.business ? [data.business] : []);
+  const business = businesses.find((entry) => entry.id === businessId);
+
+  if (!business) {
+    throw new Error(`CoinPayPortal business not found: ${businessId}`);
+  }
+
+  const wallets = extractWalletCurrenciesFromBusiness(business);
+  if (wallets.length === 0) {
+    throw new Error(`CoinPayPortal business ${businessId} has no wallet addresses configured`);
+  }
+
+  return wallets;
 }
 
 /**
@@ -273,13 +396,9 @@ export async function resolveSupportedPaymentCurrency(
   preferredCoin?: string | null,
   options: { business_id?: string } = {}
 ): Promise<SupportedCurrency> {
-  const supported = await getSupportedCoins({
+  const coins = await getBusinessWalletCurrencies({
     business_id: options.business_id,
-    active_only: true,
   });
-  const coins = (supported.coins || []).filter(
-    (coin) => coin.is_active !== false && coin.has_wallet !== false
-  );
 
   if (preferredCoin) {
     const preferred = coins.find((coin) => coinMatchesPreference(coin, preferredCoin));

--- a/supabase/migrations/20260522090000_add_gig_invoice_payment_metadata.sql
+++ b/supabase/migrations/20260522090000_add_gig_invoice_payment_metadata.sql
@@ -1,0 +1,5 @@
+ALTER TABLE gig_invoices
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN gig_invoices.metadata IS
+  'In-app CoinPay payment details for gig invoices, such as payment address, crypto amount, payment currency, checkout URL, and expiration.';


### PR DESCRIPTION
## Summary
- replace gig invoice hosted CoinPay invoice/send flow with an in-app CoinPay payment request
- store payment address/amount/currency metadata on gig_invoices and render payment details inside uGig instead of linking out to CoinPay
- update CoinPay webhooks to mark gig invoices paid/expired when payment events arrive

## Tests
- npm run test:run -- src/app/api/gigs/[id]/invoice/route.test.ts src/app/api/payments/coinpayportal/webhook/route.test.ts
- npm run type-check