### PR TITLE
feat(bounties): new section for joinpond-style bounties with structured forms

### DIFF
--- a/src/app/api/bounties/[id]/route.ts
+++ b/src/app/api/bounties/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { updateBountySchema } from "@/lib/bounties";
+
+// GET /api/bounties/[id] — single bounty, public if open
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from("bounties" as any)
+      .select(
+        `
+        *,
+        creator:profiles!creator_id (id, username, full_name, avatar_url)
+      `
+      )
+      .eq("id", id)
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ error: "Bounty not found" }, { status: 404 });
+    }
+    return NextResponse.json({ data });
+  } catch {
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}
+
+// PATCH /api/bounties/[id] — creator only
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { user, supabase } = auth;
+
+    const body = await request.json();
+    const parsed = updateBountySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { data: existing } = await (supabase as any)
+      .from("bounties")
+      .select("creator_id")
+      .eq("id", id)
+      .single();
+    if (!existing) {
+      return NextResponse.json({ error: "Bounty not found" }, { status: 404 });
+    }
+    if (existing.creator_id !== user.id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { data, error } = await (supabase as any)
+      .from("bounties")
+      .update(parsed.data)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ data });
+  } catch {
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
+++ b/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { createInvoice, sendInvoice } from "@/lib/coinpayportal";
+
+// POST /api/bounties/[id]/submissions/[sid]/pay
+// Creator generates a CoinPay payment link for an approved submission.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; sid: string }> }
+) {
+  try {
+    const { id: bountyId, sid } = await params;
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { user, supabase } = auth;
+
+    const { data: bounty } = await (supabase as any)
+      .from("bounties")
+      .select("id, creator_id, title, payout_usd")
+      .eq("id", bountyId)
+      .single();
+    if (!bounty) {
+      return NextResponse.json({ error: "Bounty not found" }, { status: 404 });
+    }
+    if (bounty.creator_id !== user.id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { data: submission } = await (supabase as any)
+      .from("bounty_submissions")
+      .select("id, submitter_id, status, payout_status, pay_url, coinpay_invoice_id")
+      .eq("id", sid)
+      .eq("bounty_id", bountyId)
+      .single();
+    if (!submission) {
+      return NextResponse.json({ error: "Submission not found" }, { status: 404 });
+    }
+    if (submission.status !== "approved") {
+      return NextResponse.json(
+        { error: "Only approved submissions can be paid" },
+        { status: 400 }
+      );
+    }
+
+    // Already has a pay link — return it
+    if (submission.pay_url) {
+      return NextResponse.json({
+        data: {
+          submission_id: sid,
+          coinpay_invoice_id: submission.coinpay_invoice_id,
+          pay_url: submission.pay_url,
+        },
+      });
+    }
+
+    // Create CoinPay invoice
+    const invoiceResult = await createInvoice({
+      amount: Number(bounty.payout_usd),
+      currency: "USD",
+      notes: `Bounty payout: ${bounty.title}`,
+      metadata: {
+        bounty_id: bountyId,
+        submission_id: sid,
+        creator_id: user.id,
+        submitter_id: submission.submitter_id,
+        kind: "bounty",
+        platform: "ugig.net",
+      },
+    });
+    const sendResult = await sendInvoice(invoiceResult.invoice.id);
+    const payUrl = sendResult.invoice.pay_url || invoiceResult.invoice.pay_url;
+
+    const { error: updateError } = await (supabase as any)
+      .from("bounty_submissions")
+      .update({
+        payout_status: "invoiced",
+        coinpay_invoice_id: invoiceResult.invoice.id,
+        pay_url: payUrl,
+      })
+      .eq("id", sid);
+
+    if (updateError) {
+      return NextResponse.json({ error: updateError.message }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      data: {
+        submission_id: sid,
+        coinpay_invoice_id: invoiceResult.invoice.id,
+        pay_url: payUrl,
+      },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unexpected error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/bounties/[id]/submissions/[sid]/route.ts
+++ b/src/app/api/bounties/[id]/submissions/[sid]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { reviewSubmissionSchema } from "@/lib/bounties";
+
+// PATCH /api/bounties/[id]/submissions/[sid] — creator approves/rejects
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; sid: string }> }
+) {
+  try {
+    const { id: bountyId, sid } = await params;
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { user, supabase } = auth;
+
+    const body = await request.json();
+    const parsed = reviewSubmissionSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    // Verify caller is the bounty creator
+    const { data: bounty } = await (supabase as any)
+      .from("bounties")
+      .select("id, creator_id, title")
+      .eq("id", bountyId)
+      .single();
+    if (!bounty) {
+      return NextResponse.json({ error: "Bounty not found" }, { status: 404 });
+    }
+    if (bounty.creator_id !== user.id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { data: submission, error } = await (supabase as any)
+      .from("bounty_submissions")
+      .update({
+        status: parsed.data.status,
+        review_notes: parsed.data.review_notes || null,
+        reviewed_by: user.id,
+        reviewed_at: new Date().toISOString(),
+      })
+      .eq("id", sid)
+      .eq("bounty_id", bountyId)
+      .select()
+      .single();
+
+    if (error || !submission) {
+      return NextResponse.json(
+        { error: error?.message || "Submission not found" },
+        { status: 400 }
+      );
+    }
+
+    // Notify submitter
+    await supabase.from("notifications").insert({
+      user_id: submission.submitter_id,
+      type: "payment_received",
+      title:
+        parsed.data.status === "approved"
+          ? "Bounty submission approved"
+          : "Bounty submission rejected",
+      body: `Your submission to "${bounty.title}" was ${parsed.data.status}.`,
+      data: { bounty_id: bountyId, submission_id: sid },
+    });
+
+    return NextResponse.json({ data: submission });
+  } catch {
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/src/app/api/bounties/[id]/submissions/route.ts
+++ b/src/app/api/bounties/[id]/submissions/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { submitAnswersSchema, validateAnswers, BountyQuestion } from "@/lib/bounties";
+
+// GET /api/bounties/[id]/submissions — creator sees all, submitter sees own
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { user, supabase } = auth;
+
+    // RLS will filter to (submitter or bounty creator) automatically.
+    const { data, error } = await (supabase as any)
+      .from("bounty_submissions")
+      .select(
+        `
+        *,
+        submitter:profiles!submitter_id (id, username, full_name, avatar_url)
+      `
+      )
+      .eq("bounty_id", id)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    void user;
+    return NextResponse.json({ data: data || [] });
+  } catch {
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}
+
+// POST /api/bounties/[id]/submissions — submit answers (must be logged in)
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { user, supabase } = auth;
+
+    const body = await request.json();
+    const parsed = submitAnswersSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    // Load the bounty to validate answers + enforce open/max_submissions
+    const { data: bounty } = await (supabase as any)
+      .from("bounties")
+      .select("id, creator_id, title, status, max_submissions, questions")
+      .eq("id", id)
+      .single();
+    if (!bounty) {
+      return NextResponse.json({ error: "Bounty not found" }, { status: 404 });
+    }
+    if (bounty.creator_id === user.id) {
+      return NextResponse.json(
+        { error: "You can't submit to your own bounty" },
+        { status: 400 }
+      );
+    }
+    if (bounty.status !== "open") {
+      return NextResponse.json(
+        { error: "This bounty is not accepting submissions" },
+        { status: 400 }
+      );
+    }
+
+    const questions = (bounty.questions || []) as BountyQuestion[];
+    const validationError = validateAnswers(questions, parsed.data.answers);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
+    }
+
+    // Check submission cap. Done in two steps (count + insert) — a race here
+    // could let one extra submission slip past, which is acceptable.
+    if (bounty.max_submissions) {
+      const { count } = await (supabase as any)
+        .from("bounty_submissions")
+        .select("id", { count: "exact", head: true })
+        .eq("bounty_id", id);
+      if ((count ?? 0) >= bounty.max_submissions) {
+        // Auto-close so the next visitor sees it as closed
+        await (supabase as any)
+          .from("bounties")
+          .update({ status: "closed" })
+          .eq("id", id);
+        return NextResponse.json(
+          { error: "This bounty has reached its submission cap" },
+          { status: 400 }
+        );
+      }
+    }
+
+    const { data, error } = await (supabase as any)
+      .from("bounty_submissions")
+      .insert({
+        bounty_id: id,
+        submitter_id: user.id,
+        answers: parsed.data.answers,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      // Unique violation = duplicate submission
+      if ((error as { code?: string }).code === "23505") {
+        return NextResponse.json(
+          { error: "You've already submitted to this bounty" },
+          { status: 409 }
+        );
+      }
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    // After insert: if we just hit the cap, auto-close.
+    if (bounty.max_submissions) {
+      const { count } = await (supabase as any)
+        .from("bounty_submissions")
+        .select("id", { count: "exact", head: true })
+        .eq("bounty_id", id);
+      if ((count ?? 0) >= bounty.max_submissions) {
+        await (supabase as any)
+          .from("bounties")
+          .update({ status: "closed" })
+          .eq("id", id);
+      }
+    }
+
+    // Notify the creator
+    const { data: submitterProfile } = await supabase
+      .from("profiles")
+      .select("username, full_name")
+      .eq("id", user.id)
+      .single();
+    const name =
+      submitterProfile?.full_name || submitterProfile?.username || "Someone";
+    await supabase.from("notifications").insert({
+      user_id: bounty.creator_id,
+      type: "payment_received",
+      title: "New bounty submission",
+      body: `${name} submitted to "${bounty.title}".`,
+      data: { bounty_id: id, submission_id: data.id },
+    });
+
+    return NextResponse.json({ data }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/src/app/api/bounties/route.ts
+++ b/src/app/api/bounties/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { createClient } from "@/lib/supabase/server";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { createBountySchema } from "@/lib/bounties";
+
+// GET /api/bounties — public list of open bounties
+export async function GET(request: NextRequest) {
+  try {
+    const params = request.nextUrl.searchParams;
+    const status = params.get("status") || "open";
+    const limit = Math.min(Number(params.get("limit") || 50), 100);
+    const page = Math.max(Number(params.get("page") || 1), 1);
+    const offset = (page - 1) * limit;
+
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from("bounties" as any)
+      .select(
+        `
+        id, title, description, payout_usd, payout_currency, max_submissions,
+        status, closes_at, created_at,
+        creator:profiles!creator_id (id, username, full_name, avatar_url)
+      `
+      )
+      .eq("status", status)
+      .order("created_at", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ data: data || [] });
+  } catch {
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}
+
+// POST /api/bounties — create a bounty
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { user, supabase } = auth;
+
+    const body = await request.json();
+    const parsed = createBountySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    // Assign ids to any questions missing them
+    const questions = parsed.data.questions.map((q) => ({
+      ...q,
+      id: q.id || randomUUID(),
+    }));
+
+    const { data, error } = await (supabase as any)
+      .from("bounties")
+      .insert({
+        creator_id: user.id,
+        title: parsed.data.title,
+        description: parsed.data.description,
+        payout_usd: parsed.data.payout_usd,
+        payout_currency: parsed.data.payout_currency || "USD",
+        max_submissions: parsed.data.max_submissions ?? null,
+        closes_at: parsed.data.closes_at || null,
+        questions,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ data }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/src/app/bounties/[id]/ReviewPanel.tsx
+++ b/src/app/bounties/[id]/ReviewPanel.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  ExternalLink,
+  DollarSign,
+} from "lucide-react";
+
+interface Question {
+  id: string;
+  type: "short_text" | "long_text" | "multiple_choice";
+  label: string;
+  required: boolean;
+  options?: string[];
+}
+
+interface Submission {
+  id: string;
+  submitter_id: string;
+  answers: { question_id: string; value: string | string[] }[];
+  status: "pending" | "approved" | "rejected";
+  payout_status: "unpaid" | "invoiced" | "paid";
+  review_notes: string | null;
+  reviewed_at: string | null;
+  pay_url: string | null;
+  created_at: string;
+  submitter: {
+    id: string;
+    username: string | null;
+    full_name: string | null;
+    avatar_url: string | null;
+  } | null;
+}
+
+interface ReviewPanelProps {
+  bountyId: string;
+  payoutUsd: number;
+  questions: Question[];
+  submissions: Submission[];
+}
+
+export function ReviewPanel({
+  bountyId,
+  payoutUsd,
+  questions,
+  submissions,
+}: ReviewPanelProps) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const questionLabel = (qid: string) =>
+    questions.find((q) => q.id === qid)?.label || qid;
+
+  const review = async (sid: string, status: "approved" | "rejected") => {
+    setError(null);
+    setBusyId(sid);
+    try {
+      const res = await fetch(
+        `/api/bounties/${bountyId}/submissions/${sid}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        }
+      );
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || "Failed");
+        return;
+      }
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const pay = async (sid: string) => {
+    setError(null);
+    setBusyId(sid);
+    try {
+      const res = await fetch(
+        `/api/bounties/${bountyId}/submissions/${sid}/pay`,
+        { method: "POST" }
+      );
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || "Failed to create payment link");
+        return;
+      }
+      if (json.data?.pay_url) {
+        window.open(json.data.pay_url, "_blank", "noopener,noreferrer");
+      }
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const pending = submissions.filter((s) => s.status === "pending");
+  const reviewed = submissions.filter((s) => s.status !== "pending");
+
+  if (submissions.length === 0) {
+    return (
+      <div className="p-6 text-center text-sm text-muted-foreground border border-dashed border-border rounded-lg">
+        No submissions yet.
+      </div>
+    );
+  }
+
+  const renderCard = (s: Submission) => {
+    const name = s.submitter?.full_name || s.submitter?.username || "Unknown";
+    return (
+      <div
+        key={s.id}
+        className="p-4 bg-card border border-border rounded-lg space-y-3"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-medium">{name}</p>
+            <p className="text-xs text-muted-foreground">
+              Submitted {new Date(s.created_at).toLocaleString()}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {s.status === "pending" && (
+              <Badge variant="secondary" className="gap-1">
+                <Clock className="h-3 w-3" /> Pending
+              </Badge>
+            )}
+            {s.status === "approved" && (
+              <Badge className="gap-1 bg-green-500/10 text-green-600 border-green-500/20">
+                <CheckCircle2 className="h-3 w-3" /> Approved
+              </Badge>
+            )}
+            {s.status === "rejected" && (
+              <Badge variant="secondary" className="gap-1 text-destructive">
+                <XCircle className="h-3 w-3" /> Rejected
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {s.answers.map((a, i) => (
+            <div key={i}>
+              <p className="text-xs font-medium text-muted-foreground">
+                {questionLabel(a.question_id)}
+              </p>
+              <p className="text-sm whitespace-pre-wrap">
+                {Array.isArray(a.value) ? a.value.join(", ") : a.value || "—"}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 pt-2 border-t">
+          {s.status === "pending" && (
+            <>
+              <Button
+                size="sm"
+                disabled={busyId === s.id}
+                onClick={() => review(s.id, "approved")}
+                className="gap-1"
+              >
+                {busyId === s.id ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <CheckCircle2 className="h-3 w-3" />
+                )}
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={busyId === s.id}
+                onClick={() => review(s.id, "rejected")}
+                className="gap-1"
+              >
+                <XCircle className="h-3 w-3" />
+                Reject
+              </Button>
+            </>
+          )}
+
+          {s.status === "approved" && s.payout_status === "unpaid" && (
+            <Button
+              size="sm"
+              disabled={busyId === s.id}
+              onClick={() => pay(s.id)}
+              className="gap-1"
+            >
+              {busyId === s.id ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <DollarSign className="h-3 w-3" />
+              )}
+              Pay ${payoutUsd}
+            </Button>
+          )}
+
+          {s.status === "approved" &&
+            s.payout_status === "invoiced" &&
+            s.pay_url && (
+              <a
+                href={s.pay_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+              >
+                <ExternalLink className="h-3 w-3" />
+                Open payment link
+              </a>
+            )}
+
+          {s.payout_status === "paid" && (
+            <Badge className="gap-1 bg-green-500/10 text-green-600 border-green-500/20">
+              <CheckCircle2 className="h-3 w-3" /> Paid
+            </Badge>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {pending.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold mb-2 text-muted-foreground">
+            Awaiting review ({pending.length})
+          </h3>
+          <div className="space-y-3">{pending.map(renderCard)}</div>
+        </div>
+      )}
+
+      {reviewed.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold mb-2 text-muted-foreground">
+            Reviewed ({reviewed.length})
+          </h3>
+          <div className="space-y-3">{reviewed.map(renderCard)}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/bounties/[id]/SubmitForm.tsx
+++ b/src/app/bounties/[id]/SubmitForm.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Loader2, CheckCircle2 } from "lucide-react";
+
+interface Question {
+  id: string;
+  type: "short_text" | "long_text" | "multiple_choice";
+  label: string;
+  required: boolean;
+  options?: string[];
+}
+
+interface SubmitFormProps {
+  bountyId: string;
+  questions: Question[];
+}
+
+export function SubmitForm({ bountyId, questions }: SubmitFormProps) {
+  const router = useRouter();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const setValue = (id: string, v: string) => {
+    setValues((cur) => ({ ...cur, [id]: v }));
+  };
+
+  const submit = async () => {
+    setError(null);
+    const answers = questions
+      .map((q) => ({
+        question_id: q.id,
+        value: values[q.id] ?? "",
+      }))
+      .filter((a) => a.value !== "" || questions.find((q) => q.id === a.question_id)?.required);
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/bounties/${bountyId}/submissions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answers }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || "Failed to submit");
+        return;
+      }
+      setSuccess(true);
+      setTimeout(() => router.refresh(), 800);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="p-6 border border-green-500/20 bg-green-500/5 rounded-lg text-center">
+        <CheckCircle2 className="h-10 w-10 text-green-500 mx-auto mb-3" />
+        <p className="font-medium mb-1">Submission received</p>
+        <p className="text-sm text-muted-foreground">
+          The bounty creator will review and notify you of the decision.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {questions.map((q, idx) => (
+        <div key={q.id} className="space-y-2">
+          <label className="text-sm font-medium">
+            {idx + 1}. {q.label}
+            {q.required && <span className="text-destructive ml-1">*</span>}
+          </label>
+          {q.type === "short_text" && (
+            <input
+              type="text"
+              value={values[q.id] || ""}
+              onChange={(e) => setValue(q.id, e.target.value)}
+              className="w-full border rounded-md px-3 py-2 bg-background"
+              maxLength={500}
+            />
+          )}
+          {q.type === "long_text" && (
+            <textarea
+              value={values[q.id] || ""}
+              onChange={(e) => setValue(q.id, e.target.value)}
+              rows={4}
+              className="w-full border rounded-md px-3 py-2 bg-background resize-y"
+              maxLength={5000}
+            />
+          )}
+          {q.type === "multiple_choice" && (
+            <div className="space-y-1.5">
+              {(q.options || []).map((opt) => (
+                <label
+                  key={opt}
+                  className="flex items-center gap-2 p-2 rounded-md border border-border hover:bg-accent cursor-pointer text-sm"
+                >
+                  <input
+                    type="radio"
+                    name={q.id}
+                    value={opt}
+                    checked={values[q.id] === opt}
+                    onChange={(e) => setValue(q.id, e.target.value)}
+                  />
+                  {opt}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {error && (
+        <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Button onClick={submit} disabled={submitting} className="w-full gap-2">
+        {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+        Submit
+      </Button>
+    </div>
+  );
+}

--- a/src/app/bounties/[id]/page.tsx
+++ b/src/app/bounties/[id]/page.tsx
@@ -1,0 +1,223 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { Header } from "@/components/layout/Header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  ArrowLeft,
+  DollarSign,
+  Users,
+  Clock,
+  Lock,
+} from "lucide-react";
+import { SubmitForm } from "./SubmitForm";
+import { ReviewPanel } from "./ReviewPanel";
+
+interface BountyDetail {
+  id: string;
+  creator_id: string;
+  title: string;
+  description: string;
+  payout_usd: number;
+  payout_currency: string;
+  max_submissions: number | null;
+  status: "open" | "paused" | "closed";
+  questions: {
+    id: string;
+    type: "short_text" | "long_text" | "multiple_choice";
+    label: string;
+    required: boolean;
+    options?: string[];
+  }[];
+  created_at: string;
+  creator: {
+    id: string;
+    username: string | null;
+    full_name: string | null;
+    avatar_url: string | null;
+  } | null;
+}
+
+export default async function BountyDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data: bountyData } = await supabase
+    .from("bounties" as any)
+    .select(
+      `
+      *,
+      creator:profiles!creator_id (id, username, full_name, avatar_url)
+    `
+    )
+    .eq("id", id)
+    .single();
+
+  if (!bountyData) {
+    notFound();
+  }
+  const bounty = bountyData as unknown as BountyDetail;
+
+  const isCreator = user?.id === bounty.creator_id;
+
+  // Submission count
+  const { count: submissionCount } = await (supabase as any)
+    .from("bounty_submissions")
+    .select("id", { count: "exact", head: true })
+    .eq("bounty_id", id);
+
+  // Check if current user has already submitted
+  let mySubmission: { id: string; status: string } | null = null;
+  if (user && !isCreator) {
+    const { data } = await (supabase as any)
+      .from("bounty_submissions")
+      .select("id, status")
+      .eq("bounty_id", id)
+      .eq("submitter_id", user.id)
+      .maybeSingle();
+    mySubmission = data;
+  }
+
+  // For the creator: load all submissions
+  let submissions: any[] = [];
+  if (isCreator) {
+    const { data } = await (supabase as any)
+      .from("bounty_submissions")
+      .select(
+        `
+        *,
+        submitter:profiles!submitter_id (id, username, full_name, avatar_url)
+      `
+      )
+      .eq("bounty_id", id)
+      .order("created_at", { ascending: false });
+    submissions = data || [];
+  }
+
+  const creatorName =
+    bounty.creator?.full_name || bounty.creator?.username || "Anonymous";
+
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-3xl mx-auto">
+          <Link
+            href="/bounties"
+            className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            All bounties
+          </Link>
+
+          <div className="bg-card border border-border rounded-lg p-6 shadow-sm mb-6">
+            <div className="flex items-start justify-between gap-4 mb-4">
+              <div>
+                <h1 className="text-2xl font-bold mb-2">{bounty.title}</h1>
+                <p className="text-sm text-muted-foreground">
+                  Posted by{" "}
+                  {bounty.creator?.username ? (
+                    <Link
+                      href={`/u/${bounty.creator.username}`}
+                      className="hover:text-foreground hover:underline"
+                    >
+                      {creatorName}
+                    </Link>
+                  ) : (
+                    creatorName
+                  )}
+                </p>
+              </div>
+              <Badge className="bg-green-500/10 text-green-600 border-green-500/20 text-base">
+                <DollarSign className="h-4 w-4 mr-0.5" />
+                {Number(bounty.payout_usd).toFixed(2)}
+              </Badge>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground mb-6">
+              <div className="inline-flex items-center gap-1.5">
+                <Users className="h-4 w-4" />
+                {submissionCount || 0} submission
+                {(submissionCount ?? 0) === 1 ? "" : "s"}
+                {bounty.max_submissions && ` / ${bounty.max_submissions}`}
+              </div>
+              <div className="inline-flex items-center gap-1.5">
+                <Clock className="h-4 w-4" />
+                Posted {new Date(bounty.created_at).toLocaleDateString()}
+              </div>
+              {bounty.status !== "open" && (
+                <Badge variant="secondary" className="capitalize">
+                  {bounty.status}
+                </Badge>
+              )}
+            </div>
+
+            <div className="prose dark:prose-invert max-w-none text-sm whitespace-pre-wrap">
+              {bounty.description}
+            </div>
+          </div>
+
+          {/* Creator view: review panel */}
+          {isCreator ? (
+            <div>
+              <h2 className="text-lg font-semibold mb-4">Submissions</h2>
+              <ReviewPanel
+                bountyId={bounty.id}
+                payoutUsd={Number(bounty.payout_usd)}
+                questions={bounty.questions || []}
+                submissions={submissions}
+              />
+            </div>
+          ) : (
+            // Submitter view
+            <div className="bg-card border border-border rounded-lg p-6 shadow-sm">
+              {!user ? (
+                <div className="text-center py-6">
+                  <Lock className="h-8 w-8 text-muted-foreground/50 mx-auto mb-3" />
+                  <p className="text-muted-foreground mb-4">
+                    Sign in to submit to this bounty.
+                  </p>
+                  <Link href={`/login?redirect=/bounties/${bounty.id}`}>
+                    <Button>Sign in</Button>
+                  </Link>
+                </div>
+              ) : bounty.status !== "open" ? (
+                <div className="text-center py-6 text-sm text-muted-foreground">
+                  This bounty is no longer accepting submissions.
+                </div>
+              ) : mySubmission ? (
+                <div className="text-center py-6">
+                  <p className="font-medium mb-1">
+                    You&apos;ve already submitted to this bounty.
+                  </p>
+                  <p className="text-sm text-muted-foreground capitalize">
+                    Status: {mySubmission.status}
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <h2 className="text-lg font-semibold mb-4">
+                    Submit to this bounty
+                  </h2>
+                  <SubmitForm
+                    bountyId={bounty.id}
+                    questions={bounty.questions || []}
+                  />
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/bounties/new/BountyForm.tsx
+++ b/src/app/bounties/new/BountyForm.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Loader2, Plus, Trash2, GripVertical } from "lucide-react";
+
+type QuestionType = "short_text" | "long_text" | "multiple_choice";
+
+interface DraftQuestion {
+  id: string;
+  type: QuestionType;
+  label: string;
+  required: boolean;
+  options: string[];
+}
+
+function newQuestion(): DraftQuestion {
+  return {
+    id: crypto.randomUUID(),
+    type: "short_text",
+    label: "",
+    required: true,
+    options: [],
+  };
+}
+
+export function BountyForm() {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [payout, setPayout] = useState("5");
+  const [maxSubmissions, setMaxSubmissions] = useState("");
+  const [questions, setQuestions] = useState<DraftQuestion[]>([
+    {
+      id: crypto.randomUUID(),
+      type: "long_text",
+      label: "Share your feedback",
+      required: true,
+      options: [],
+    },
+  ]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateQuestion = (id: string, patch: Partial<DraftQuestion>) => {
+    setQuestions((qs) => qs.map((q) => (q.id === id ? { ...q, ...patch } : q)));
+  };
+
+  const submit = async () => {
+    setError(null);
+    if (!title.trim()) return setError("Title is required");
+    if (!description.trim()) return setError("Description is required");
+    const payoutNum = parseFloat(payout);
+    if (!payoutNum || payoutNum <= 0) return setError("Enter a valid payout amount");
+    if (questions.length === 0) return setError("Add at least one question");
+    for (const q of questions) {
+      if (!q.label.trim()) return setError("Every question needs a label");
+      if (q.type === "multiple_choice" && q.options.filter((o) => o.trim()).length < 2) {
+        return setError(`Multiple choice "${q.label}" needs at least 2 options`);
+      }
+    }
+
+    const max = maxSubmissions.trim() ? parseInt(maxSubmissions, 10) : null;
+    if (max !== null && (!Number.isFinite(max) || max <= 0)) {
+      return setError("Max submissions must be a positive number or blank");
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/bounties", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim(),
+          payout_usd: payoutNum,
+          max_submissions: max,
+          questions: questions.map((q) => ({
+            id: q.id,
+            type: q.type,
+            label: q.label.trim(),
+            required: q.required,
+            options:
+              q.type === "multiple_choice"
+                ? q.options.map((o) => o.trim()).filter(Boolean)
+                : undefined,
+          })),
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || "Failed to create bounty");
+        return;
+      }
+      router.push(`/bounties/${json.data.id}`);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Title</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="e.g. Share product feedback on our new dashboard"
+          className="w-full border rounded-md px-3 py-2 bg-background"
+          maxLength={200}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Description</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What is this bounty about? Who should submit? What counts as a good answer?"
+          rows={4}
+          className="w-full border rounded-md px-3 py-2 bg-background resize-y"
+          maxLength={10000}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Payout per approval (USD)</label>
+          <input
+            type="number"
+            value={payout}
+            onChange={(e) => setPayout(e.target.value)}
+            min="0.01"
+            step="0.01"
+            className="w-full border rounded-md px-3 py-2 bg-background"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">
+            Max submissions <span className="text-muted-foreground">(optional)</span>
+          </label>
+          <input
+            type="number"
+            value={maxSubmissions}
+            onChange={(e) => setMaxSubmissions(e.target.value)}
+            placeholder="Leave blank for no cap"
+            min="1"
+            step="1"
+            className="w-full border rounded-md px-3 py-2 bg-background"
+          />
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <label className="text-sm font-medium">Submission form</label>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => setQuestions((qs) => [...qs, newQuestion()])}
+            className="gap-2"
+          >
+            <Plus className="h-4 w-4" />
+            Add question
+          </Button>
+        </div>
+
+        <div className="space-y-3">
+          {questions.map((q, idx) => (
+            <div
+              key={q.id}
+              className="border border-border rounded-lg p-4 space-y-3 bg-card"
+            >
+              <div className="flex items-start gap-3">
+                <GripVertical className="h-4 w-4 text-muted-foreground mt-2 flex-shrink-0" />
+                <div className="flex-1 space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-xs text-muted-foreground">
+                      Question {idx + 1}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setQuestions((qs) => qs.filter((x) => x.id !== q.id))
+                      }
+                      className="text-muted-foreground hover:text-destructive"
+                      aria-label="Remove question"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                  <input
+                    type="text"
+                    value={q.label}
+                    onChange={(e) => updateQuestion(q.id, { label: e.target.value })}
+                    placeholder="Question text (shown to submitters)"
+                    className="w-full border rounded-md px-3 py-2 bg-background"
+                    maxLength={500}
+                  />
+                  <div className="flex flex-wrap items-center gap-4 text-sm">
+                    <select
+                      value={q.type}
+                      onChange={(e) =>
+                        updateQuestion(q.id, {
+                          type: e.target.value as QuestionType,
+                          options: e.target.value === "multiple_choice" ? ["", ""] : [],
+                        })
+                      }
+                      className="border rounded-md px-2 py-1.5 bg-background"
+                    >
+                      <option value="short_text">Short text</option>
+                      <option value="long_text">Long text</option>
+                      <option value="multiple_choice">Multiple choice</option>
+                    </select>
+                    <label className="inline-flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={q.required}
+                        onChange={(e) =>
+                          updateQuestion(q.id, { required: e.target.checked })
+                        }
+                      />
+                      Required
+                    </label>
+                  </div>
+
+                  {q.type === "multiple_choice" && (
+                    <div className="space-y-2 pt-2 border-t">
+                      <p className="text-xs text-muted-foreground">Options</p>
+                      {q.options.map((opt, optIdx) => (
+                        <div key={optIdx} className="flex gap-2">
+                          <input
+                            type="text"
+                            value={opt}
+                            onChange={(e) =>
+                              updateQuestion(q.id, {
+                                options: q.options.map((o, i) =>
+                                  i === optIdx ? e.target.value : o
+                                ),
+                              })
+                            }
+                            placeholder={`Option ${optIdx + 1}`}
+                            className="flex-1 border rounded-md px-2 py-1.5 bg-background text-sm"
+                          />
+                          <button
+                            type="button"
+                            onClick={() =>
+                              updateQuestion(q.id, {
+                                options: q.options.filter((_, i) => i !== optIdx),
+                              })
+                            }
+                            className="text-muted-foreground hover:text-destructive"
+                            aria-label="Remove option"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      ))}
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() =>
+                          updateQuestion(q.id, { options: [...q.options, ""] })
+                        }
+                        className="gap-2"
+                      >
+                        <Plus className="h-3 w-3" />
+                        Add option
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2 pt-4">
+        <Button
+          variant="outline"
+          onClick={() => router.back()}
+          disabled={submitting}
+        >
+          Cancel
+        </Button>
+        <Button onClick={submit} disabled={submitting} className="gap-2">
+          {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+          Post bounty
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/bounties/new/page.tsx
+++ b/src/app/bounties/new/page.tsx
@@ -1,0 +1,48 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { Header } from "@/components/layout/Header";
+import { ArrowLeft } from "lucide-react";
+import { BountyForm } from "./BountyForm";
+
+export const metadata = {
+  title: "Post a bounty | ugig.net",
+  description: "Post a bounty with a structured submission form",
+};
+
+export default async function NewBountyPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/login?redirect=/bounties/new");
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-3xl mx-auto">
+          <Link
+            href="/bounties"
+            className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            All bounties
+          </Link>
+
+          <div className="mb-6">
+            <h1 className="text-3xl font-bold mb-2">Post a bounty</h1>
+            <p className="text-muted-foreground">
+              Define the submission form. Submitters will answer it; you
+              approve or reject each one and pay approved submissions.
+            </p>
+          </div>
+
+          <BountyForm />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/bounties/page.tsx
+++ b/src/app/bounties/page.tsx
@@ -1,0 +1,127 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { Header } from "@/components/layout/Header";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Target, DollarSign, Users, Plus } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Bounties | ugig.net",
+  description:
+    "Open bounties with structured submission forms. Earn by completing tasks, providing feedback, and more.",
+  alternates: { canonical: "/bounties" },
+};
+
+interface BountyListItem {
+  id: string;
+  title: string;
+  description: string;
+  payout_usd: number;
+  payout_currency: string;
+  max_submissions: number | null;
+  status: string;
+  created_at: string;
+  creator: {
+    id: string;
+    username: string | null;
+    full_name: string | null;
+    avatar_url: string | null;
+  } | null;
+}
+
+export default async function BountiesPage() {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("bounties" as any)
+    .select(
+      `
+      id, title, description, payout_usd, payout_currency, max_submissions,
+      status, created_at,
+      creator:profiles!creator_id (id, username, full_name, avatar_url)
+    `
+    )
+    .eq("status", "open")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  const bounties = (data || []) as unknown as BountyListItem[];
+
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-start justify-between gap-4 mb-8">
+            <div>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="p-2 bg-primary/10 rounded-lg">
+                  <Target className="h-6 w-6 text-primary" />
+                </div>
+                <h1 className="text-3xl font-bold">Bounties</h1>
+              </div>
+              <p className="text-muted-foreground">
+                Complete short tasks for a fixed payout. Answer the form, get
+                approved, get paid.
+              </p>
+            </div>
+            <Link href="/bounties/new">
+              <Button className="gap-2">
+                <Plus className="h-4 w-4" />
+                Post a bounty
+              </Button>
+            </Link>
+          </div>
+
+          {bounties.length === 0 ? (
+            <div className="text-center py-16 bg-card rounded-lg border border-border">
+              <Target className="h-12 w-12 mx-auto text-muted-foreground/50 mb-4" />
+              <h3 className="text-lg font-semibold mb-2">No open bounties yet</h3>
+              <p className="text-muted-foreground mb-6">
+                Be the first to post one.
+              </p>
+              <Link href="/bounties/new">
+                <Button>Post the first bounty</Button>
+              </Link>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {bounties.map((b) => (
+                <Link
+                  key={b.id}
+                  href={`/bounties/${b.id}`}
+                  className="p-5 bg-card rounded-lg border border-border shadow-sm hover:shadow-md hover:border-primary/30 transition-all duration-200"
+                >
+                  <div className="flex items-start justify-between gap-3 mb-3">
+                    <h2 className="font-semibold line-clamp-2">{b.title}</h2>
+                    <Badge className="bg-green-500/10 text-green-600 border-green-500/20 whitespace-nowrap">
+                      <DollarSign className="h-3 w-3 mr-0.5" />
+                      {Number(b.payout_usd).toFixed(2)}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground line-clamp-3 mb-4">
+                    {b.description}
+                  </p>
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>
+                      by{" "}
+                      {b.creator?.full_name ||
+                        b.creator?.username ||
+                        "Anonymous"}
+                    </span>
+                    {b.max_submissions && (
+                      <span className="inline-flex items-center gap-1">
+                        <Users className="h-3 w-3" />
+                        Cap: {b.max_submissions}
+                      </span>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/dashboard/bounties/page.tsx
+++ b/src/app/dashboard/bounties/page.tsx
@@ -1,0 +1,273 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  ArrowLeft,
+  Plus,
+  Target,
+  DollarSign,
+  CheckCircle2,
+  Clock,
+  XCircle,
+} from "lucide-react";
+
+export const metadata = {
+  title: "My Bounties | ugig.net",
+  description: "Manage bounties you've posted or submitted to",
+};
+
+type TabKey = "created" | "submitted";
+
+export default async function DashboardBountiesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/login?redirect=/dashboard/bounties");
+  }
+
+  const tabParam = (await searchParams).tab;
+  const tab: TabKey = tabParam === "submitted" ? "submitted" : "created";
+
+  // Bounties I've created
+  const { data: createdData } = await (supabase as any)
+    .from("bounties")
+    .select("id, title, payout_usd, max_submissions, status, created_at")
+    .eq("creator_id", user.id)
+    .order("created_at", { ascending: false });
+  const created = (createdData || []) as Array<{
+    id: string;
+    title: string;
+    payout_usd: number;
+    max_submissions: number | null;
+    status: string;
+    created_at: string;
+  }>;
+
+  // Submission counts per bounty I created (best-effort, single query)
+  const createdIds = created.map((b) => b.id);
+  const submissionStats: Record<
+    string,
+    { total: number; pending: number; approved_unpaid: number }
+  > = {};
+  if (createdIds.length > 0) {
+    const { data: subs } = await (supabase as any)
+      .from("bounty_submissions")
+      .select("bounty_id, status, payout_status")
+      .in("bounty_id", createdIds);
+    for (const id of createdIds) {
+      submissionStats[id] = { total: 0, pending: 0, approved_unpaid: 0 };
+    }
+    for (const s of subs || []) {
+      const stat = submissionStats[s.bounty_id];
+      if (!stat) continue;
+      stat.total += 1;
+      if (s.status === "pending") stat.pending += 1;
+      if (s.status === "approved" && s.payout_status === "unpaid") {
+        stat.approved_unpaid += 1;
+      }
+    }
+  }
+
+  // Bounties I've submitted to
+  const { data: submittedData } = await (supabase as any)
+    .from("bounty_submissions")
+    .select(
+      `
+      id, status, payout_status, pay_url, created_at,
+      bounty:bounties (id, title, payout_usd)
+    `
+    )
+    .eq("submitter_id", user.id)
+    .order("created_at", { ascending: false });
+  const submitted = (submittedData || []) as Array<{
+    id: string;
+    status: "pending" | "approved" | "rejected";
+    payout_status: "unpaid" | "invoiced" | "paid";
+    pay_url: string | null;
+    created_at: string;
+    bounty: { id: string; title: string; payout_usd: number } | null;
+  }>;
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="max-w-5xl mx-auto">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to dashboard
+        </Link>
+
+        <div className="flex items-start justify-between gap-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-bold mb-2">Bounties</h1>
+            <p className="text-muted-foreground">
+              Manage bounties you&apos;ve posted and submissions you&apos;ve
+              made.
+            </p>
+          </div>
+          <Link href="/bounties/new">
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              Post bounty
+            </Button>
+          </Link>
+        </div>
+
+        <div className="flex gap-1 border-b border-border mb-6">
+          <Link
+            href="/dashboard/bounties?tab=created"
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              tab === "created"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Bounties I posted ({created.length})
+          </Link>
+          <Link
+            href="/dashboard/bounties?tab=submitted"
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              tab === "submitted"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            My submissions ({submitted.length})
+          </Link>
+        </div>
+
+        {tab === "created" ? (
+          created.length === 0 ? (
+            <div className="text-center py-16 bg-card rounded-lg border border-border">
+              <Target className="h-12 w-12 mx-auto text-muted-foreground/50 mb-4" />
+              <h3 className="text-lg font-semibold mb-2">No bounties yet</h3>
+              <p className="text-muted-foreground mb-6">
+                Post your first bounty to start collecting submissions.
+              </p>
+              <Link href="/bounties/new">
+                <Button>Post a bounty</Button>
+              </Link>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {created.map((b) => {
+                const stat = submissionStats[b.id] || {
+                  total: 0,
+                  pending: 0,
+                  approved_unpaid: 0,
+                };
+                return (
+                  <Link
+                    key={b.id}
+                    href={`/bounties/${b.id}`}
+                    className="block p-4 bg-card border border-border rounded-lg shadow-sm hover:shadow-md hover:border-primary/30 transition-all"
+                  >
+                    <div className="flex items-start justify-between gap-3 mb-2">
+                      <div>
+                        <p className="font-medium">{b.title}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Posted {new Date(b.created_at).toLocaleDateString()}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Badge className="bg-green-500/10 text-green-600 border-green-500/20">
+                          <DollarSign className="h-3 w-3 mr-0.5" />
+                          {Number(b.payout_usd).toFixed(2)}
+                        </Badge>
+                        <Badge
+                          variant="secondary"
+                          className="capitalize"
+                        >
+                          {b.status}
+                        </Badge>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground mt-2">
+                      <span>
+                        {stat.total} submission{stat.total === 1 ? "" : "s"}
+                        {b.max_submissions && ` / ${b.max_submissions}`}
+                      </span>
+                      {stat.pending > 0 && (
+                        <span className="text-yellow-600 font-medium">
+                          {stat.pending} awaiting review
+                        </span>
+                      )}
+                      {stat.approved_unpaid > 0 && (
+                        <span className="text-blue-600 font-medium">
+                          {stat.approved_unpaid} approved &amp; unpaid
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          )
+        ) : submitted.length === 0 ? (
+          <div className="text-center py-16 bg-card rounded-lg border border-border">
+            <Target className="h-12 w-12 mx-auto text-muted-foreground/50 mb-4" />
+            <h3 className="text-lg font-semibold mb-2">No submissions yet</h3>
+            <p className="text-muted-foreground mb-6">
+              Browse open bounties and submit to start earning.
+            </p>
+            <Link href="/bounties">
+              <Button>Browse bounties</Button>
+            </Link>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {submitted.map((s) => (
+              <Link
+                key={s.id}
+                href={s.bounty ? `/bounties/${s.bounty.id}` : "#"}
+                className="block p-4 bg-card border border-border rounded-lg shadow-sm hover:shadow-md transition-all"
+              >
+                <div className="flex items-start justify-between gap-3 mb-1">
+                  <p className="font-medium">{s.bounty?.title || "Bounty"}</p>
+                  <div className="flex items-center gap-2">
+                    {s.status === "pending" && (
+                      <Badge variant="secondary" className="gap-1">
+                        <Clock className="h-3 w-3" /> Pending
+                      </Badge>
+                    )}
+                    {s.status === "approved" && (
+                      <Badge className="gap-1 bg-green-500/10 text-green-600 border-green-500/20">
+                        <CheckCircle2 className="h-3 w-3" /> Approved
+                      </Badge>
+                    )}
+                    {s.status === "rejected" && (
+                      <Badge variant="secondary" className="gap-1 text-destructive">
+                        <XCircle className="h-3 w-3" /> Rejected
+                      </Badge>
+                    )}
+                    {s.payout_status === "paid" && (
+                      <Badge className="gap-1 bg-green-500/10 text-green-600 border-green-500/20">
+                        Paid
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Submitted {new Date(s.created_at).toLocaleDateString()}
+                  {s.bounty && (
+                    <> · ${Number(s.bounty.payout_usd).toFixed(2)} payout</>
+                  )}
+                </p>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -15,6 +15,7 @@ import {
   Megaphone,
   HandCoins,
   Receipt,
+  Target,
 } from "lucide-react";
 import { FundingDashboard } from "@/components/funding/FundingDashboard";
 
@@ -334,6 +335,19 @@ export default async function DashboardPage() {
                   <h3 className="font-medium">Invoices</h3>
                   <p className="text-sm text-muted-foreground mt-1">
                     Pay accepted applicants and view invoices
+                  </p>
+                </Link>
+
+                <Link
+                  href="/dashboard/bounties"
+                  className="p-4 border border-border rounded-lg shadow-sm hover:shadow-md hover:border-pink-500/40 hover:bg-pink-500/5 transition-all duration-200"
+                >
+                  <div className="p-2.5 bg-pink-500/10 rounded-xl w-fit mb-3">
+                    <Target className="h-5 w-5 text-pink-500" />
+                  </div>
+                  <h3 className="font-medium">Bounties</h3>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Post bounties and review submissions
                   </p>
                 </Link>
 

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -11,6 +11,7 @@ const NAV_LINKS = [
   { href: "/feed", label: "The Lounge" },
   { href: "/gigs", label: "Gigs (Hiring)" },
   { href: "/for-hire", label: "I will... (Looking)" },
+  { href: "/bounties", label: "Bounties" },
   { href: "/skills", label: "Skills" },
   { href: "/prompts", label: "Prompts" },
   { href: "/mcp", label: "MCP Servers" },

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -9,9 +9,9 @@ import { Button } from "@/components/ui/button";
 const NAV_LINKS = [
   { href: "/search", label: "Search", icon: true },
   { href: "/feed", label: "The Lounge" },
+  { href: "/bounties", label: "Bounties" },
   { href: "/gigs", label: "Gigs (Hiring)" },
   { href: "/for-hire", label: "I will... (Looking)" },
-  { href: "/bounties", label: "Bounties" },
   { href: "/skills", label: "Skills" },
   { href: "/prompts", label: "Prompts" },
   { href: "/mcp", label: "MCP Servers" },

--- a/src/components/layout/NavLinks.tsx
+++ b/src/components/layout/NavLinks.tsx
@@ -9,6 +9,7 @@ const PRIMARY_NAV = [
   { href: "/feed", label: "The Lounge" },
   { href: "/gigs", label: "Gigs (Hiring)" },
   { href: "/for-hire", label: "I will... (Looking)" },
+  { href: "/bounties", label: "Bounties" },
 ];
 
 const MORE_NAV = [

--- a/src/components/layout/NavLinks.tsx
+++ b/src/components/layout/NavLinks.tsx
@@ -7,9 +7,9 @@ import { ChevronDown } from "lucide-react";
 
 const PRIMARY_NAV = [
   { href: "/feed", label: "The Lounge" },
+  { href: "/bounties", label: "Bounties" },
   { href: "/gigs", label: "Gigs (Hiring)" },
   { href: "/for-hire", label: "I will... (Looking)" },
-  { href: "/bounties", label: "Bounties" },
 ];
 
 const MORE_NAV = [

--- a/src/lib/bounties.ts
+++ b/src/lib/bounties.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+export const questionSchema = z.object({
+  id: z.string().min(1).max(64),
+  type: z.enum(["short_text", "long_text", "multiple_choice"]),
+  label: z.string().min(1).max(500),
+  required: z.boolean().default(true),
+  options: z.array(z.string().min(1).max(200)).optional(),
+});
+
+export const createBountySchema = z.object({
+  title: z.string().min(3).max(200),
+  description: z.string().min(10).max(10000),
+  payout_usd: z.number().positive().max(100000),
+  payout_currency: z.string().default("USD"),
+  max_submissions: z.number().int().positive().max(100000).nullable().optional(),
+  closes_at: z.string().datetime().optional(),
+  questions: z.array(questionSchema).min(1).max(20),
+});
+
+export const updateBountySchema = createBountySchema.partial().extend({
+  status: z.enum(["open", "paused", "closed"]).optional(),
+});
+
+export const answerSchema = z.object({
+  question_id: z.string(),
+  value: z.union([z.string(), z.array(z.string())]),
+});
+
+export const submitAnswersSchema = z.object({
+  answers: z.array(answerSchema),
+});
+
+export const reviewSubmissionSchema = z.object({
+  status: z.enum(["approved", "rejected"]),
+  review_notes: z.string().max(2000).optional(),
+});
+
+export type BountyQuestion = z.infer<typeof questionSchema>;
+export type BountyAnswer = z.infer<typeof answerSchema>;
+
+export function validateAnswers(
+  questions: BountyQuestion[],
+  answers: BountyAnswer[]
+): string | null {
+  const byId = new Map(questions.map((q) => [q.id, q]));
+  const answeredIds = new Set(answers.map((a) => a.question_id));
+
+  // Required questions must have an answer with non-empty value
+  for (const q of questions) {
+    if (!q.required) continue;
+    const a = answers.find((x) => x.question_id === q.id);
+    if (!a) return `Missing answer for required question: ${q.label}`;
+    if (typeof a.value === "string" && a.value.trim() === "") {
+      return `Required answer cannot be empty: ${q.label}`;
+    }
+    if (Array.isArray(a.value) && a.value.length === 0) {
+      return `Required answer cannot be empty: ${q.label}`;
+    }
+  }
+
+  // Each answer must reference a real question, with matching type
+  for (const a of answers) {
+    const q = byId.get(a.question_id);
+    if (!q) return `Unknown question id: ${a.question_id}`;
+    if (q.type === "multiple_choice") {
+      const options = q.options || [];
+      const values = Array.isArray(a.value) ? a.value : [a.value];
+      for (const v of values) {
+        if (!options.includes(v)) {
+          return `Invalid option for "${q.label}": ${v}`;
+        }
+      }
+    } else if (typeof a.value !== "string") {
+      return `Answer for "${q.label}" must be a string`;
+    }
+  }
+
+  // Stray answers for unknown questions are caught above; check missing
+  void answeredIds;
+  return null;
+}

--- a/supabase/migrations/20260522010000_add_bounties.sql
+++ b/supabase/migrations/20260522010000_add_bounties.sql
@@ -1,0 +1,119 @@
+-- Bounties: a separate marketplace primitive from gigs. A creator posts a
+-- bounty with a structured questionnaire and a fixed per-submission payout.
+-- Submitters answer the questionnaire; the creator approves/rejects each one,
+-- and pays approved submissions via CoinPayPortal (manual pay flow, mirroring
+-- gig_invoices).
+
+CREATE TABLE IF NOT EXISTS bounties (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text NOT NULL,
+  payout_usd numeric NOT NULL CHECK (payout_usd > 0),
+  payout_currency text NOT NULL DEFAULT 'USD',
+  -- questions: jsonb array of
+  --   { id: string, type: 'short_text'|'long_text'|'multiple_choice',
+  --     label: string, required: boolean, options?: string[] }
+  questions jsonb NOT NULL DEFAULT '[]'::jsonb,
+  max_submissions int CHECK (max_submissions IS NULL OR max_submissions > 0),
+  status text NOT NULL DEFAULT 'open'
+    CHECK (status IN ('open', 'paused', 'closed')),
+  closes_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_bounties_creator_id ON bounties(creator_id);
+CREATE INDEX idx_bounties_status ON bounties(status);
+CREATE INDEX idx_bounties_created_at ON bounties(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS bounty_submissions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  bounty_id uuid NOT NULL REFERENCES bounties(id) ON DELETE CASCADE,
+  submitter_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  -- answers: jsonb array of { question_id: string, value: string|string[] }
+  answers jsonb NOT NULL DEFAULT '[]'::jsonb,
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'approved', 'rejected')),
+  review_notes text,
+  reviewed_at timestamptz,
+  reviewed_by uuid REFERENCES profiles(id),
+  -- Payout tracking; separate from approval status so we can show
+  -- "approved but unpaid" in the dashboard.
+  payout_status text NOT NULL DEFAULT 'unpaid'
+    CHECK (payout_status IN ('unpaid', 'invoiced', 'paid')),
+  coinpay_invoice_id text,
+  pay_url text,
+  paid_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (bounty_id, submitter_id)
+);
+
+CREATE INDEX idx_bounty_submissions_bounty_id ON bounty_submissions(bounty_id);
+CREATE INDEX idx_bounty_submissions_submitter_id ON bounty_submissions(submitter_id);
+CREATE INDEX idx_bounty_submissions_status ON bounty_submissions(status);
+CREATE INDEX idx_bounty_submissions_payout_status ON bounty_submissions(payout_status);
+
+-- updated_at maintenance
+CREATE OR REPLACE FUNCTION set_bounty_updated_at() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_bounties_updated_at
+  BEFORE UPDATE ON bounties
+  FOR EACH ROW EXECUTE FUNCTION set_bounty_updated_at();
+
+CREATE TRIGGER trg_bounty_submissions_updated_at
+  BEFORE UPDATE ON bounty_submissions
+  FOR EACH ROW EXECUTE FUNCTION set_bounty_updated_at();
+
+-- ── RLS ──────────────────────────────────────────────────────────────────
+ALTER TABLE bounties ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bounty_submissions ENABLE ROW LEVEL SECURITY;
+
+-- Bounties: anyone (anon or authed) can read non-closed bounties; the creator
+-- can always read their own (including closed). Only the creator can mutate.
+CREATE POLICY "Bounties are publicly readable when not closed"
+  ON bounties FOR SELECT
+  USING (status <> 'closed' OR auth.uid() = creator_id);
+
+CREATE POLICY "Creators can insert their own bounties"
+  ON bounties FOR INSERT
+  WITH CHECK (auth.uid() = creator_id);
+
+CREATE POLICY "Creators can update their own bounties"
+  ON bounties FOR UPDATE
+  USING (auth.uid() = creator_id);
+
+CREATE POLICY "Creators can delete their own bounties"
+  ON bounties FOR DELETE
+  USING (auth.uid() = creator_id);
+
+-- Submissions: visible to the submitter (own rows) and to the bounty creator
+-- (all rows on their bounty). Submitter inserts own. Submitter can update only
+-- their own pending submission (e.g. withdraw). Creator can update any
+-- submission on their bounty (approve/reject/pay).
+CREATE POLICY "Submissions visible to submitter and bounty creator"
+  ON bounty_submissions FOR SELECT
+  USING (
+    auth.uid() = submitter_id
+    OR auth.uid() IN (SELECT creator_id FROM bounties WHERE id = bounty_id)
+  );
+
+CREATE POLICY "Users can submit their own answers"
+  ON bounty_submissions FOR INSERT
+  WITH CHECK (auth.uid() = submitter_id);
+
+CREATE POLICY "Submitters can update their pending submission"
+  ON bounty_submissions FOR UPDATE
+  USING (auth.uid() = submitter_id AND status = 'pending');
+
+CREATE POLICY "Creators can update submissions on their bounty"
+  ON bounty_submissions FOR UPDATE
+  USING (
+    auth.uid() IN (SELECT creator_id FROM bounties WHERE id = bounty_id)
+  );


### PR DESCRIPTION
> Stacked on top of #226 (invoices). When that merges, GitHub will auto-retarget this PR to \`master\`.

## Summary

Bounties are a separate primitive from gigs: many-to-one with structured submissions, fixed per-approval payout, and an approve/reject review flow ending in a CoinPayPortal payment link. Useful for things like the \$5-feedback collection pattern where every submitter answers the same questionnaire (joinpond.ai style).

### Data model
- **\`bounties\`** — creator, title, description, \`payout_usd\` (per approval), optional \`max_submissions\` cap, \`questions\` JSONB (array of \`{id, type, label, required, options?}\`), status (\`open\`/\`paused\`/\`closed\`).
- **\`bounty_submissions\`** — \`answers\` JSONB, \`status\` (\`pending\`/\`approved\`/\`rejected\`), \`payout_status\` (\`unpaid\`/\`invoiced\`/\`paid\`), \`coinpay_invoice_id\`, \`pay_url\`. Unique \`(bounty_id, submitter_id)\` to enforce one submission per user.
- **RLS**: bounties publicly readable when not closed; submissions visible only to the submitter (own) and the bounty creator. Submitter can only update their own pending submission; creator can review any submission on their bounty.

### API
- \`GET\` / \`POST /api/bounties\`
- \`GET\` / \`PATCH /api/bounties/[id]\`
- \`GET\` / \`POST /api/bounties/[id]/submissions\` (enforces one-per-user, validates answers against the questionnaire, auto-closes the bounty when \`max_submissions\` is hit)
- \`PATCH /api/bounties/[id]/submissions/[sid]\` (approve/reject)
- \`POST /api/bounties/[id]/submissions/[sid]/pay\` (creates a CoinPay invoice, stores \`pay_url\`)

### UI
- \`/bounties\` — public browse, sorted newest-first.
- \`/bounties/new\` — create form with a dynamic question builder (short text / long text / multiple choice).
- \`/bounties/[id]\` — submit form for visitors, full review panel with approve/reject + pay button for the creator.
- \`/dashboard/bounties\` — tabs for "Bounties I posted" (with submission/pending/approved-unpaid counts) and "My submissions".

### Nav
- Added **Bounties** to desktop \`NavLinks\` and \`MobileMenu\` primary nav (positioned before Gigs).
- New dashboard card linking to \`/dashboard/bounties\`.

## Known gap (out of scope)

Same as invoices: no CoinPay webhook handler to flip \`bounty_submissions.payout_status\` from \`invoiced\` → \`paid\`. Tracked for a follow-up that adds invoice + bounty webhook handling together.

## Test plan

- [ ] Run the migration: \`psql ... -f supabase/migrations/20260522010000_add_bounties.sql\`
- [ ] Visit \`/bounties\` while logged out → confirm browse page renders.
- [ ] Visit \`/bounties/new\` as a logged-in user → build a bounty with 1 short_text, 1 long_text, 1 multiple_choice question (with options) and a \$5 payout. Submit.
- [ ] Open the new bounty detail page → confirm form renders the questions correctly.
- [ ] As a different user, submit answers → confirm submission appears on the creator's review panel.
- [ ] Approve the submission → confirm submitter is notified. Click "Pay \$5" → confirm CoinPay link opens and \`payout_status\` becomes \`invoiced\`.
- [ ] Try to submit a second time as the same user → confirm 409 with "already submitted".
- [ ] Create a bounty with \`max_submissions: 1\`, fill it, then attempt another submission → confirm auto-close + rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)