### PR TITLE
Show in-app invoice payment details

### DIFF
--- a/src/app/dashboard/invoices/PayApplicantButton.tsx
+++ b/src/app/dashboard/invoices/PayApplicantButton.tsx
@@ -2,13 +2,20 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Loader2, ExternalLink, DollarSign } from "lucide-react";
+import { CheckCircle2, Copy, DollarSign, Loader2 } from "lucide-react";
 
 interface PayApplicantButtonProps {
   gigId: string;
   applicationId: string;
   suggestedAmount: number | null;
   workerName: string;
+}
+
+interface PaymentDetails {
+  payment_address: string | null;
+  amount_crypto: number | string | null;
+  payment_currency: string | null;
+  expires_at: string | null;
 }
 
 export function PayApplicantButton({
@@ -22,7 +29,9 @@ export function PayApplicantButton({
   const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [payUrl, setPayUrl] = useState<string | null>(null);
+  const [paymentDetails, setPaymentDetails] = useState<PaymentDetails | null>(
+    null
+  );
 
   const submit = async () => {
     const parsed = parseFloat(amount);
@@ -48,7 +57,20 @@ export function PayApplicantButton({
         setError(json.error || "Failed to create invoice");
         return;
       }
-      setPayUrl(json.data?.pay_url || null);
+      setPaymentDetails({
+        payment_address:
+          json.data?.payment_address ??
+          json.data?.metadata?.payment_address ??
+          null,
+        amount_crypto:
+          json.data?.amount_crypto ?? json.data?.metadata?.amount_crypto ?? null,
+        payment_currency:
+          json.data?.payment_currency ??
+          json.data?.metadata?.payment_currency ??
+          null,
+        expires_at:
+          json.data?.expires_at ?? json.data?.metadata?.expires_at ?? null,
+      });
     } catch {
       setError("Network error. Try again.");
     } finally {
@@ -56,17 +78,56 @@ export function PayApplicantButton({
     }
   };
 
-  if (payUrl) {
+  if (paymentDetails) {
+    const amountDue = paymentDetails.amount_crypto
+      ? `${paymentDetails.amount_crypto} ${
+          paymentDetails.payment_currency || ""
+        }`.trim()
+      : paymentDetails.payment_currency || "the selected coin";
+
     return (
-      <a
-        href={payUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-      >
-        <ExternalLink className="h-4 w-4" />
-        Open payment link
-      </a>
+      <div className="border border-border rounded-lg p-3 space-y-2 bg-background">
+        <div className="flex items-center gap-2 text-sm font-medium text-green-600">
+          <CheckCircle2 className="h-4 w-4" />
+          Payment details ready for {workerName}
+        </div>
+        {paymentDetails.payment_address ? (
+          <div className="rounded-md border border-border bg-muted/30 p-3 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs font-medium text-muted-foreground">
+                Payment address
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={() =>
+                  navigator.clipboard?.writeText(
+                    paymentDetails.payment_address || ""
+                  )
+                }
+              >
+                <Copy className="h-3 w-3" />
+                Copy
+              </Button>
+            </div>
+            <code className="block break-all rounded bg-background px-2 py-1.5 text-xs">
+              {paymentDetails.payment_address}
+            </code>
+            <p className="text-xs text-muted-foreground">
+              Send {amountDue} to this address.
+              {paymentDetails.expires_at
+                ? ` Expires ${new Date(paymentDetails.expires_at).toLocaleString()}.`
+                : ""}
+            </p>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            The invoice was created, but no in-app payment address was returned.
+          </p>
+        )}
+      </div>
     );
   }
 
@@ -107,7 +168,7 @@ export function PayApplicantButton({
       <div className="flex gap-2">
         <Button size="sm" disabled={submitting || !amount} onClick={submit} className="flex-1">
           {submitting ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
-          Create payment link
+          Prepare payment
         </Button>
         <Button size="sm" variant="outline" onClick={() => setOpen(false)}>
           Cancel

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -40,6 +40,12 @@ interface InvoiceRow {
   pay_url: string | null;
   notes: string | null;
   due_date: string | null;
+  metadata: {
+    payment_address?: string | null;
+    amount_crypto?: number | string | null;
+    payment_currency?: string | null;
+    expires_at?: string | null;
+  } | null;
   created_at: string;
   gig: { id: string; title: string } | null;
   worker: Counterparty | null;
@@ -91,6 +97,33 @@ function statusBadge(status: InvoiceRow["status"]) {
 function counterpartyName(c: Counterparty | null): string {
   if (!c) return "Unknown";
   return c.full_name || c.username || "Unknown";
+}
+
+function paymentAmount(inv: InvoiceRow): string {
+  if (inv.metadata?.amount_crypto) {
+    return `${inv.metadata.amount_crypto} ${
+      inv.metadata.payment_currency || ""
+    }`.trim();
+  }
+  return inv.metadata?.payment_currency || "the selected coin";
+}
+
+function paymentDetails(inv: InvoiceRow, label: string) {
+  if (!inv.metadata?.payment_address) return null;
+  return (
+    <div className="rounded-md border border-border bg-muted/30 p-3 space-y-2 mb-3">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <code className="block break-all rounded bg-background px-2 py-1.5 text-xs">
+        {inv.metadata.payment_address}
+      </code>
+      <p className="text-xs text-muted-foreground">
+        Send {paymentAmount(inv)} to this address.
+        {inv.metadata.expires_at
+          ? ` Expires ${new Date(inv.metadata.expires_at).toLocaleString()}.`
+          : ""}
+      </p>
+    </div>
+  );
 }
 
 export default async function InvoicesDashboardPage({
@@ -232,8 +265,8 @@ export default async function InvoicesDashboardPage({
               Accepted applicants awaiting payment
             </h2>
             <p className="text-sm text-muted-foreground mb-4">
-              These workers were accepted but no invoice exists yet. Generate a payment link
-              now and they&apos;ll be notified.
+              These workers were accepted but no invoice exists yet. Prepare in-app
+              payment details now and they&apos;ll be notified.
             </p>
             <div className="space-y-3">
               {acceptedNeedingInvoice.map((app) => {
@@ -342,6 +375,14 @@ export default async function InvoicesDashboardPage({
                       <p className="text-sm text-muted-foreground mb-3">{inv.notes}</p>
                     )}
 
+                    {tab === "received" &&
+                      inv.status === "sent" &&
+                      paymentDetails(inv, "In-app payment details")}
+
+                    {tab === "sent" &&
+                      inv.status === "sent" &&
+                      paymentDetails(inv, "Payment details shared with client")}
+
                     <div className="flex items-center justify-between text-xs text-muted-foreground">
                       <span>
                         Created {new Date(inv.created_at).toLocaleDateString()}
@@ -349,28 +390,34 @@ export default async function InvoicesDashboardPage({
                           <> · Due {new Date(inv.due_date).toLocaleDateString()}</>
                         )}
                       </span>
-                      {tab === "received" && inv.status === "sent" && inv.pay_url && (
-                        <a
-                          href={inv.pay_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-                        >
-                          <ExternalLink className="h-4 w-4" />
-                          Pay now
-                        </a>
-                      )}
-                      {tab === "sent" && inv.status === "sent" && inv.pay_url && (
-                        <a
-                          href={inv.pay_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-                        >
-                          <ExternalLink className="h-3 w-3" />
-                          View payment link
-                        </a>
-                      )}
+                      {tab === "received" &&
+                        inv.status === "sent" &&
+                        !inv.metadata?.payment_address &&
+                        inv.pay_url && (
+                          <a
+                            href={inv.pay_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                          >
+                            <ExternalLink className="h-4 w-4" />
+                            Pay now
+                          </a>
+                        )}
+                      {tab === "sent" &&
+                        inv.status === "sent" &&
+                        !inv.metadata?.payment_address &&
+                        inv.pay_url && (
+                          <a
+                            href={inv.pay_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                          >
+                            <ExternalLink className="h-3 w-3" />
+                            View payment link
+                          </a>
+                        )}
                     </div>
                   </div>
                 );


### PR DESCRIPTION
## Summary
- Show CoinPay payment addresses directly in the invoices dashboard after an in-app payment is prepared.
- Update the poster payment action to render the returned payment address, crypto amount, currency, expiry, and copy action instead of waiting for an external pay_url.
- Keep legacy pay_url links only as a fallback when older invoice records do not have embedded payment metadata.

## Bug fixed
The invoice API now returns pay_url: null and stores payment details in metadata so users are not sent to coinpayportal.com. The dashboard still assumed pay_url was the primary success path, so creating a payment could succeed without showing the poster any address to pay. Existing invoice rows had the same problem.

## Verification
- git diff --check -- src/app/dashboard/invoices/PayApplicantButton.tsx src/app/dashboard/invoices/page.tsx
- Full type/test run was blocked in this local checkout: the machine only has Node 18.20.8 while Next 16/Supabase/Vitest packages require Node 20+, and npm ci also reports package-lock.json is out of sync with package.json.