### PR TITLE
Fetch CoinPay business wallets by merchant id

### DIFF
--- a/src/lib/coinpayportal.test.ts
+++ b/src/lib/coinpayportal.test.ts
@@ -127,16 +127,14 @@ describe("CoinPayPortal supported coins API", () => {
             { symbol: "SOL", name: "Solana", is_active: true, has_wallet: true },
             { symbol: "BTC", name: "Bitcoin", is_active: true, has_wallet: true },
           ],
-          businesses: [
-            {
-              id: "biz_123",
-              name: "uGig",
-              walletAddresses: {
-                SOL: "SolAddress1234567890",
-                BTC: "bc1qaddress1234567890",
-              },
+          business: {
+            id: "biz_123",
+            name: "uGig",
+            walletAddresses: {
+              SOL: "SolAddress1234567890",
+              BTC: "bc1qaddress1234567890",
             },
-          ],
+          },
         }),
       })
     );
@@ -175,7 +173,7 @@ describe("CoinPayPortal supported coins API", () => {
     const wallets = await getBusinessWalletCurrencies();
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://coinpayportal.com/api/businesses",
+      "https://coinpayportal.com/api/businesses/biz_123",
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Bearer ${process.env.COINPAY_API_KEY}`,

--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -329,7 +329,7 @@ export async function getBusinessWalletCurrencies(options: {
     throw new Error("CoinPayPortal credentials not configured");
   }
 
-  const response = await fetch(`${COINPAY_API_URL}/businesses`, {
+  const response = await fetch(`${COINPAY_API_URL}/businesses/${businessId}`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
@@ -340,12 +340,14 @@ export async function getBusinessWalletCurrencies(options: {
     throw new Error(error.message || `Business wallets fetch failed: ${response.status}`);
   }
 
-  const data = (await response.json()) as {
-    businesses?: Array<Record<string, unknown>>;
+  const data = (await response.json()) as Record<string, unknown> & {
     business?: Record<string, unknown>;
+    data?: Record<string, unknown>;
   };
-  const businesses = data.businesses || (data.business ? [data.business] : []);
-  const business = businesses.find((entry) => entry.id === businessId);
+  const business =
+    data.business ||
+    data.data ||
+    (data.id === businessId ? data : null);
 
   if (!business) {
     throw new Error(`CoinPayPortal business not found: ${businessId}`);


### PR DESCRIPTION
## Summary
- fetch the configured CoinPay business with `/api/businesses/{COINPAY_MERCHANT_ID}` instead of listing all businesses
- accept the single-business response shapes returned by the SDK/API (`business`, `data`, or root object)
- update the wallet-currency test to cover the direct merchant lookup

## Why
After #224 merged, creating an invoice for the accepted uGig invoice-flow gig still failed in production with `Business wallets fetch failed: 401`. The CoinPay SDK exposes `getBusiness(businessId)` via `/businesses/{businessId}`, so the invoice path should use that merchant-specific endpoint rather than the list endpoint.

## Validation
- `npm run test:run -- src/lib/coinpayportal.test.ts src/app/api/gigs/[id]/invoice/route.test.ts src/app/api/payments/coinpayportal/webhook/route.test.ts` -> 33 passed
- `npm run type-check` -> passed