### PR TITLE
Avoid wallet enumeration for preferred invoice coin

### DIFF
--- a/src/lib/coinpayportal.test.ts
+++ b/src/lib/coinpayportal.test.ts
@@ -188,13 +188,18 @@ describe("CoinPayPortal supported coins API", () => {
     ]);
   });
 
-  it("resolves a preferred gig coin from active CoinPay wallets", async () => {
+  it("resolves a preferred gig coin without requiring business wallet enumeration", async () => {
     await expect(resolveSupportedPaymentCurrency("SOL")).resolves.toBe("sol");
+    expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("rejects preferred gig coins not configured in CoinPay", async () => {
-    await expect(resolveSupportedPaymentCurrency("ETH")).rejects.toThrow(
-      "CoinPayPortal does not have an active ETH wallet configured"
+  it("falls back to active business wallets when no preferred coin is set", async () => {
+    await expect(resolveSupportedPaymentCurrency()).resolves.toBe("sol");
+  });
+
+  it("rejects unsupported preferred gig coins after checking CoinPay wallets", async () => {
+    await expect(resolveSupportedPaymentCurrency("SATS")).rejects.toThrow(
+      "CoinPayPortal does not have an active SATS wallet configured"
     );
   });
 });

--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -199,6 +199,21 @@ function normalizeCoinSymbol(value?: string | null): string {
     .replace(/[\s-]+/g, "_");
 }
 
+function preferredCoinToSupportedCurrency(value?: string | null): SupportedCurrency | null {
+  const directCurrency = normalizeCurrencyKey(value);
+  if (isSupportedCurrency(directCurrency)) return directCurrency;
+
+  const symbol = normalizeCoinSymbol(value);
+  if (symbol === "BTC") return "btc";
+  if (symbol === "ETH") return "eth";
+  if (symbol === "POL" || symbol === "MATIC") return "pol";
+  if (symbol === "SOL") return "sol";
+  if (symbol === "USDT") return "usdt";
+  if (symbol === "USDC") return "usdc_sol";
+
+  return null;
+}
+
 export function coinToPaymentCurrency(coin: SupportedCoin): SupportedCurrency | null {
   const directCurrency =
     normalizeCurrencyKey(coin.currency) ||
@@ -396,6 +411,11 @@ export async function resolveSupportedPaymentCurrency(
   preferredCoin?: string | null,
   options: { business_id?: string } = {}
 ): Promise<SupportedCurrency> {
+  if (preferredCoin) {
+    const directCurrency = preferredCoinToSupportedCurrency(preferredCoin);
+    if (directCurrency) return directCurrency;
+  }
+
   const coins = await getBusinessWalletCurrencies({
     business_id: options.business_id,
   });


### PR DESCRIPTION
## Summary
- Resolve explicit gig payment coins directly to CoinPay payment currencies before calling business wallet enumeration
- Avoid blocking accepted-gig invoice creation on the CoinPay /businesses endpoint when a gig already declares SOL/ETH/BTC/USDC/USDT
- Keep the existing business-wallet fallback for gigs without a preferred coin or unsupported coin labels

## Tests
- git diff --check -- src/lib/coinpayportal.ts src/lib/coinpayportal.test.ts
- npm test -- src/lib/coinpayportal.test.ts (blocked locally: vitest is not installed; npm install is blocked in this workspace by Node 18.20.8 vs project Node 20+ dependencies and existing lockfile mismatch)
