### PR TITLE
Fix build blockers for tracker deploy

### DIFF
--- a/src/app/api/affiliates/offers/[id]/apply/route.ts
+++ b/src/app/api/affiliates/offers/[id]/apply/route.ts
@@ -71,11 +71,6 @@ export async function POST(
     );
 
     const body = await request.json().catch(() => ({}));
-    const note = body.note;
-    if (note !== undefined && note !== null && typeof note !== "string") {
-      return NextResponse.json({ error: "note must be a string" }, { status: 400 });
-    }
-    const normalizedNote = typeof note === "string" ? note.trim() || null : null;
 
     // Validate note field (#145 — must be string if provided)
     if (body.note !== undefined && body.note !== null) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,13 @@
   "exclude": [
     "node_modules",
     "cli",
-    "scripts"
+    "scripts",
+    "InlinePayModal.tsx",
+    "PayApplicantButton.tsx",
+    "api-invoices-pay.ts",
+    "api-invoices-status.ts",
+    "coinpayportal-lib.ts",
+    "dashboard-invoices-page.tsx",
+    "webhook-enhancement.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- remove duplicate normalizedNote declaration in affiliate offer application route
- exclude root-level scaffold artifacts from TypeScript/Next build so the real src/ app files compile

## Verification
- pnpm install --frozen-lockfile --prefer-offline
- pnpm run build (passes compile and TypeScript; local prerender then stops because local env is missing Supabase service role config)