### PR TITLE
Keep bounty payout payment details in-app

### DIFF
--- a/src/app/api/bounties/[id]/submissions/[sid]/pay/route.test.ts
+++ b/src/app/api/bounties/[id]/submissions/[sid]/pay/route.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/coinpayportal", () => ({
+  createPayment: vi.fn(),
+  resolveSupportedPaymentCurrency: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { createPayment, resolveSupportedPaymentCurrency } from "@/lib/coinpayportal";
+
+const BOUNTY_ID = "11111111-1111-4111-8111-111111111111";
+const SUBMISSION_ID = "22222222-2222-4222-8222-222222222222";
+const CREATOR_ID = "33333333-3333-4333-8333-333333333333";
+const SUBMITTER_ID = "44444444-4444-4444-8444-444444444444";
+
+const params = { params: Promise.resolve({ id: BOUNTY_ID, sid: SUBMISSION_ID }) };
+
+function mockSupabase() {
+  const update = vi.fn().mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  });
+
+  const bountyChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: {
+        id: BOUNTY_ID,
+        creator_id: CREATOR_ID,
+        title: "Bounty bug fix",
+        payout_usd: 25,
+        payment_coin: "SOL",
+      },
+      error: null,
+    }),
+  };
+
+  const submissionChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: {
+        id: SUBMISSION_ID,
+        submitter_id: SUBMITTER_ID,
+        status: "approved",
+        payout_status: "unpaid",
+        coinpay_invoice_id: null,
+        pay_url: null,
+        payment_metadata: {},
+      },
+      error: null,
+    }),
+  };
+
+  return {
+    update,
+    from: vi.fn((table: string) => {
+      if (table === "bounties") return bountyChain;
+      if (table === "bounty_submissions") {
+        return {
+          select: submissionChain.select,
+          eq: submissionChain.eq,
+          single: submissionChain.single,
+          update,
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    }),
+  };
+}
+
+describe("POST /api/bounties/[id]/submissions/[sid]/pay", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("stores and returns in-app payment details without a hosted pay_url", async () => {
+    const supabase = mockSupabase();
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: CREATOR_ID },
+      supabase,
+    });
+    (resolveSupportedPaymentCurrency as any).mockResolvedValue("sol");
+    (createPayment as any).mockResolvedValue({
+      payment_id: "cp-pay-1",
+      address: "So11111111111111111111111111111111111111112",
+      amount_crypto: 0.25,
+      currency: "sol",
+      checkout_url: "https://coinpay.example/hosted",
+      expires_at: "2026-05-23T06:30:00Z",
+    });
+
+    const res = await POST({} as any, params);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toMatchObject({
+      coinpay_invoice_id: "cp-pay-1",
+      payment_address: "So11111111111111111111111111111111111111112",
+      payment_currency: "sol",
+      amount_crypto: 0.25,
+      expires_at: "2026-05-23T06:30:00Z",
+      pay_url: null,
+    });
+    expect(supabase.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payout_status: "invoiced",
+        coinpay_invoice_id: "cp-pay-1",
+        pay_url: null,
+        payment_metadata: expect.objectContaining({
+          payment_address: "So11111111111111111111111111111111111111112",
+          payment_currency: "sol",
+          amount_crypto: 0.25,
+          checkout_url: "https://coinpay.example/hosted",
+          expires_at: "2026-05-23T06:30:00Z",
+        }),
+      })
+    );
+  });
+});

--- a/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
+++ b/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
@@ -45,13 +45,16 @@ export async function POST(
       return NextResponse.json({ error: "Only approved submissions can be paid" }, { status: 400 });
     }
 
-    // Already invoiced — return existing details
-    if (submission.coinpay_invoice_id) {
+    // Already invoiced with in-app payment details — return existing details.
+    // Older rows may have a CoinPay invoice id/pay_url from the previous hosted-checkout flow
+    // but no in-app address metadata. In that case, intentionally fall through and create a
+    // fresh in-app payment request so creators are not stuck after the migration.
+    if (submission.coinpay_invoice_id && submission.payment_metadata?.payment_address) {
       return NextResponse.json({
         data: {
           submission_id: sid,
           coinpay_invoice_id: submission.coinpay_invoice_id,
-          payment_address: submission.payment_metadata?.payment_address || null,
+          payment_address: submission.payment_metadata.payment_address,
           payment_currency: submission.payment_metadata?.payment_currency || null,
           amount_crypto: submission.payment_metadata?.amount_crypto || null,
           expires_at: submission.payment_metadata?.expires_at || null,

--- a/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
+++ b/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
@@ -32,7 +32,9 @@ export async function POST(
 
     const { data: submission } = await (supabase as any)
       .from("bounty_submissions")
-      .select("id, submitter_id, status, payout_status, pay_url, coinpay_invoice_id")
+      .select(
+        "id, submitter_id, status, payout_status, pay_url, coinpay_invoice_id, payment_metadata"
+      )
       .eq("id", sid)
       .eq("bounty_id", bountyId)
       .single();
@@ -40,10 +42,7 @@ export async function POST(
       return NextResponse.json({ error: "Submission not found" }, { status: 404 });
     }
     if (submission.status !== "approved") {
-      return NextResponse.json(
-        { error: "Only approved submissions can be paid" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Only approved submissions can be paid" }, { status: 400 });
     }
 
     // Already invoiced — return existing details
@@ -52,22 +51,20 @@ export async function POST(
         data: {
           submission_id: sid,
           coinpay_invoice_id: submission.coinpay_invoice_id,
-          pay_url: submission.pay_url,
+          payment_address: submission.payment_metadata?.payment_address || null,
+          payment_currency: submission.payment_metadata?.payment_currency || null,
+          amount_crypto: submission.payment_metadata?.amount_crypto || null,
+          expires_at: submission.payment_metadata?.expires_at || null,
+          pay_url: null,
         },
       });
     }
 
-    const appUrl =
-      process.env.APP_URL ||
-      process.env.NEXT_PUBLIC_APP_URL ||
-      "https://ugig.net";
-    const businessId =
-      process.env.COINPAY_UGIG_BUSINESS_ID ||
-      process.env.COINPAY_MERCHANT_ID;
-    const paymentCurrency = await resolveSupportedPaymentCurrency(
-      bounty.payment_coin,
-      { business_id: businessId }
-    );
+    const appUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
+    const businessId = process.env.COINPAY_UGIG_BUSINESS_ID || process.env.COINPAY_MERCHANT_ID;
+    const paymentCurrency = await resolveSupportedPaymentCurrency(bounty.payment_coin, {
+      business_id: businessId,
+    });
 
     const paymentResult = await createPayment({
       amount_usd: Number(bounty.payout_usd),
@@ -87,12 +84,17 @@ export async function POST(
     });
 
     const cpPayment = (paymentResult.payment || paymentResult) as Record<string, unknown>;
-    const paymentId =
-      paymentResult.payment_id || (cpPayment.id as string | undefined);
+    const paymentId = paymentResult.payment_id || (cpPayment.id as string | undefined);
     const paymentAddress =
-      (cpPayment.payment_address as string | undefined) ||
-      paymentResult.address ||
+      (cpPayment.payment_address as string | undefined) || paymentResult.address || null;
+    const responseCurrency = paymentResult.currency || paymentCurrency;
+    const amountCrypto =
+      paymentResult.amount_crypto ||
+      (cpPayment.amount_crypto as number | undefined) ||
+      (cpPayment.crypto_amount as number | undefined) ||
       null;
+    const expiresAt =
+      paymentResult.expires_at || (cpPayment.expires_at as string | undefined) || null;
 
     if (!paymentId || !paymentAddress) {
       return NextResponse.json(
@@ -106,7 +108,15 @@ export async function POST(
       .update({
         payout_status: "invoiced",
         coinpay_invoice_id: paymentId,
-        pay_url: paymentResult.checkout_url || (cpPayment.checkout_url as string | undefined) || null,
+        pay_url: null,
+        payment_metadata: {
+          payment_address: paymentAddress,
+          amount_crypto: amountCrypto,
+          payment_currency: responseCurrency,
+          checkout_url:
+            paymentResult.checkout_url || (cpPayment.checkout_url as string | undefined) || null,
+          expires_at: expiresAt,
+        },
       })
       .eq("id", sid);
 
@@ -119,20 +129,10 @@ export async function POST(
         submission_id: sid,
         coinpay_invoice_id: paymentId,
         payment_address: paymentAddress,
-        payment_currency: paymentResult.currency || paymentCurrency,
-        amount_crypto:
-          paymentResult.amount_crypto ||
-          (cpPayment.amount_crypto as number | undefined) ||
-          (cpPayment.crypto_amount as number | undefined) ||
-          null,
-        expires_at:
-          paymentResult.expires_at ||
-          (cpPayment.expires_at as string | undefined) ||
-          null,
-        pay_url:
-          paymentResult.checkout_url ||
-          (cpPayment.checkout_url as string | undefined) ||
-          null,
+        payment_currency: responseCurrency,
+        amount_crypto: amountCrypto,
+        expires_at: expiresAt,
+        pay_url: null,
       },
     });
   } catch (err) {

--- a/src/app/bounties/[id]/ReviewPanel.tsx
+++ b/src/app/bounties/[id]/ReviewPanel.tsx
@@ -186,21 +186,23 @@ export function ReviewPanel({ bountyId, payoutUsd, questions, submissions }: Rev
             </>
           )}
 
-          {s.status === "approved" && s.payout_status === "unpaid" && (
-            <Button
-              size="sm"
-              disabled={busyId === s.id}
-              onClick={() => pay(s.id)}
-              className="gap-1"
-            >
-              {busyId === s.id ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <DollarSign className="h-3 w-3" />
-              )}
-              Pay ${payoutUsd}
-            </Button>
-          )}
+          {s.status === "approved" &&
+            (s.payout_status === "unpaid" ||
+              (s.payout_status === "invoiced" && !paymentDetails?.payment_address)) && (
+              <Button
+                size="sm"
+                disabled={busyId === s.id}
+                onClick={() => pay(s.id)}
+                className="gap-1"
+              >
+                {busyId === s.id ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <DollarSign className="h-3 w-3" />
+                )}
+                {s.payout_status === "invoiced" ? "Create new payment request" : `Pay $${payoutUsd}`}
+              </Button>
+            )}
 
           {s.status === "approved" &&
             s.payout_status === "invoiced" &&
@@ -245,8 +247,8 @@ export function ReviewPanel({ bountyId, payoutUsd, questions, submissions }: Rev
             s.payout_status === "invoiced" &&
             !paymentDetails?.payment_address && (
               <p className="text-sm text-muted-foreground">
-                Payment was prepared, but in-app payment details are not available. Create a new
-                payment request if this one expired.
+                Payment was prepared before in-app payment details were available. Create a new
+                payment request to show a fresh payment address here.
               </p>
             )}
 

--- a/src/app/bounties/[id]/ReviewPanel.tsx
+++ b/src/app/bounties/[id]/ReviewPanel.tsx
@@ -4,14 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import {
-  Loader2,
-  CheckCircle2,
-  XCircle,
-  Clock,
-  ExternalLink,
-  DollarSign,
-} from "lucide-react";
+import { Loader2, CheckCircle2, XCircle, Clock, DollarSign, Copy } from "lucide-react";
 
 interface Question {
   id: string;
@@ -30,6 +23,7 @@ interface Submission {
   review_notes: string | null;
   reviewed_at: string | null;
   pay_url: string | null;
+  payment_metadata?: PaymentDetails | null;
   created_at: string;
   submitter: {
     id: string;
@@ -39,6 +33,13 @@ interface Submission {
   } | null;
 }
 
+interface PaymentDetails {
+  payment_address?: string | null;
+  amount_crypto?: number | string | null;
+  payment_currency?: string | null;
+  expires_at?: string | null;
+}
+
 interface ReviewPanelProps {
   bountyId: string;
   payoutUsd: number;
@@ -46,31 +47,23 @@ interface ReviewPanelProps {
   submissions: Submission[];
 }
 
-export function ReviewPanel({
-  bountyId,
-  payoutUsd,
-  questions,
-  submissions,
-}: ReviewPanelProps) {
+export function ReviewPanel({ bountyId, payoutUsd, questions, submissions }: ReviewPanelProps) {
   const router = useRouter();
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [paymentDetailsById, setPaymentDetailsById] = useState<Record<string, PaymentDetails>>({});
 
-  const questionLabel = (qid: string) =>
-    questions.find((q) => q.id === qid)?.label || qid;
+  const questionLabel = (qid: string) => questions.find((q) => q.id === qid)?.label || qid;
 
   const review = async (sid: string, status: "approved" | "rejected") => {
     setError(null);
     setBusyId(sid);
     try {
-      const res = await fetch(
-        `/api/bounties/${bountyId}/submissions/${sid}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status }),
-        }
-      );
+      const res = await fetch(`/api/bounties/${bountyId}/submissions/${sid}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
       const json = await res.json();
       if (!res.ok) {
         setError(json.error || "Failed");
@@ -86,18 +79,23 @@ export function ReviewPanel({
     setError(null);
     setBusyId(sid);
     try {
-      const res = await fetch(
-        `/api/bounties/${bountyId}/submissions/${sid}/pay`,
-        { method: "POST" }
-      );
+      const res = await fetch(`/api/bounties/${bountyId}/submissions/${sid}/pay`, {
+        method: "POST",
+      });
       const json = await res.json();
       if (!res.ok) {
         setError(json.error || "Failed to create payment link");
         return;
       }
-      if (json.data?.pay_url) {
-        window.open(json.data.pay_url, "_blank", "noopener,noreferrer");
-      }
+      setPaymentDetailsById((cur) => ({
+        ...cur,
+        [sid]: {
+          payment_address: json.data?.payment_address || null,
+          amount_crypto: json.data?.amount_crypto || null,
+          payment_currency: json.data?.payment_currency || null,
+          expires_at: json.data?.expires_at || null,
+        },
+      }));
       router.refresh();
     } finally {
       setBusyId(null);
@@ -117,11 +115,9 @@ export function ReviewPanel({
 
   const renderCard = (s: Submission) => {
     const name = s.submitter?.full_name || s.submitter?.username || "Unknown";
+    const paymentDetails = paymentDetailsById[s.id] || s.payment_metadata || null;
     return (
-      <div
-        key={s.id}
-        className="p-4 bg-card border border-border rounded-lg space-y-3"
-      >
+      <div key={s.id} className="p-4 bg-card border border-border rounded-lg space-y-3">
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="font-medium">{name}</p>
@@ -208,16 +204,50 @@ export function ReviewPanel({
 
           {s.status === "approved" &&
             s.payout_status === "invoiced" &&
-            s.pay_url && (
-              <a
-                href={s.pay_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
-              >
-                <ExternalLink className="h-3 w-3" />
-                Open payment link
-              </a>
+            paymentDetails?.payment_address && (
+              <div className="w-full rounded-md border border-border bg-muted/30 p-3 space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-medium text-muted-foreground">Payment address</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 text-xs"
+                    onClick={() =>
+                      navigator.clipboard?.writeText(paymentDetails.payment_address || "")
+                    }
+                  >
+                    <Copy className="h-3 w-3" />
+                    Copy
+                  </Button>
+                </div>
+                <code className="block break-all rounded bg-background px-2 py-1.5 text-xs">
+                  {paymentDetails.payment_address}
+                </code>
+                <p className="text-xs text-muted-foreground">
+                  Send{" "}
+                  {paymentDetails.amount_crypto
+                    ? `${paymentDetails.amount_crypto} ${
+                        paymentDetails.payment_currency || ""
+                      }`.trim()
+                    : paymentDetails.payment_currency || "the selected coin"}{" "}
+                  to this address.
+                </p>
+                {paymentDetails.expires_at && (
+                  <p className="text-xs text-muted-foreground">
+                    Expires {new Date(paymentDetails.expires_at).toLocaleString()}
+                  </p>
+                )}
+              </div>
+            )}
+
+          {s.status === "approved" &&
+            s.payout_status === "invoiced" &&
+            !paymentDetails?.payment_address && (
+              <p className="text-sm text-muted-foreground">
+                Payment was prepared, but in-app payment details are not available. Create a new
+                payment request if this one expired.
+              </p>
             )}
 
           {s.payout_status === "paid" && (

--- a/supabase/migrations/20260523054000_add_bounty_submission_payment_metadata.sql
+++ b/supabase/migrations/20260523054000_add_bounty_submission_payment_metadata.sql
@@ -1,0 +1,7 @@
+-- Store CoinPay in-app payment details for bounty payouts so creators can pay
+-- inside uGig without relying on an external hosted checkout link.
+ALTER TABLE bounty_submissions
+  ADD COLUMN IF NOT EXISTS payment_metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN bounty_submissions.payment_metadata IS
+  'CoinPay in-app payment details for bounty payout requests: payment_address, amount_crypto, payment_currency, checkout_url, expires_at.';


### PR DESCRIPTION
# Keep bounty payout payment details in-app

## Summary
- Stops the bounty payout review UI from opening a hosted CoinPay checkout URL.
- Persists CoinPay payment address, crypto amount, currency, expiry, and checkout URL as bounty_submissions.payment_metadata while keeping pay_url null for in-app UX.
- Shows creators an in-app payment address with copy button for approved/invoiced bounty submissions.
- Adds a route test asserting the API stores/returns in-app payment details and does not expose a hosted pay_url.
- Follow-up fix: older pre-migration invoiced rows without in-app payment metadata can create a fresh in-app payment request instead of getting stuck.

## Local QA
- Route Vitest exited 0.
- TypeScript exited 0.
- Targeted ESLint exited 0.

## Notes
This supersedes closed PR #241 after reviewer feedback on pre-migration invoiced submissions.
