### PR TITLE
feat(ui): shared <PriceBox> across gigs, for-hire, and bounties

### DIFF
--- a/src/app/bounties/[id]/page.tsx
+++ b/src/app/bounties/[id]/page.tsx
@@ -6,13 +6,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   ArrowLeft,
-  DollarSign,
   Users,
   Clock,
   Lock,
   Pencil,
 } from "lucide-react";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";
+import { PriceBox, PriceBoxRow } from "@/components/ui/PriceBox";
 import { formatBountyPayout } from "@/lib/bounties";
 import { SubmitForm } from "./SubmitForm";
 import { ReviewPanel } from "./ReviewPanel";
@@ -113,21 +113,28 @@ export default async function BountyDetailPage({
   return (
     <>
       <Header />
-      <main className="container mx-auto px-4 py-8">
-        <div className="max-w-3xl mx-auto">
-          <Link
-            href="/bounties"
-            className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            All bounties
-          </Link>
+      <main className="container mx-auto px-4 py-8 max-w-5xl">
+        <Link
+          href="/bounties"
+          className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          All bounties
+        </Link>
 
-          <div className="bg-card border border-border rounded-lg p-6 shadow-sm mb-6">
-            <div className="flex items-start justify-between gap-4 mb-4">
-              <div>
-                <h1 className="text-2xl font-bold mb-2">{bounty.title}</h1>
-                <p className="text-sm text-muted-foreground">
+        <div className="grid lg:grid-cols-3 gap-8">
+          <div className="lg:col-span-2 space-y-8">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                {bounty.status !== "open" && (
+                  <Badge variant="secondary" className="capitalize">
+                    {bounty.status}
+                  </Badge>
+                )}
+              </div>
+              <h1 className="text-3xl font-bold mb-4">{bounty.title}</h1>
+              <div className="flex flex-wrap items-center gap-4 text-muted-foreground">
+                <span>
                   Posted by{" "}
                   {bounty.creator?.username ? (
                     <Link
@@ -139,94 +146,105 @@ export default async function BountyDetailPage({
                   ) : (
                     creatorName
                   )}
-                </p>
+                </span>
+                <span className="flex items-center gap-1">
+                  <Clock className="h-4 w-4" />
+                  Posted {new Date(bounty.created_at).toLocaleDateString()}
+                </span>
+                <span className="flex items-center gap-1">
+                  <Users className="h-4 w-4" />
+                  {submissionCount || 0} submission
+                  {(submissionCount ?? 0) === 1 ? "" : "s"}
+                  {bounty.max_submissions && ` / ${bounty.max_submissions}`}
+                </span>
               </div>
-              {isCreator && (
-                <Link href={`/bounties/${bounty.id}/edit`} className="flex-shrink-0">
-                  <Button size="sm" variant="outline" className="gap-1.5">
-                    <Pencil className="h-3.5 w-3.5" />
-                    Edit
-                  </Button>
-                </Link>
-              )}
             </div>
 
-            <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground mb-6">
-              <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
-                <DollarSign className="h-4 w-4" />
-                {formatBountyPayout(bounty.payout_usd, bounty.payment_coin)}
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <Users className="h-4 w-4" />
+            <div>
+              <h2 className="text-xl font-semibold mb-4">Description</h2>
+              <MarkdownContent content={bounty.description || ""} />
+            </div>
+
+            {/* Creator view: review panel */}
+            {isCreator ? (
+              <div>
+                <h2 className="text-lg font-semibold mb-4">Submissions</h2>
+                <ReviewPanel
+                  bountyId={bounty.id}
+                  payoutUsd={Number(bounty.payout_usd)}
+                  questions={bounty.questions || []}
+                  submissions={submissions}
+                />
+              </div>
+            ) : (
+              // Submitter view
+              <div className="bg-card border border-border rounded-lg p-6 shadow-sm">
+                {!user ? (
+                  <div className="text-center py-6">
+                    <Lock className="h-8 w-8 text-muted-foreground/50 mx-auto mb-3" />
+                    <p className="text-muted-foreground mb-4">
+                      Sign in to submit to this bounty.
+                    </p>
+                    <Link href={`/login?redirect=/bounties/${bounty.id}`}>
+                      <Button>Sign in</Button>
+                    </Link>
+                  </div>
+                ) : bounty.status !== "open" ? (
+                  <div className="text-center py-6 text-sm text-muted-foreground">
+                    This bounty is no longer accepting submissions.
+                  </div>
+                ) : mySubmission ? (
+                  <div className="text-center py-6">
+                    <p className="font-medium mb-1">
+                      You&apos;ve already submitted to this bounty.
+                    </p>
+                    <p className="text-sm text-muted-foreground capitalize">
+                      Status: {mySubmission.status}
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    <h2 className="text-lg font-semibold mb-4">
+                      Submit to this bounty
+                    </h2>
+                    <SubmitForm
+                      bountyId={bounty.id}
+                      questions={bounty.questions || []}
+                    />
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Sidebar */}
+          <div className="space-y-6">
+            <PriceBox
+              amount={formatBountyPayout(bounty.payout_usd, bounty.payment_coin)}
+              subtitle="Per approved submission"
+              topRight={
+                isCreator ? (
+                  <Link href={`/bounties/${bounty.id}/edit`}>
+                    <Button size="sm" variant="outline" className="gap-1.5">
+                      <Pencil className="h-3.5 w-3.5" />
+                      Edit
+                    </Button>
+                  </Link>
+                ) : null
+              }
+            >
+              <PriceBoxRow icon={<Users className="h-4 w-4" />}>
                 {submissionCount || 0} submission
                 {(submissionCount ?? 0) === 1 ? "" : "s"}
                 {bounty.max_submissions && ` / ${bounty.max_submissions}`}
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <Clock className="h-4 w-4" />
-                Posted {new Date(bounty.created_at).toLocaleDateString()}
-              </span>
-              {bounty.status !== "open" && (
-                <Badge variant="secondary" className="capitalize">
-                  {bounty.status}
-                </Badge>
+              </PriceBoxRow>
+              {!isCreator && bounty.status === "open" && user && !mySubmission && (
+                <p className="text-xs text-muted-foreground pt-2 border-t border-border">
+                  Scroll down to submit your answers.
+                </p>
               )}
-            </div>
-
-            <MarkdownContent content={bounty.description || ""} />
-
+            </PriceBox>
           </div>
-
-          {/* Creator view: review panel */}
-          {isCreator ? (
-            <div>
-              <h2 className="text-lg font-semibold mb-4">Submissions</h2>
-              <ReviewPanel
-                bountyId={bounty.id}
-                payoutUsd={Number(bounty.payout_usd)}
-                questions={bounty.questions || []}
-                submissions={submissions}
-              />
-            </div>
-          ) : (
-            // Submitter view
-            <div className="bg-card border border-border rounded-lg p-6 shadow-sm">
-              {!user ? (
-                <div className="text-center py-6">
-                  <Lock className="h-8 w-8 text-muted-foreground/50 mx-auto mb-3" />
-                  <p className="text-muted-foreground mb-4">
-                    Sign in to submit to this bounty.
-                  </p>
-                  <Link href={`/login?redirect=/bounties/${bounty.id}`}>
-                    <Button>Sign in</Button>
-                  </Link>
-                </div>
-              ) : bounty.status !== "open" ? (
-                <div className="text-center py-6 text-sm text-muted-foreground">
-                  This bounty is no longer accepting submissions.
-                </div>
-              ) : mySubmission ? (
-                <div className="text-center py-6">
-                  <p className="font-medium mb-1">
-                    You&apos;ve already submitted to this bounty.
-                  </p>
-                  <p className="text-sm text-muted-foreground capitalize">
-                    Status: {mySubmission.status}
-                  </p>
-                </div>
-              ) : (
-                <>
-                  <h2 className="text-lg font-semibold mb-4">
-                    Submit to this bounty
-                  </h2>
-                  <SubmitForm
-                    bountyId={bounty.id}
-                    questions={bounty.questions || []}
-                  />
-                </>
-              )}
-            </div>
-          )}
         </div>
       </main>
     </>

--- a/src/app/gigs/[id]/page.tsx
+++ b/src/app/gigs/[id]/page.tsx
@@ -26,6 +26,7 @@ import { CloseGigButton } from "@/components/gigs/CloseGigButton";
 import { EscrowPaymentButton } from "@/components/gigs/EscrowPaymentButton";
 import { InvoiceButton } from "@/components/gigs/InvoiceButton";
 import { SatsRangeToUsd } from "@/components/gigs/SatsToUsd";
+import { PriceBox, PriceBoxRow } from "@/components/ui/PriceBox";
 import { ZapButton } from "@/components/zaps/ZapButton";
 import { GigTestimonialSection } from "@/components/testimonials/GigTestimonialSection";
 import { HiredWorkerReview } from "@/components/gigs/HiredWorkerReview";
@@ -425,34 +426,26 @@ export default async function GigPage({ params }: GigPageProps) {
           {/* Sidebar */}
           <div className="space-y-6">
             {/* Apply Card */}
-            <div className="border border-border rounded-lg p-6 bg-card">
-              <div className="space-y-4">
-                <div className="flex items-center gap-2">
-                  <DollarSign className="h-5 w-5 text-primary" />
-                  <span className="text-2xl font-bold">{budgetDisplay}</span>
-                </div>
-                {gig.payment_coin && (gig.payment_coin === "SATS" || gig.payment_coin === "LN" || gig.payment_coin === "BTC") && (gig.budget_min || gig.budget_max) && (
+            <PriceBox
+              amount={budgetDisplay}
+              amountHint={
+                gig.payment_coin && (gig.payment_coin === "SATS" || gig.payment_coin === "LN" || gig.payment_coin === "BTC") && (gig.budget_min || gig.budget_max) ? (
                   <SatsRangeToUsd min={gig.budget_min} max={gig.budget_max} className="text-sm text-muted-foreground" />
-                )}
-                <div className="text-sm text-muted-foreground">
-                  <span className="capitalize">{gig.budget_type.replace("_", " ")}</span> rate{gig.budget_unit ? ` (per ${gig.budget_unit})` : ""}
-                </div>
+                ) : null
+              }
+              subtitle={
+                <><span className="capitalize">{gig.budget_type.replace("_", " ")}</span> rate{gig.budget_unit ? ` (per ${gig.budget_unit})` : ""}</>
+              }
+            >
+              {gig.duration && (
+                <PriceBoxRow icon={<Briefcase className="h-4 w-4" />}>{gig.duration}</PriceBoxRow>
+              )}
 
-                {gig.duration && (
-                  <div className="flex items-center gap-2 text-muted-foreground">
-                    <Briefcase className="h-4 w-4" />
-                    <span>{gig.duration}</span>
-                  </div>
-                )}
+              {gig.location && (
+                <PriceBoxRow icon={<MapPin className="h-4 w-4" />}>{gig.location}</PriceBoxRow>
+              )}
 
-                {gig.location && (
-                  <div className="flex items-center gap-2 text-muted-foreground">
-                    <MapPin className="h-4 w-4" />
-                    <span>{gig.location}</span>
-                  </div>
-                )}
-
-                {gig.status === "active" && !isOwner && (
+              {gig.status === "active" && !isOwner && (
                   <>
                     {user ? (
                       hasApplied ? (
@@ -518,8 +511,7 @@ export default async function GigPage({ params }: GigPageProps) {
                     )}
                   </div>
                 )}
-              </div>
-            </div>
+            </PriceBox>
 
             {/* Poster Info */}
             {poster && (

--- a/src/components/ui/PriceBox.tsx
+++ b/src/components/ui/PriceBox.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import { DollarSign } from "lucide-react";
+
+// Shared "price box" card used on detail pages for paid services (gigs,
+// for-hire, bounties, etc.). Matches the sidebar widget on /gigs/[id]:
+// dollar icon + 2xl bold amount, optional subtitle, then any meta rows
+// (e.g. duration, location) and an action slot.
+
+interface PriceBoxProps {
+  amount: string;
+  /** Optional small line under the amount, e.g. "Fixed rate" or "Per approval". */
+  subtitle?: ReactNode;
+  /** Inline content rendered immediately under the amount (e.g. sats-to-USD hint). */
+  amountHint?: ReactNode;
+  /** Top-right slot for badges or actions like an Edit button. */
+  topRight?: ReactNode;
+  /** Meta rows + action buttons. Use <PriceBoxRow> for icon+text rows. */
+  children?: ReactNode;
+  className?: string;
+}
+
+export function PriceBox({
+  amount,
+  subtitle,
+  amountHint,
+  topRight,
+  children,
+  className,
+}: PriceBoxProps) {
+  return (
+    <div
+      className={`border border-border rounded-lg p-6 bg-card space-y-4 ${className || ""}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <DollarSign className="h-5 w-5 text-primary flex-shrink-0" />
+          <span className="text-2xl font-bold leading-tight break-words">
+            {amount}
+          </span>
+        </div>
+        {topRight && <div className="flex-shrink-0">{topRight}</div>}
+      </div>
+      {amountHint && <div className="text-sm text-muted-foreground">{amountHint}</div>}
+      {subtitle && <div className="text-sm text-muted-foreground">{subtitle}</div>}
+      {children}
+    </div>
+  );
+}
+
+interface PriceBoxRowProps {
+  icon?: ReactNode;
+  children: ReactNode;
+}
+
+export function PriceBoxRow({ icon, children }: PriceBoxRowProps) {
+  return (
+    <div className="flex items-center gap-2 text-muted-foreground">
+      {icon && <span className="flex-shrink-0">{icon}</span>}
+      <span>{children}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Per UX request, the bounty detail page should use the same price widget that gigs use. Extracted the gig sidebar's "price box" into a shared component so every paid-service surface displays payout the same way.

- **New** \`src/components/ui/PriceBox.tsx\` exposing \`<PriceBox>\` + \`<PriceBoxRow>\`. \$ icon, 2xl bold amount, optional subtitle, slot for meta rows + actions, and a \`topRight\` slot for inline buttons.
- **Gig detail** (\`/gigs/[id]\`, which \`/for-hire/[id]\` re-exports) refactored to use \`<PriceBox>\` instead of an inline card.
- **Bounty detail** restructured from a single column into the same 2-column layout gigs use, with \`<PriceBox>\` in the sidebar showing the payout, submission count, and the creator's Edit button.

No data model or API changes — purely UI consolidation.

## Test plan

- [ ] Open a gig — confirm the sidebar Apply card looks identical to before.
- [ ] Open a for-hire listing — same.
- [ ] Open a bounty as a logged-out visitor — confirm sidebar shows payout, submission count, and the description/form sits to the left.
- [ ] Open a bounty as the creator — confirm Edit button shows in the sidebar (top-right of the PriceBox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)