### PR TITLE
fix(api): add DELETE /api/applications/[id] for withdraw

### DIFF
--- a/src/app/api/applications/[id]/route.test.ts
+++ b/src/app/api/applications/[id]/route.test.ts
@@ -16,10 +16,11 @@ beforeEach(() => {
 describe("DELETE /api/applications/[id]", () => {
   const routeParams = { params: Promise.resolve({ id: "test-app-id" }) };
 
-  it("delegates to PUT status with withdrawn", async () => {
+  it("delegates to PUT status with withdrawn and returns the response", async () => {
     mockPut.mockResolvedValue(
       new Response(JSON.stringify({ application: { status: "withdrawn" } }), {
         status: 200,
+        headers: { "Content-Type": "application/json" },
       })
     );
 
@@ -28,11 +29,19 @@ describe("DELETE /api/applications/[id]", () => {
       { method: "DELETE", headers: { Authorization: "Bearer test" } }
     );
 
-    await DELETE(request, routeParams);
+    const response = await DELETE(request, routeParams);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.application.status).toBe("withdrawn");
 
     expect(mockPut).toHaveBeenCalledTimes(1);
     const [putRequest, putContext] = mockPut.mock.calls[0];
     expect(putRequest.method).toBe("PUT");
+    expect(putRequest.url).toBe(
+      "http://localhost/api/applications/test-app-id/status"
+    );
+    expect(putRequest.headers.get("Content-Type")).toBe("application/json");
     expect(await putRequest.json()).toEqual({ status: "withdrawn" });
     expect(putContext).toEqual(routeParams);
   });

--- a/src/app/api/applications/[id]/route.test.ts
+++ b/src/app/api/applications/[id]/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { DELETE } from "./route";
+import { PUT } from "./status/route";
+
+vi.mock("./status/route", () => ({
+  PUT: vi.fn(),
+}));
+
+const mockPut = vi.mocked(PUT);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DELETE /api/applications/[id]", () => {
+  const routeParams = { params: Promise.resolve({ id: "test-app-id" }) };
+
+  it("delegates to PUT status with withdrawn", async () => {
+    mockPut.mockResolvedValue(
+      new Response(JSON.stringify({ application: { status: "withdrawn" } }), {
+        status: 200,
+      })
+    );
+
+    const request = new NextRequest(
+      "http://localhost/api/applications/test-app-id",
+      { method: "DELETE", headers: { Authorization: "Bearer test" } }
+    );
+
+    await DELETE(request, routeParams);
+
+    expect(mockPut).toHaveBeenCalledTimes(1);
+    const [putRequest, putContext] = mockPut.mock.calls[0];
+    expect(putRequest.method).toBe("PUT");
+    expect(await putRequest.json()).toEqual({ status: "withdrawn" });
+    expect(putContext).toEqual(routeParams);
+  });
+});

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { PUT } from "./status/route";
+
+/**
+ * DELETE /api/applications/[id] — Withdraw application (applicant only).
+ * Documented in public/skill.md; delegates to PUT .../status with withdrawn.
+ */
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const withdrawRequest = new NextRequest(
+    "http://localhost/api/applications/withdraw/status",
+    {
+      method: "PUT",
+      headers: request.headers,
+      body: JSON.stringify({ status: "withdrawn" }),
+    }
+  );
+  return PUT(withdrawRequest, context);
+}

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -9,13 +9,19 @@ export async function DELETE(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const withdrawRequest = new NextRequest(
-    "http://localhost/api/applications/withdraw/status",
-    {
-      method: "PUT",
-      headers: request.headers,
-      body: JSON.stringify({ status: "withdrawn" }),
-    }
+  const statusUrl = new URL(
+    `${request.nextUrl.pathname}/status`,
+    request.nextUrl.origin
   );
+
+  const headers = new Headers(request.headers);
+  headers.set("Content-Type", "application/json");
+
+  const withdrawRequest = new NextRequest(statusUrl, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({ status: "withdrawn" }),
+  });
+
   return PUT(withdrawRequest, context);
 }


### PR DESCRIPTION
## Summary

- Add `DELETE /api/applications/[id]` to withdraw an application
- Delegates to existing `PUT /api/applications/[id]/status` with `{ "status": "withdrawn" }`
- Matches `public/skill.md` agent documentation
- Adds unit test for the DELETE handler

Fixes #250.

## Reproduction (before fix)

```bash
curl -X DELETE "https://ugig.net/api/applications/<application-id>" \
  -H "X-API-Key: $API_KEY"
# → 404 HTML
```

## Validation

```bash
pnpm vitest run src/app/api/applications/[id]/route.test.ts
```

## Notes

- OpenAPI already documents PUT `/api/applications/{id}/status`; this PR implements the DELETE alias documented in skill.md for agent ergonomics.
- Submitted as part of ugig.net bug bounty work by @Biqiu.
