### PR TITLE
feat(bounties): show payout as "$2.00 USD (paid in SOL)" — match gig style

### DIFF
--- a/src/app/bounties/[id]/page.tsx
+++ b/src/app/bounties/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
   Pencil,
 } from "lucide-react";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";
+import { formatBountyPayout } from "@/lib/bounties";
 import { SubmitForm } from "./SubmitForm";
 import { ReviewPanel } from "./ReviewPanel";
 
@@ -140,36 +141,31 @@ export default async function BountyDetailPage({
                   )}
                 </p>
               </div>
-              <div className="flex items-center gap-2 flex-shrink-0">
-                <Badge className="bg-green-500/10 text-green-600 border-green-500/20 text-base">
-                  <DollarSign className="h-4 w-4 mr-0.5" />
-                  {Number(bounty.payout_usd).toFixed(2)}
-                </Badge>
-                {bounty.payment_coin && (
-                  <Badge variant="secondary">{bounty.payment_coin}</Badge>
-                )}
-                {isCreator && (
-                  <Link href={`/bounties/${bounty.id}/edit`}>
-                    <Button size="sm" variant="outline" className="gap-1.5">
-                      <Pencil className="h-3.5 w-3.5" />
-                      Edit
-                    </Button>
-                  </Link>
-                )}
-              </div>
+              {isCreator && (
+                <Link href={`/bounties/${bounty.id}/edit`} className="flex-shrink-0">
+                  <Button size="sm" variant="outline" className="gap-1.5">
+                    <Pencil className="h-3.5 w-3.5" />
+                    Edit
+                  </Button>
+                </Link>
+              )}
             </div>
 
             <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground mb-6">
-              <div className="inline-flex items-center gap-1.5">
+              <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+                <DollarSign className="h-4 w-4" />
+                {formatBountyPayout(bounty.payout_usd, bounty.payment_coin)}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
                 <Users className="h-4 w-4" />
                 {submissionCount || 0} submission
                 {(submissionCount ?? 0) === 1 ? "" : "s"}
                 {bounty.max_submissions && ` / ${bounty.max_submissions}`}
-              </div>
-              <div className="inline-flex items-center gap-1.5">
+              </span>
+              <span className="inline-flex items-center gap-1.5">
                 <Clock className="h-4 w-4" />
                 Posted {new Date(bounty.created_at).toLocaleDateString()}
-              </div>
+              </span>
               {bounty.status !== "open" && (
                 <Badge variant="secondary" className="capitalize">
                   {bounty.status}

--- a/src/app/bounties/page.tsx
+++ b/src/app/bounties/page.tsx
@@ -3,8 +3,8 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { Header } from "@/components/layout/Header";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Target, DollarSign, Users, Plus } from "lucide-react";
+import { formatBountyPayout } from "@/lib/bounties";
 
 export const metadata: Metadata = {
   title: "Bounties | ugig.net",
@@ -93,32 +93,23 @@ export default async function BountiesPage() {
                   href={`/bounties/${b.id}`}
                   className="p-5 bg-card rounded-lg border border-border shadow-sm hover:shadow-md hover:border-primary/30 transition-all duration-200"
                 >
-                  <div className="flex items-start justify-between gap-3 mb-3">
-                    <h2 className="font-semibold line-clamp-2">{b.title}</h2>
-                    <div className="flex items-center gap-1.5 flex-shrink-0">
-                      <Badge className="bg-green-500/10 text-green-600 border-green-500/20 whitespace-nowrap">
-                        <DollarSign className="h-3 w-3 mr-0.5" />
-                        {Number(b.payout_usd).toFixed(2)}
-                      </Badge>
-                      {b.payment_coin && (
-                        <Badge variant="secondary" className="text-xs">
-                          {b.payment_coin}
-                        </Badge>
-                      )}
-                    </div>
-                  </div>
+                  <h2 className="font-semibold line-clamp-2 mb-2">{b.title}</h2>
                   <p className="text-sm text-muted-foreground line-clamp-3 mb-4">
                     {b.description}
                   </p>
-                  <div className="flex items-center justify-between text-xs text-muted-foreground">
-                    <span>
+                  <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground border-t border-border pt-3">
+                    <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+                      <DollarSign className="h-4 w-4" />
+                      {formatBountyPayout(b.payout_usd, b.payment_coin)}
+                    </span>
+                    <span className="text-xs">
                       by{" "}
                       {b.creator?.full_name ||
                         b.creator?.username ||
                         "Anonymous"}
                     </span>
                     {b.max_submissions && (
-                      <span className="inline-flex items-center gap-1">
+                      <span className="inline-flex items-center gap-1 text-xs">
                         <Users className="h-3 w-3" />
                         Cap: {b.max_submissions}
                       </span>

--- a/src/app/dashboard/bounties/page.tsx
+++ b/src/app/dashboard/bounties/page.tsx
@@ -12,6 +12,7 @@ import {
   Clock,
   XCircle,
 } from "lucide-react";
+import { formatBountyPayout } from "@/lib/bounties";
 
 export const metadata = {
   title: "My Bounties | ugig.net",
@@ -83,7 +84,7 @@ export default async function DashboardBountiesPage({
     .select(
       `
       id, status, payout_status, pay_url, created_at,
-      bounty:bounties (id, title, payout_usd)
+      bounty:bounties (id, title, payout_usd, payment_coin)
     `
     )
     .eq("submitter_id", user.id)
@@ -94,7 +95,7 @@ export default async function DashboardBountiesPage({
     payout_status: "unpaid" | "invoiced" | "paid";
     pay_url: string | null;
     created_at: string;
-    bounty: { id: string; title: string; payout_usd: number } | null;
+    bounty: { id: string; title: string; payout_usd: number; payment_coin: string | null } | null;
   }>;
 
   return (
@@ -180,25 +181,15 @@ export default async function DashboardBountiesPage({
                           Posted {new Date(b.created_at).toLocaleDateString()}
                         </p>
                       </div>
-                      <div className="flex items-center gap-2">
-                        <Badge className="bg-green-500/10 text-green-600 border-green-500/20">
-                          <DollarSign className="h-3 w-3 mr-0.5" />
-                          {Number(b.payout_usd).toFixed(2)}
-                        </Badge>
-                        {b.payment_coin && (
-                          <Badge variant="secondary" className="text-xs">
-                            {b.payment_coin}
-                          </Badge>
-                        )}
-                        <Badge
-                          variant="secondary"
-                          className="capitalize"
-                        >
-                          {b.status}
-                        </Badge>
-                      </div>
+                      <Badge variant="secondary" className="capitalize">
+                        {b.status}
+                      </Badge>
                     </div>
                     <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground mt-2">
+                      <span className="inline-flex items-center gap-1 text-sm text-foreground font-medium">
+                        <DollarSign className="h-3.5 w-3.5" />
+                        {formatBountyPayout(b.payout_usd, b.payment_coin)}
+                      </span>
                       <span>
                         {stat.total} submission{stat.total === 1 ? "" : "s"}
                         {b.max_submissions && ` / ${b.max_submissions}`}
@@ -266,7 +257,7 @@ export default async function DashboardBountiesPage({
                 <p className="text-xs text-muted-foreground">
                   Submitted {new Date(s.created_at).toLocaleDateString()}
                   {s.bounty && (
-                    <> · ${Number(s.bounty.payout_usd).toFixed(2)} payout</>
+                    <> · {formatBountyPayout(s.bounty.payout_usd, s.bounty.payment_coin)} payout</>
                   )}
                 </p>
               </Link>

--- a/src/lib/bounties.ts
+++ b/src/lib/bounties.ts
@@ -1,4 +1,19 @@
 import { z } from "zod";
+import { formatCurrency } from "@/lib/utils";
+
+/**
+ * Human label for a bounty payout, matching the gig card style:
+ * "$2.00 USD (paid in SOL)" when a coin is set, otherwise "$2.00 USD".
+ * Centralized so browse/detail/dashboard stay consistent.
+ */
+export function formatBountyPayout(
+  amountUsd: number | string,
+  paymentCoin: string | null | undefined
+): string {
+  const amount = Number(amountUsd);
+  const usd = `${formatCurrency(amount)} USD`;
+  return paymentCoin ? `${usd} (paid in ${paymentCoin})` : usd;
+}
 
 export const questionSchema = z.object({
   id: z.string().min(1).max(64),


### PR DESCRIPTION
## Summary

The previous bounty payout UI used a colored \$-badge plus a small secondary coin chip. Per UX feedback, it didn't clearly communicate "this is USD, paid in this crypto." Replaced with the same plain-text-with-\$-icon row that gig cards already use, surfaced via a new \`formatBountyPayout()\` helper in \`src/lib/bounties.ts\`.

Now browse cards, detail page, and dashboard all read the same way:
- With a coin set: \`\$2.00 USD (paid in SOL)\`
- Without a coin: \`\$2.00 USD\`

## Test plan

- [ ] Visit \`/bounties\` and confirm each card shows the new format in the bottom stats row alongside author/cap.
- [ ] Visit a bounty detail page and confirm the payout sits in the meta row beside submission count, posted-date, and status.
- [ ] Visit \`/dashboard/bounties\` and confirm both the "Bounties I posted" cards and "My submissions" cards use the same format.
- [ ] Edit a bounty to remove the payment_coin → confirm the display gracefully degrades to \`\$X USD\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)