### PR TITLE
Fix affiliate dashboard profile links

### DIFF
--- a/src/app/dashboard/affiliates/[id]/page.tsx
+++ b/src/app/dashboard/affiliates/[id]/page.tsx
@@ -408,7 +408,7 @@ export default function SellerOfferDetailPage() {
                         )}
                         {aff.username ? (
                           <Link
-                            href={`/@${aff.username}`}
+                            href={`/u/${encodeURIComponent(aff.username)}`}
                             className="font-medium hover:underline"
                           >
                             @{aff.username}
@@ -585,7 +585,7 @@ export default function SellerOfferDetailPage() {
                     <td className="p-3">
                       {conv.username ? (
                         <Link
-                          href={`/@${conv.username}`}
+                          href={`/u/${encodeURIComponent(conv.username)}`}
                           className="font-medium hover:underline"
                         >
                           @{conv.username}


### PR DESCRIPTION
## Summary
- Fix affiliate dashboard profile links for affiliate rows and recent conversion rows.
- Replace the non-existent /@username URL with the real public profile route /u/[username].
- URL-encode usernames before placing them in the route.

## Bug fixed
The seller affiliate dashboard displayed clickable @username links, but those links pointed to /@username. This app's profile pages live under /u/[username], so the links broke the affiliate management flow when a seller tried to inspect an affiliate or conversion owner.

## Verification
- git diff --check -- src/app/dashboard/affiliates/[id]/page.tsx
- Full type/test run remains blocked in this local checkout because the machine only has Node 18.20.8 while project dependencies require Node 20+, and npm ci reports package-lock.json is out of sync with package.json.