### PR TITLE
feat(bounties): edit page, payment_coin, shared payment inputs, markdown

### DIFF
--- a/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
+++ b/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
-import { createInvoice, sendInvoice } from "@/lib/coinpayportal";
+import { createPayment, resolveSupportedPaymentCurrency } from "@/lib/coinpayportal";
 
 // POST /api/bounties/[id]/submissions/[sid]/pay
-// Creator generates a CoinPay payment link for an approved submission.
+// Creator generates a CoinPay in-app payment for an approved submission,
+// matching the post-#224 gig invoice flow (in-app payment address, not a
+// redirect to a hosted invoice page).
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; sid: string }> }
@@ -18,7 +20,7 @@ export async function POST(
 
     const { data: bounty } = await (supabase as any)
       .from("bounties")
-      .select("id, creator_id, title, payout_usd")
+      .select("id, creator_id, title, payout_usd, payment_coin")
       .eq("id", bountyId)
       .single();
     if (!bounty) {
@@ -44,8 +46,8 @@ export async function POST(
       );
     }
 
-    // Already has a pay link — return it
-    if (submission.pay_url) {
+    // Already invoiced — return existing details
+    if (submission.coinpay_invoice_id) {
       return NextResponse.json({
         data: {
           submission_id: sid,
@@ -55,29 +57,56 @@ export async function POST(
       });
     }
 
-    // Create CoinPay invoice
-    const invoiceResult = await createInvoice({
-      amount: Number(bounty.payout_usd),
-      currency: "USD",
-      notes: `Bounty payout: ${bounty.title}`,
+    const appUrl =
+      process.env.APP_URL ||
+      process.env.NEXT_PUBLIC_APP_URL ||
+      "https://ugig.net";
+    const businessId =
+      process.env.COINPAY_UGIG_BUSINESS_ID ||
+      process.env.COINPAY_MERCHANT_ID;
+    const paymentCurrency = await resolveSupportedPaymentCurrency(
+      bounty.payment_coin,
+      { business_id: businessId }
+    );
+
+    const paymentResult = await createPayment({
+      amount_usd: Number(bounty.payout_usd),
+      currency: paymentCurrency,
+      description: `Bounty payout: ${bounty.title}`,
+      business_id: businessId,
+      redirect_url: `${appUrl}/bounties/${bountyId}?paid=${sid}`,
       metadata: {
+        type: "bounty_payout",
         bounty_id: bountyId,
         submission_id: sid,
         creator_id: user.id,
         submitter_id: submission.submitter_id,
-        kind: "bounty",
+        payment_currency: paymentCurrency,
         platform: "ugig.net",
       },
     });
-    const sendResult = await sendInvoice(invoiceResult.invoice.id);
-    const payUrl = sendResult.invoice.pay_url || invoiceResult.invoice.pay_url;
+
+    const cpPayment = (paymentResult.payment || paymentResult) as Record<string, unknown>;
+    const paymentId =
+      paymentResult.payment_id || (cpPayment.id as string | undefined);
+    const paymentAddress =
+      (cpPayment.payment_address as string | undefined) ||
+      paymentResult.address ||
+      null;
+
+    if (!paymentId || !paymentAddress) {
+      return NextResponse.json(
+        { error: "CoinPay did not return a usable payment" },
+        { status: 502 }
+      );
+    }
 
     const { error: updateError } = await (supabase as any)
       .from("bounty_submissions")
       .update({
         payout_status: "invoiced",
-        coinpay_invoice_id: invoiceResult.invoice.id,
-        pay_url: payUrl,
+        coinpay_invoice_id: paymentId,
+        pay_url: paymentResult.checkout_url || (cpPayment.checkout_url as string | undefined) || null,
       })
       .eq("id", sid);
 
@@ -88,8 +117,22 @@ export async function POST(
     return NextResponse.json({
       data: {
         submission_id: sid,
-        coinpay_invoice_id: invoiceResult.invoice.id,
-        pay_url: payUrl,
+        coinpay_invoice_id: paymentId,
+        payment_address: paymentAddress,
+        payment_currency: paymentResult.currency || paymentCurrency,
+        amount_crypto:
+          paymentResult.amount_crypto ||
+          (cpPayment.amount_crypto as number | undefined) ||
+          (cpPayment.crypto_amount as number | undefined) ||
+          null,
+        expires_at:
+          paymentResult.expires_at ||
+          (cpPayment.expires_at as string | undefined) ||
+          null,
+        pay_url:
+          paymentResult.checkout_url ||
+          (cpPayment.checkout_url as string | undefined) ||
+          null,
       },
     });
   } catch (err) {

--- a/src/app/api/bounties/route.ts
+++ b/src/app/api/bounties/route.ts
@@ -69,6 +69,7 @@ export async function POST(request: NextRequest) {
         description: parsed.data.description,
         payout_usd: parsed.data.payout_usd,
         payout_currency: parsed.data.payout_currency || "USD",
+        payment_coin: parsed.data.payment_coin || null,
         max_submissions: parsed.data.max_submissions ?? null,
         closes_at: parsed.data.closes_at || null,
         questions,

--- a/src/app/bounties/[id]/edit/page.tsx
+++ b/src/app/bounties/[id]/edit/page.tsx
@@ -1,0 +1,77 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { Header } from "@/components/layout/Header";
+import { ArrowLeft } from "lucide-react";
+import { BountyForm } from "../../new/BountyForm";
+
+export const metadata = {
+  title: "Edit bounty | ugig.net",
+};
+
+export default async function EditBountyPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/login?redirect=/bounties/${id}/edit`);
+  }
+
+  const { data: bounty } = await (supabase as any)
+    .from("bounties")
+    .select(
+      "id, creator_id, title, description, payout_usd, payment_coin, max_submissions, questions, status"
+    )
+    .eq("id", id)
+    .single();
+
+  if (!bounty) {
+    notFound();
+  }
+  if (bounty.creator_id !== user.id) {
+    redirect(`/bounties/${id}`);
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-3xl mx-auto">
+          <Link
+            href={`/bounties/${id}`}
+            className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to bounty
+          </Link>
+
+          <div className="mb-6">
+            <h1 className="text-3xl font-bold mb-2">Edit bounty</h1>
+            <p className="text-muted-foreground">
+              Adjust the title, description, payout, or questionnaire. Existing
+              submissions stay attached.
+            </p>
+          </div>
+
+          <BountyForm
+            bountyId={id}
+            initialData={{
+              title: bounty.title,
+              description: bounty.description,
+              payout_usd: Number(bounty.payout_usd),
+              payment_coin: bounty.payment_coin,
+              max_submissions: bounty.max_submissions,
+              questions: bounty.questions || [],
+            }}
+          />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/bounties/[id]/page.tsx
+++ b/src/app/bounties/[id]/page.tsx
@@ -10,7 +10,9 @@ import {
   Users,
   Clock,
   Lock,
+  Pencil,
 } from "lucide-react";
+import { MarkdownContent } from "@/components/ui/MarkdownContent";
 import { SubmitForm } from "./SubmitForm";
 import { ReviewPanel } from "./ReviewPanel";
 
@@ -21,6 +23,7 @@ interface BountyDetail {
   description: string;
   payout_usd: number;
   payout_currency: string;
+  payment_coin: string | null;
   max_submissions: number | null;
   status: "open" | "paused" | "closed";
   questions: {
@@ -137,10 +140,23 @@ export default async function BountyDetailPage({
                   )}
                 </p>
               </div>
-              <Badge className="bg-green-500/10 text-green-600 border-green-500/20 text-base">
-                <DollarSign className="h-4 w-4 mr-0.5" />
-                {Number(bounty.payout_usd).toFixed(2)}
-              </Badge>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <Badge className="bg-green-500/10 text-green-600 border-green-500/20 text-base">
+                  <DollarSign className="h-4 w-4 mr-0.5" />
+                  {Number(bounty.payout_usd).toFixed(2)}
+                </Badge>
+                {bounty.payment_coin && (
+                  <Badge variant="secondary">{bounty.payment_coin}</Badge>
+                )}
+                {isCreator && (
+                  <Link href={`/bounties/${bounty.id}/edit`}>
+                    <Button size="sm" variant="outline" className="gap-1.5">
+                      <Pencil className="h-3.5 w-3.5" />
+                      Edit
+                    </Button>
+                  </Link>
+                )}
+              </div>
             </div>
 
             <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground mb-6">
@@ -161,9 +177,8 @@ export default async function BountyDetailPage({
               )}
             </div>
 
-            <div className="prose dark:prose-invert max-w-none text-sm whitespace-pre-wrap">
-              {bounty.description}
-            </div>
+            <MarkdownContent content={bounty.description || ""} />
+
           </div>
 
           {/* Creator view: review panel */}

--- a/src/app/bounties/new/BountyForm.tsx
+++ b/src/app/bounties/new/BountyForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { PaymentInput } from "@/components/ui/PaymentInputs";
 import { Loader2, Plus, Trash2, GripVertical } from "lucide-react";
 
 type QuestionType = "short_text" | "long_text" | "multiple_choice";
@@ -15,6 +16,26 @@ interface DraftQuestion {
   options: string[];
 }
 
+interface BountyInitialData {
+  title?: string;
+  description?: string;
+  payout_usd?: number;
+  payment_coin?: string | null;
+  max_submissions?: number | null;
+  questions?: Array<{
+    id: string;
+    type: QuestionType;
+    label: string;
+    required: boolean;
+    options?: string[];
+  }>;
+}
+
+interface BountyFormProps {
+  initialData?: BountyInitialData;
+  bountyId?: string;
+}
+
 function newQuestion(): DraftQuestion {
   return {
     id: crypto.randomUUID(),
@@ -25,21 +46,37 @@ function newQuestion(): DraftQuestion {
   };
 }
 
-export function BountyForm() {
+export function BountyForm({ initialData, bountyId }: BountyFormProps = {}) {
   const router = useRouter();
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [payout, setPayout] = useState("5");
-  const [maxSubmissions, setMaxSubmissions] = useState("");
-  const [questions, setQuestions] = useState<DraftQuestion[]>([
-    {
-      id: crypto.randomUUID(),
-      type: "long_text",
-      label: "Share your feedback",
-      required: true,
-      options: [],
-    },
-  ]);
+  const isEdit = !!bountyId;
+  const [title, setTitle] = useState(initialData?.title ?? "");
+  const [description, setDescription] = useState(initialData?.description ?? "");
+  const [payout, setPayout] = useState(
+    initialData?.payout_usd != null ? String(initialData.payout_usd) : "5"
+  );
+  const [coin, setCoin] = useState(initialData?.payment_coin ?? "");
+  const [maxSubmissions, setMaxSubmissions] = useState(
+    initialData?.max_submissions != null ? String(initialData.max_submissions) : ""
+  );
+  const [questions, setQuestions] = useState<DraftQuestion[]>(
+    initialData?.questions && initialData.questions.length > 0
+      ? initialData.questions.map((q) => ({
+          id: q.id,
+          type: q.type,
+          label: q.label,
+          required: q.required,
+          options: q.options ?? [],
+        }))
+      : [
+          {
+            id: crypto.randomUUID(),
+            type: "long_text",
+            label: "Share your feedback",
+            required: true,
+            options: [],
+          },
+        ]
+  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -68,13 +105,16 @@ export function BountyForm() {
 
     setSubmitting(true);
     try {
-      const res = await fetch("/api/bounties", {
-        method: "POST",
+      const url = isEdit ? `/api/bounties/${bountyId}` : "/api/bounties";
+      const method = isEdit ? "PATCH" : "POST";
+      const res = await fetch(url, {
+        method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: title.trim(),
           description: description.trim(),
           payout_usd: payoutNum,
+          payment_coin: coin || null,
           max_submissions: max,
           questions: questions.map((q) => ({
             id: q.id,
@@ -90,10 +130,10 @@ export function BountyForm() {
       });
       const json = await res.json();
       if (!res.ok) {
-        setError(json.error || "Failed to create bounty");
+        setError(json.error || (isEdit ? "Failed to save bounty" : "Failed to create bounty"));
         return;
       }
-      router.push(`/bounties/${json.data.id}`);
+      router.push(`/bounties/${isEdit ? bountyId : json.data.id}`);
     } catch {
       setError("Network error. Try again.");
     } finally {
@@ -127,32 +167,28 @@ export function BountyForm() {
         />
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <label className="text-sm font-medium">Payout per approval (USD)</label>
-          <input
-            type="number"
-            value={payout}
-            onChange={(e) => setPayout(e.target.value)}
-            min="0.01"
-            step="0.01"
-            className="w-full border rounded-md px-3 py-2 bg-background"
-          />
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-medium">
-            Max submissions <span className="text-muted-foreground">(optional)</span>
-          </label>
-          <input
-            type="number"
-            value={maxSubmissions}
-            onChange={(e) => setMaxSubmissions(e.target.value)}
-            placeholder="Leave blank for no cap"
-            min="1"
-            step="1"
-            className="w-full border rounded-md px-3 py-2 bg-background"
-          />
-        </div>
+      <PaymentInput
+        coin={coin}
+        onCoinChange={setCoin}
+        amount={payout}
+        onAmountChange={setPayout}
+        amountLabel="Payout per approval (USD)"
+        disabled={submitting}
+      />
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">
+          Max submissions <span className="text-muted-foreground">(optional)</span>
+        </label>
+        <input
+          type="number"
+          value={maxSubmissions}
+          onChange={(e) => setMaxSubmissions(e.target.value)}
+          placeholder="Leave blank for no cap"
+          min="1"
+          step="1"
+          className="w-full border rounded-md px-3 py-2 bg-background"
+        />
       </div>
 
       <div>
@@ -298,7 +334,7 @@ export function BountyForm() {
         </Button>
         <Button onClick={submit} disabled={submitting} className="gap-2">
           {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
-          Post bounty
+          {isEdit ? "Save changes" : "Post bounty"}
         </Button>
       </div>
     </div>

--- a/src/app/bounties/page.tsx
+++ b/src/app/bounties/page.tsx
@@ -19,6 +19,7 @@ interface BountyListItem {
   description: string;
   payout_usd: number;
   payout_currency: string;
+  payment_coin: string | null;
   max_submissions: number | null;
   status: string;
   created_at: string;
@@ -36,7 +37,7 @@ export default async function BountiesPage() {
     .from("bounties" as any)
     .select(
       `
-      id, title, description, payout_usd, payout_currency, max_submissions,
+      id, title, description, payout_usd, payout_currency, payment_coin, max_submissions,
       status, created_at,
       creator:profiles!creator_id (id, username, full_name, avatar_url)
     `
@@ -94,10 +95,17 @@ export default async function BountiesPage() {
                 >
                   <div className="flex items-start justify-between gap-3 mb-3">
                     <h2 className="font-semibold line-clamp-2">{b.title}</h2>
-                    <Badge className="bg-green-500/10 text-green-600 border-green-500/20 whitespace-nowrap">
-                      <DollarSign className="h-3 w-3 mr-0.5" />
-                      {Number(b.payout_usd).toFixed(2)}
-                    </Badge>
+                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                      <Badge className="bg-green-500/10 text-green-600 border-green-500/20 whitespace-nowrap">
+                        <DollarSign className="h-3 w-3 mr-0.5" />
+                        {Number(b.payout_usd).toFixed(2)}
+                      </Badge>
+                      {b.payment_coin && (
+                        <Badge variant="secondary" className="text-xs">
+                          {b.payment_coin}
+                        </Badge>
+                      )}
+                    </div>
                   </div>
                   <p className="text-sm text-muted-foreground line-clamp-3 mb-4">
                     {b.description}

--- a/src/app/dashboard/bounties/page.tsx
+++ b/src/app/dashboard/bounties/page.tsx
@@ -39,13 +39,14 @@ export default async function DashboardBountiesPage({
   // Bounties I've created
   const { data: createdData } = await (supabase as any)
     .from("bounties")
-    .select("id, title, payout_usd, max_submissions, status, created_at")
+    .select("id, title, payout_usd, payment_coin, max_submissions, status, created_at")
     .eq("creator_id", user.id)
     .order("created_at", { ascending: false });
   const created = (createdData || []) as Array<{
     id: string;
     title: string;
     payout_usd: number;
+    payment_coin: string | null;
     max_submissions: number | null;
     status: string;
     created_at: string;
@@ -184,6 +185,11 @@ export default async function DashboardBountiesPage({
                           <DollarSign className="h-3 w-3 mr-0.5" />
                           {Number(b.payout_usd).toFixed(2)}
                         </Badge>
+                        {b.payment_coin && (
+                          <Badge variant="secondary" className="text-xs">
+                            {b.payment_coin}
+                          </Badge>
+                        )}
                         <Badge
                           variant="secondary"
                           className="capitalize"

--- a/src/components/gigs/GigForm.tsx
+++ b/src/components/gigs/GigForm.tsx
@@ -12,7 +12,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { GIG_CATEGORIES, AI_TOOLS, SKILLS, PAYMENT_COINS } from "@/types";
+import { GIG_CATEGORIES, AI_TOOLS, SKILLS } from "@/types";
+import { PaymentCoinSelect } from "@/components/ui/PaymentInputs";
 import { X } from "lucide-react";
 
 interface GigFormProps {
@@ -355,20 +356,12 @@ export function GigForm({ initialData, gigId, mode = "create" }: GigFormProps) {
       {/* Payment Coin */}
       <div className="space-y-2">
         <Label htmlFor="payment_coin">Payment Coin</Label>
-        <div className="flex gap-2">
-          <select
-            {...register("payment_coin")}
-            disabled={isLoading}
-            className="w-full border border-input rounded-md px-3 py-2 bg-background"
-          >
-            <option value="">Select coin...</option>
-            {PAYMENT_COINS.map((coin) => (
-              <option key={coin} value={coin}>
-                {coin}
-              </option>
-            ))}
-          </select>
-        </div>
+        <PaymentCoinSelect
+          id="payment_coin"
+          value={paymentCoin || ""}
+          onChange={(v) => setValue("payment_coin", v)}
+          disabled={isLoading}
+        />
         <p className="text-xs text-muted-foreground">
           Which crypto will you pay in? Leave blank for fiat/negotiable.
         </p>

--- a/src/components/ui/PaymentInputs.tsx
+++ b/src/components/ui/PaymentInputs.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { PAYMENT_COINS, SATS_COINS } from "@/types";
+
+// Shared coin + amount inputs used wherever a paid-service form lets the user
+// pick a payout currency and an amount: gigs, for-hire, bounties, etc.
+// The amount is denominated in USD unless the coin is a sats variant.
+
+interface PaymentCoinSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  id?: string;
+  disabled?: boolean;
+  includeBlank?: boolean;
+  blankLabel?: string;
+  className?: string;
+}
+
+export function PaymentCoinSelect({
+  value,
+  onChange,
+  id,
+  disabled,
+  includeBlank = true,
+  blankLabel = "Select coin...",
+  className,
+}: PaymentCoinSelectProps) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className={
+        className ||
+        "w-full border border-input rounded-md px-3 py-2 bg-background"
+      }
+    >
+      {includeBlank && <option value="">{blankLabel}</option>}
+      {PAYMENT_COINS.map((coin) => (
+        <option key={coin} value={coin}>
+          {coin}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+interface AmountInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  coin?: string | null;
+  id?: string;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  /** When true, treats per-unit / fractional pricing styles (step=0.01). */
+  fractional?: boolean;
+  min?: string;
+  step?: string;
+}
+
+export function AmountInput({
+  value,
+  onChange,
+  coin,
+  id,
+  disabled,
+  placeholder,
+  className,
+  fractional = false,
+  min,
+  step,
+}: AmountInputProps) {
+  const isSats = !!coin && SATS_COINS.has(coin);
+  const resolvedStep = step ?? (isSats ? "1" : fractional ? "0.01" : "1");
+  const resolvedPlaceholder =
+    placeholder ?? (isSats ? "e.g. 50000" : "0");
+  return (
+    <input
+      id={id}
+      type="number"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      min={min ?? "0"}
+      step={resolvedStep}
+      placeholder={resolvedPlaceholder}
+      className={
+        className ||
+        "w-full border border-input rounded-md px-3 py-2 bg-background"
+      }
+    />
+  );
+}
+
+/**
+ * Convenience wrapper bundling coin + amount with sensible labels — use this
+ * when a form needs a single fixed payment (e.g. bounty payout). Forms with
+ * budget ranges should use PaymentCoinSelect + AmountInput directly.
+ */
+interface PaymentInputProps {
+  coin: string;
+  onCoinChange: (coin: string) => void;
+  amount: string;
+  onAmountChange: (amount: string) => void;
+  amountLabel?: string;
+  coinLabel?: string;
+  disabled?: boolean;
+}
+
+export function PaymentInput({
+  coin,
+  onCoinChange,
+  amount,
+  onAmountChange,
+  amountLabel = "Amount (USD)",
+  coinLabel = "Payment coin",
+  disabled,
+}: PaymentInputProps) {
+  const isSats = !!coin && SATS_COINS.has(coin);
+  const effectiveLabel = isSats
+    ? amountLabel.replace(/\bUSD\b/i, "sats")
+    : amountLabel;
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div className="space-y-1">
+        <label className="text-sm font-medium">{effectiveLabel}</label>
+        <AmountInput
+          value={amount}
+          onChange={onAmountChange}
+          coin={coin}
+          disabled={disabled}
+          fractional
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="text-sm font-medium">{coinLabel}</label>
+        <PaymentCoinSelect
+          value={coin}
+          onChange={onCoinChange}
+          disabled={disabled}
+        />
+        <p className="text-xs text-muted-foreground">
+          Leave blank for fiat / negotiable.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/bounties.ts
+++ b/src/lib/bounties.ts
@@ -13,6 +13,7 @@ export const createBountySchema = z.object({
   description: z.string().min(10).max(10000),
   payout_usd: z.number().positive().max(100000),
   payout_currency: z.string().default("USD"),
+  payment_coin: z.string().max(16).nullable().optional(),
   max_submissions: z.number().int().positive().max(100000).nullable().optional(),
   closes_at: z.string().datetime().optional(),
   questions: z.array(questionSchema).min(1).max(20),

--- a/supabase/migrations/20260522110000_add_bounty_payment_coin.sql
+++ b/supabase/migrations/20260522110000_add_bounty_payment_coin.sql
@@ -1,0 +1,9 @@
+-- Let bounty creators specify which crypto they'll pay approved submitters
+-- in, matching the payment_coin pattern already used on gigs. Amount stays
+-- denominated in USD; payment_coin selects the crypto for the CoinPay payout.
+
+ALTER TABLE bounties
+  ADD COLUMN IF NOT EXISTS payment_coin text;
+
+COMMENT ON COLUMN bounties.payment_coin IS
+  'Crypto symbol (BTC, SOL, ETH, USDC, USDT, POL, SATS, LN) the creator will use to pay approved submissions. NULL means fiat/negotiable.';


### PR DESCRIPTION
## Summary

Closes a handful of bounty UX gaps in one focused PR:

1. **Edit page** at \`/bounties/[id]/edit\` (creator only) with an Edit button on the detail page. \`BountyForm\` now accepts \`initialData\` + \`bountyId\` and switches between POST and PATCH automatically.
2. **\`payment_coin\` on bounties** (matching gigs). The creator picks a crypto when posting/editing; the pay endpoint passes it through \`resolveSupportedPaymentCurrency\` so CoinPay receives the right currency. Pay endpoint also migrated from \`createInvoice\`/\`sendInvoice\` (hosted invoice) to \`createPayment\` (in-app payment address), mirroring the post-#224 gig invoice flow so payment stays inside uGig.
3. **Shared payment inputs** in \`src/components/ui/PaymentInputs.tsx\`: \`<PaymentCoinSelect>\`, \`<AmountInput>\`, \`<PaymentInput>\`. \`GigForm\` consumes the coin select; \`BountyForm\` uses the combined input. Single source of truth for \`PAYMENT_COINS\`-backed UI across all paid surfaces.
4. **Markdown bounty descriptions** rendered via \`<MarkdownContent>\` (GFM + breaks + external-link normalization). URLs auto-linkify; same renderer used for gig descriptions.

## Migration

\`supabase/migrations/20260522110000_add_bounty_payment_coin.sql\` — already applied to production and recorded in \`supabase_migrations.schema_migrations\`.

## Test plan

- [ ] Create a new bounty at \`/bounties/new\` with a crypto coin selected — confirm it persists and shows the coin badge on the browse + detail + dashboard cards.
- [ ] On a bounty I created, click Edit → change the title, payout, and coin → save → confirm changes stick and existing submissions are untouched.
- [ ] Try \`/bounties/{otherUserBounty}/edit\` while signed in as a non-creator → confirm redirect to the detail page.
- [ ] Approve a submission and click Pay → confirm CoinPay receives a payment in the selected coin (or a sensible fallback if the coin isn't supported by the merchant).
- [ ] Put markdown + a bare URL in the description → confirm rendering with headings, bold, and a clickable link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)