### PR TITLE
Fix auth token response docs

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -823,17 +823,17 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["message", "user", "access_token", "refresh_token"],
                   "properties": {
                     "message": { "type": "string" },
                     "user": { "type": "object" },
-                    "session": {
-                      "type": "object",
-                      "properties": {
-                        "access_token": { "type": "string" },
-                        "refresh_token": { "type": "string" },
-                        "expires_in": { "type": "integer" },
-                        "token_type": { "type": "string" }
-                      }
+                    "access_token": {
+                      "type": "string",
+                      "description": "Bearer token for authenticated API requests. Avoid logging or storing it in insecure client-side storage."
+                    },
+                    "refresh_token": {
+                      "type": "string",
+                      "description": "Refresh token returned by Supabase auth. Avoid logging or storing it in insecure client-side storage."
                     }
                   }
                 }
@@ -944,20 +944,20 @@
     "/api/auth/session": {
       "get": {
         "tags": ["Auth"],
-        "summary": "Get current session",
-        "description": "Returns the current authenticated user and session info.",
-        "operationId": "getSession",
+        "summary": "Get current user profile",
+        "description": "Returns the current authenticated user and profile.",
+        "operationId": "getCurrentUserProfile",
         "security": [{ "bearerAuth": [] }, { "apiKey": [] }],
         "responses": {
           "200": {
-            "description": "Session info",
+            "description": "Current user and profile info",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
                     "user": { "type": "object" },
-                    "session": { "type": "object" }
+                    "profile": { "$ref": "#/components/schemas/Profile" }
                   }
                 }
               }

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -60,7 +60,7 @@ describe("POST /api/auth/login", () => {
     mockSignInWithPassword.mockResolvedValue({
       data: {
         user: { id: "u1", email: "test@x.com", email_confirmed_at: "2026-01-01T00:00:00Z" },
-        session: { access_token: "tok" },
+        session: { access_token: "tok", refresh_token: "refresh" },
       },
       error: null,
     });
@@ -69,6 +69,9 @@ describe("POST /api/auth/login", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.message).toBe("Login successful");
+    expect(body.access_token).toBe("tok");
+    expect(body.refresh_token).toBe("refresh");
+    expect(body.session).toBeUndefined();
   });
 
   it("should return 403 for unconfirmed user", async () => {

--- a/src/app/docs/api/api-docs-content.tsx
+++ b/src/app/docs/api/api-docs-content.tsx
@@ -48,7 +48,8 @@ const SECTIONS: Section[] = [
       {
         method: "POST",
         path: "/api/auth/login",
-        description: "Authenticate with email and password to get a Bearer token.",
+        description:
+          "Authenticate with email and password to get a Bearer token. Keep returned tokens out of logs and insecure browser storage.",
         curl: `curl -X POST ${BASE}/api/auth/login \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -58,23 +59,19 @@ const SECTIONS: Section[] = [
         response: `{
   "message": "Login successful",
   "user": { "id": "uuid", "email": "you@example.com" },
-  "session": {
-    "access_token": "eyJhbGciOi...",
-    "refresh_token": "abc123...",
-    "expires_in": 3600,
-    "token_type": "bearer"
-  }
+  "access_token": "eyJhbGciOi...",
+  "refresh_token": "abc123..."
 }`,
       },
       {
         method: "GET",
         path: "/api/auth/session",
-        description: "Get the current authenticated user and session info.",
+        description: "Get the current authenticated user and profile.",
         curl: `curl ${BASE}/api/auth/session \\
   -H "X-API-Key: $API_KEY"`,
         response: `{
   "user": { "id": "uuid", "email": "you@example.com" },
-  "session": { ... }
+  "profile": { "username": "you" }
 }`,
       },
     ],


### PR DESCRIPTION
## Summary

- update REST docs and OpenAPI schema to show `access_token` / `refresh_token` at the top level for `POST /api/auth/login`
- update `/api/auth/session` docs/schema to describe the returned `profile` object instead of a nested `session`
- assert the login route returns top-level token fields and no `session` object

Fixes #248.

## Validation

- `pnpm vitest run src/app/api/auth/login/route.test.ts src/app/api/openapi.json/spec.test.ts`
