### PR TITLE
feat(invoices): dashboard with Sent/Received tabs and poster-initiated pay

### DIFF
--- a/src/app/api/gigs/[id]/invoice/route.test.ts
+++ b/src/app/api/gigs/[id]/invoice/route.test.ts
@@ -107,7 +107,7 @@ describe("POST /api/gigs/[id]/invoice", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 403 when user is not the worker", async () => {
+  it("returns 403 when user is neither worker nor poster", async () => {
     const sb = mockSupabase({
       gigs: {
         select: vi.fn().mockReturnThis(),
@@ -234,6 +234,76 @@ describe("POST /api/gigs/[id]/invoice", () => {
     expect(resolveSupportedPaymentCurrency).toHaveBeenCalledWith(
       "SOL",
       expect.any(Object)
+    );
+  });
+
+  it("allows the poster to create an invoice for the accepted worker", async () => {
+    const gig = { id: GIG_ID, title: "Test Gig", poster_id: POSTER_ID, payment_coin: "SOL" };
+    const application = { id: APP_ID, applicant_id: WORKER_ID, status: "accepted", proposed_rate: 200 };
+    const invoiceRecord = { id: "local-inv-2", metadata: {} };
+
+    let inserted: any = null;
+    const sb = mockSupabase({
+      gigs: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: gig, error: null }),
+      },
+      applications: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: application, error: null }),
+      },
+      gig_invoices: {
+        insert: vi.fn((row: any) => {
+          inserted = row;
+          return {
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: invoiceRecord, error: null }),
+            }),
+          };
+        }),
+      },
+      profiles: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { username: "client", full_name: "The Client" }, error: null }),
+      },
+      notifications: {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      },
+    });
+
+    (getAuthContext as any).mockResolvedValue({ user: { id: POSTER_ID }, supabase: sb });
+    (resolveSupportedPaymentCurrency as any).mockResolvedValue("sol");
+    (createPayment as any).mockResolvedValue({
+      success: true,
+      payment_id: "cp-pay-2",
+      address: "So11111111111111111111111111111111111111112",
+      amount_crypto: 1.0,
+      currency: "sol",
+      expires_at: "2026-05-22T12:00:00Z",
+      payment: {
+        id: "cp-pay-2",
+        payment_address: "So11111111111111111111111111111111111111112",
+      },
+    });
+
+    const res = await POST(
+      req({ application_id: APP_ID, amount: 200 }),
+      params
+    );
+
+    expect(res.status).toBe(201);
+    expect(inserted).toMatchObject({
+      worker_id: WORKER_ID,
+      poster_id: POSTER_ID,
+      amount_usd: 200,
+    });
+    expect(createPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ initiated_by: "poster" }),
+      })
     );
   });
 });

--- a/src/app/api/gigs/[id]/invoice/route.ts
+++ b/src/app/api/gigs/[id]/invoice/route.ts
@@ -84,7 +84,8 @@ export async function POST(
       return NextResponse.json({ error: "Gig not found" }, { status: 404 });
     }
 
-    // Get application — must be accepted, user must be the applicant (worker)
+    // Get application — must be accepted; the user must be either the worker
+    // (self-billing) or the gig poster (paying the worker directly).
     const { data: application } = await supabase
       .from("applications")
       .select("id, applicant_id, status, proposed_rate")
@@ -99,9 +100,12 @@ export async function POST(
       );
     }
 
-    if (application.applicant_id !== user.id) {
+    const isWorker = application.applicant_id === user.id;
+    const isPoster = gig.poster_id === user.id;
+
+    if (!isWorker && !isPoster) {
       return NextResponse.json(
-        { error: "Only the accepted worker can create an invoice" },
+        { error: "Only the worker or gig poster can create an invoice" },
         { status: 403 }
       );
     }
@@ -112,6 +116,9 @@ export async function POST(
         { status: 400 }
       );
     }
+
+    const workerId = application.applicant_id;
+    const posterId = gig.poster_id;
 
     const appUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
     const regularBusinessId =
@@ -134,8 +141,9 @@ export async function POST(
         type: "gig_invoice",
         gig_id: gigId,
         application_id,
-        worker_id: user.id,
-        poster_id: gig.poster_id,
+        worker_id: workerId,
+        poster_id: posterId,
+        initiated_by: isPoster ? "poster" : "worker",
         invoice_currency: currency,
         payment_currency: paymentCurrency,
         platform: "ugig.net",
@@ -174,8 +182,8 @@ export async function POST(
       .insert({
         gig_id: gigId,
         application_id,
-        worker_id: user.id,
-        poster_id: gig.poster_id,
+        worker_id: workerId,
+        poster_id: posterId,
         coinpay_invoice_id: paymentId,
         amount_usd: amount,
         currency,
@@ -202,18 +210,25 @@ export async function POST(
       );
     }
 
-    // Notify the poster
-    const { data: workerProfile } = await supabase
+    // Notify the counterparty
+    const { data: actorProfile } = await supabase
       .from("profiles")
       .select("username, full_name")
       .eq("id", user.id)
       .single();
 
+    const actorName =
+      actorProfile?.full_name || actorProfile?.username || (isPoster ? "The client" : "A worker");
+    const recipientId = isPoster ? workerId : posterId;
+    const notificationBody = isPoster
+      ? `${actorName} prepared a $${amount} payment for "${gig.title}". Open the invoice to confirm.`
+      : `${actorName} sent you a $${amount} invoice for "${gig.title}".`;
+
     await supabase.from("notifications").insert({
-      user_id: gig.poster_id,
+      user_id: recipientId,
       type: "payment_received",
-      title: "Invoice received",
-      body: `${workerProfile?.full_name || workerProfile?.username || "A worker"} sent you a $${amount} invoice for "${gig.title}".`,
+      title: isPoster ? "Payment prepared" : "Invoice received",
+      body: notificationBody,
       data: {
         gig_id: gigId,
         invoice_id: invoice.id,

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthContext } from "@/lib/auth/get-user";
+
+// GET /api/invoices?role=sent|received|all
+// Returns invoices where the current user is worker (sent) and/or poster (received).
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { user, supabase } = auth;
+
+    const role = new URL(request.url).searchParams.get("role") ?? "all";
+
+    let query = (supabase as any)
+      .from("gig_invoices")
+      .select(
+        `
+        *,
+        gig:gigs (id, title, poster_id),
+        worker:profiles!worker_id (id, username, full_name, avatar_url),
+        poster:profiles!poster_id (id, username, full_name, avatar_url)
+      `
+      )
+      .order("created_at", { ascending: false });
+
+    if (role === "sent") {
+      query = query.eq("worker_id", user.id);
+    } else if (role === "received") {
+      query = query.eq("poster_id", user.id);
+    } else {
+      query = query.or(`worker_id.eq.${user.id},poster_id.eq.${user.id}`);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ data: data || [] });
+  } catch {
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/applications/page.tsx
+++ b/src/app/dashboard/applications/page.tsx
@@ -88,11 +88,19 @@ export default async function MyApplicationsPage() {
             Back to dashboard
           </Link>
 
-          <div className="mb-6">
-            <h1 className="text-3xl font-bold mb-2">My Applications</h1>
-            <p className="text-muted-foreground">
-              Track the status of your gig applications
-            </p>
+          <div className="mb-6 flex items-start justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold mb-2">My Applications</h1>
+              <p className="text-muted-foreground">
+                Track the status of your gig applications
+              </p>
+            </div>
+            <Link
+              href="/dashboard/invoices"
+              className="text-sm text-primary hover:underline whitespace-nowrap"
+            >
+              View invoices →
+            </Link>
           </div>
 
           {/* Stats */}
@@ -247,12 +255,22 @@ export default async function MyApplicationsPage() {
                             Applied {new Date(app.created_at).toLocaleDateString()}
                           </p>
                         </div>
-                        <Badge
-                          variant="secondary"
-                          className={`capitalize ${statusColors[app.status] || ""}`}
-                        >
-                          {app.status}
-                        </Badge>
+                        <div className="flex items-center gap-3">
+                          {app.status === "accepted" && (
+                            <Link
+                              href={`/gigs/${gig.id}`}
+                              className="text-sm text-primary hover:underline"
+                            >
+                              Send invoice
+                            </Link>
+                          )}
+                          <Badge
+                            variant="secondary"
+                            className={`capitalize ${statusColors[app.status] || ""}`}
+                          >
+                            {app.status}
+                          </Badge>
+                        </div>
                       </div>
                     </div>
                   );

--- a/src/app/dashboard/invoices/PayApplicantButton.tsx
+++ b/src/app/dashboard/invoices/PayApplicantButton.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Loader2, ExternalLink, DollarSign } from "lucide-react";
+
+interface PayApplicantButtonProps {
+  gigId: string;
+  applicationId: string;
+  suggestedAmount: number | null;
+  workerName: string;
+}
+
+export function PayApplicantButton({
+  gigId,
+  applicationId,
+  suggestedAmount,
+  workerName,
+}: PayApplicantButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [amount, setAmount] = useState(suggestedAmount?.toString() || "");
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [payUrl, setPayUrl] = useState<string | null>(null);
+
+  const submit = async () => {
+    const parsed = parseFloat(amount);
+    if (!parsed || parsed <= 0) {
+      setError("Enter a valid amount");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/gigs/${gigId}/invoice`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          application_id: applicationId,
+          amount: parsed,
+          currency: "USD",
+          notes: notes || undefined,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || "Failed to create invoice");
+        return;
+      }
+      setPayUrl(json.data?.pay_url || null);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (payUrl) {
+    return (
+      <a
+        href={payUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+      >
+        <ExternalLink className="h-4 w-4" />
+        Open payment link
+      </a>
+    );
+  }
+
+  if (!open) {
+    return (
+      <Button size="sm" onClick={() => setOpen(true)} className="gap-2">
+        <DollarSign className="h-4 w-4" />
+        Pay {workerName}
+      </Button>
+    );
+  }
+
+  return (
+    <div className="border border-border rounded-lg p-3 space-y-2 bg-background">
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">Amount (USD)</label>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0.00"
+          min="0.01"
+          step="0.01"
+          className="w-full text-sm border rounded-md px-2 py-1.5 bg-background"
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">Notes (optional)</label>
+        <input
+          type="text"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="What you're paying for"
+          className="w-full text-sm border rounded-md px-2 py-1.5 bg-background"
+        />
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <div className="flex gap-2">
+        <Button size="sm" disabled={submitting || !amount} onClick={submit} className="flex-1">
+          {submitting ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+          Create payment link
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setOpen(false)}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -1,0 +1,390 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  ArrowLeft,
+  ExternalLink,
+  CheckCircle2,
+  Clock,
+  Send,
+  FileText,
+  DollarSign,
+} from "lucide-react";
+import { PayApplicantButton } from "./PayApplicantButton";
+
+export const metadata = {
+  title: "Invoices | ugig.net",
+  description: "Send and pay invoices for gigs",
+};
+
+type TabKey = "received" | "sent";
+
+interface Counterparty {
+  id: string;
+  username: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+interface InvoiceRow {
+  id: string;
+  gig_id: string;
+  application_id: string;
+  worker_id: string;
+  poster_id: string;
+  amount_usd: number;
+  currency: string;
+  status: "draft" | "sent" | "paid" | "cancelled" | "expired";
+  pay_url: string | null;
+  notes: string | null;
+  due_date: string | null;
+  created_at: string;
+  gig: { id: string; title: string } | null;
+  worker: Counterparty | null;
+  poster: Counterparty | null;
+}
+
+interface AcceptedAppRow {
+  id: string;
+  gig_id: string;
+  applicant_id: string;
+  proposed_rate: number | null;
+  created_at: string;
+  gig: {
+    id: string;
+    title: string;
+    budget_min: number | null;
+    budget_max: number | null;
+  } | null;
+  applicant: Counterparty | null;
+}
+
+function statusBadge(status: InvoiceRow["status"]) {
+  switch (status) {
+    case "sent":
+      return (
+        <Badge className="gap-1 bg-blue-500/10 text-blue-600 border-blue-500/20">
+          <Send className="h-3 w-3" /> Awaiting payment
+        </Badge>
+      );
+    case "paid":
+      return (
+        <Badge className="gap-1 bg-green-500/10 text-green-600 border-green-500/20">
+          <CheckCircle2 className="h-3 w-3" /> Paid
+        </Badge>
+      );
+    case "draft":
+      return (
+        <Badge variant="secondary" className="gap-1">
+          <Clock className="h-3 w-3" /> Draft
+        </Badge>
+      );
+    case "cancelled":
+      return <Badge variant="secondary">Cancelled</Badge>;
+    case "expired":
+      return <Badge variant="secondary">Expired</Badge>;
+  }
+}
+
+function counterpartyName(c: Counterparty | null): string {
+  if (!c) return "Unknown";
+  return c.full_name || c.username || "Unknown";
+}
+
+export default async function InvoicesDashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/login?redirect=/dashboard/invoices");
+  }
+
+  const tabParam = (await searchParams).tab;
+  const tab: TabKey = tabParam === "sent" ? "sent" : "received";
+
+  const { data: invoiceData } = await (supabase as any)
+    .from("gig_invoices")
+    .select(
+      `
+      *,
+      gig:gigs (id, title),
+      worker:profiles!worker_id (id, username, full_name, avatar_url),
+      poster:profiles!poster_id (id, username, full_name, avatar_url)
+    `
+    )
+    .or(`worker_id.eq.${user.id},poster_id.eq.${user.id}`)
+    .order("created_at", { ascending: false });
+
+  const invoices = (invoiceData || []) as InvoiceRow[];
+  const sent = invoices.filter((i) => i.worker_id === user.id);
+  const received = invoices.filter((i) => i.poster_id === user.id);
+
+  // Find accepted applications on the user's own gigs that don't yet have an invoice
+  // so the poster can initiate payment directly.
+  const { data: posterGigs } = await supabase
+    .from("gigs")
+    .select("id")
+    .eq("poster_id", user.id);
+  const gigIds = (posterGigs || []).map((g) => g.id);
+
+  let acceptedNeedingInvoice: AcceptedAppRow[] = [];
+  if (gigIds.length > 0) {
+    const { data: acceptedApps } = await supabase
+      .from("applications")
+      .select(
+        `
+        id, gig_id, applicant_id, proposed_rate, created_at,
+        gig:gigs (id, title, budget_min, budget_max),
+        applicant:profiles!applicant_id (id, username, full_name, avatar_url)
+      `
+      )
+      .in("gig_id", gigIds)
+      .eq("status", "accepted")
+      .order("created_at", { ascending: false });
+
+    const invoicedAppIds = new Set(received.map((i) => i.application_id));
+    acceptedNeedingInvoice = ((acceptedApps || []) as unknown as AcceptedAppRow[]).filter(
+      (a) => !invoicedAppIds.has(a.id)
+    );
+  }
+
+  const totalOwed = received
+    .filter((i) => i.status === "sent")
+    .reduce((s, i) => s + Number(i.amount_usd || 0), 0);
+  const totalEarned = sent
+    .filter((i) => i.status === "paid")
+    .reduce((s, i) => s + Number(i.amount_usd || 0), 0);
+  const totalPendingForMe = sent
+    .filter((i) => i.status === "sent")
+    .reduce((s, i) => s + Number(i.amount_usd || 0), 0);
+
+  const list = tab === "sent" ? sent : received;
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="max-w-5xl mx-auto">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to dashboard
+        </Link>
+
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold mb-2">Invoices</h1>
+          <p className="text-muted-foreground">
+            Pay accepted applicants, and track invoices you&apos;ve sent for gigs you worked on.
+          </p>
+        </div>
+
+        {/* Stats */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+          <div className="p-5 bg-card rounded-lg border border-border shadow-sm">
+            <p className="text-2xl font-bold text-blue-600">${totalOwed.toFixed(2)}</p>
+            <p className="text-sm text-muted-foreground mt-1">You owe (unpaid received)</p>
+          </div>
+          <div className="p-5 bg-card rounded-lg border border-border shadow-sm">
+            <p className="text-2xl font-bold text-yellow-600">${totalPendingForMe.toFixed(2)}</p>
+            <p className="text-sm text-muted-foreground mt-1">Awaiting payment to you</p>
+          </div>
+          <div className="p-5 bg-card rounded-lg border border-border shadow-sm">
+            <p className="text-2xl font-bold text-green-600">${totalEarned.toFixed(2)}</p>
+            <p className="text-sm text-muted-foreground mt-1">Earned (paid invoices)</p>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 border-b border-border mb-6">
+          <Link
+            href="/dashboard/invoices?tab=received"
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              tab === "received"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Invoices Received ({received.length})
+          </Link>
+          <Link
+            href="/dashboard/invoices?tab=sent"
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              tab === "sent"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Invoices Sent ({sent.length})
+          </Link>
+        </div>
+
+        {/* Accepted applicants without an invoice — only shown on Received tab */}
+        {tab === "received" && acceptedNeedingInvoice.length > 0 && (
+          <div className="mb-8">
+            <h2 className="text-lg font-semibold mb-2">
+              Accepted applicants awaiting payment
+            </h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              These workers were accepted but no invoice exists yet. Generate a payment link
+              now and they&apos;ll be notified.
+            </p>
+            <div className="space-y-3">
+              {acceptedNeedingInvoice.map((app) => {
+                const suggested =
+                  app.proposed_rate ||
+                  app.gig?.budget_min ||
+                  app.gig?.budget_max ||
+                  null;
+                return (
+                  <div
+                    key={app.id}
+                    className="p-4 bg-card rounded-lg border border-border shadow-sm space-y-3"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="font-medium">{counterpartyName(app.applicant)}</p>
+                        <Link
+                          href={`/gigs/${app.gig_id}`}
+                          className="text-sm text-muted-foreground hover:text-primary inline-flex items-center gap-1"
+                        >
+                          {app.gig?.title || "Gig"}
+                          <ExternalLink className="h-3 w-3" />
+                        </Link>
+                      </div>
+                      {suggested && (
+                        <div className="text-sm text-muted-foreground">
+                          Suggested: ${suggested}
+                        </div>
+                      )}
+                    </div>
+                    <PayApplicantButton
+                      gigId={app.gig_id}
+                      applicationId={app.id}
+                      suggestedAmount={suggested}
+                      workerName={counterpartyName(app.applicant)}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Invoice list */}
+        <div>
+          <h2 className="text-lg font-semibold mb-4">
+            {tab === "received" ? "Invoices from workers" : "Invoices you've sent"}
+          </h2>
+
+          {list.length === 0 ? (
+            <div className="text-center py-12 bg-card rounded-lg border border-border">
+              <FileText className="h-10 w-10 mx-auto text-muted-foreground/50 mb-3" />
+              <p className="text-muted-foreground mb-1">
+                {tab === "received" ? "No invoices received yet" : "No invoices sent yet"}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {tab === "received"
+                  ? "When a worker bills you (or you initiate a payment), it will appear here."
+                  : "Once you're accepted on a gig, you can send an invoice from the gig page."}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {list.map((inv) => {
+                const counterparty =
+                  tab === "received" ? inv.worker : inv.poster;
+                return (
+                  <div
+                    key={inv.id}
+                    className="p-4 bg-card rounded-lg border border-border shadow-sm hover:shadow-md transition-shadow"
+                  >
+                    <div className="flex items-start justify-between gap-4 mb-3">
+                      <div>
+                        <div className="flex items-center gap-2 mb-1">
+                          <DollarSign className="h-4 w-4 text-muted-foreground" />
+                          <span className="text-lg font-semibold">
+                            ${Number(inv.amount_usd).toFixed(2)}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {inv.currency}
+                          </span>
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          {tab === "received" ? "From " : "To "}
+                          <span className="font-medium text-foreground">
+                            {counterpartyName(counterparty)}
+                          </span>
+                          {inv.gig && (
+                            <>
+                              {" · "}
+                              <Link
+                                href={`/gigs/${inv.gig.id}`}
+                                className="hover:text-primary inline-flex items-center gap-1"
+                              >
+                                {inv.gig.title}
+                                <ExternalLink className="h-3 w-3" />
+                              </Link>
+                            </>
+                          )}
+                        </p>
+                      </div>
+                      {statusBadge(inv.status)}
+                    </div>
+
+                    {inv.notes && (
+                      <p className="text-sm text-muted-foreground mb-3">{inv.notes}</p>
+                    )}
+
+                    <div className="flex items-center justify-between text-xs text-muted-foreground">
+                      <span>
+                        Created {new Date(inv.created_at).toLocaleDateString()}
+                        {inv.due_date && (
+                          <> · Due {new Date(inv.due_date).toLocaleDateString()}</>
+                        )}
+                      </span>
+                      {tab === "received" && inv.status === "sent" && inv.pay_url && (
+                        <a
+                          href={inv.pay_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                          Pay now
+                        </a>
+                      )}
+                      {tab === "sent" && inv.status === "sent" && inv.pay_url && (
+                        <a
+                          href={inv.pay_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                        >
+                          <ExternalLink className="h-3 w-3" />
+                          View payment link
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-8 text-center">
+          <Link href="/gigs">
+            <Button variant="outline">Browse gigs</Button>
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
   FolderOpen,
   Megaphone,
   HandCoins,
+  Receipt,
 } from "lucide-react";
 import { FundingDashboard } from "@/components/funding/FundingDashboard";
 
@@ -320,6 +321,19 @@ export default async function DashboardPage() {
                   <h3 className="font-medium">My Applications</h3>
                   <p className="text-sm text-muted-foreground mt-1">
                     Track your job applications
+                  </p>
+                </Link>
+
+                <Link
+                  href="/dashboard/invoices"
+                  className="p-4 border border-border rounded-lg shadow-sm hover:shadow-md hover:border-green-500/40 hover:bg-green-500/5 transition-all duration-200"
+                >
+                  <div className="p-2.5 bg-green-500/10 rounded-xl w-fit mb-3">
+                    <Receipt className="h-5 w-5 text-green-500" />
+                  </div>
+                  <h3 className="font-medium">Invoices</h3>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Pay accepted applicants and view invoices
                   </p>
                 </Link>
 

--- a/supabase/migrations/20260522000000_invoices_poster_can_create.sql
+++ b/supabase/migrations/20260522000000_invoices_poster_can_create.sql
@@ -1,0 +1,12 @@
+-- Allow gig posters to create invoices for accepted applicants, in addition
+-- to the existing worker-initiated flow. The poster pays via CoinPayPortal's
+-- pay_url either way; this just lets a poster nudge the payment instead of
+-- waiting for the worker to submit an invoice.
+
+CREATE POLICY "Posters can create invoices for their gigs"
+  ON gig_invoices FOR INSERT
+  WITH CHECK (auth.uid() = poster_id);
+
+CREATE POLICY "Posters can update invoices on their gigs"
+  ON gig_invoices FOR UPDATE
+  USING (auth.uid() = poster_id);


### PR DESCRIPTION
## Summary

Workers could already send CoinPay invoices per-gig via the existing `InvoiceButton`, but **posters had no consolidated way to find and pay accepted applicants**. This PR adds a `/dashboard/invoices` page that aggregates invoices across gigs and lets the poster generate a CoinPay payment link inline for any accepted applicant who hasn't been billed yet.

- **Migration**: RLS policies allowing posters (in addition to workers) to insert/update `gig_invoices`.
- **API**:
  - `POST /api/gigs/[id]/invoice` now accepts poster-initiated invoices; tagged `initiated_by: "poster"` in CoinPay metadata; notifies the worker instead of the poster.
  - New `GET /api/invoices?role=sent|received|all` for cross-gig listing.
- **UI** — `/dashboard/invoices`:
  - Tabs: **Invoices Received** (default) + **Invoices Sent**.
  - Stats row: total owed / awaiting payment to you / earned.
  - Received tab surfaces "Accepted applicants awaiting payment" — every accepted application without an invoice gets an inline **Pay \$X** button that creates a CoinPay payment link in one click.
  - "Pay now" / "View payment link" actions on each existing invoice.
- **Nav**: new Invoices card on `/dashboard` and a quick link from `/dashboard/applications`.

## Known gap (out of scope)

There's no CoinPay webhook handler that flips `gig_invoices.status` from `sent` → `paid` after payment confirms. Status stays as `sent` even after the buyer pays. The escrow flow already has webhook integration but invoices don't — worth a small follow-up.

## Test plan

- [ ] Run the migration: `psql ... -f supabase/migrations/20260522000000_invoices_poster_can_create.sql`
- [ ] As a gig poster with at least one accepted applicant on a gig, visit `/dashboard/invoices` and verify the "Accepted applicants awaiting payment" section lists them.
- [ ] Click "Pay \$X" → confirm the form opens, submit → confirm a CoinPay payment link is returned.
- [ ] Open the link in a new tab and confirm the CoinPay invoice has the right amount + metadata.
- [ ] As a worker on a separate account, send an invoice from the gig page → confirm it appears on the Sent tab.
- [ ] Verify RLS: a third unrelated user querying `/api/invoices` sees nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)