### PR TITLE
fix(skill.md): change PATCH to PUT for gigs and posts update routes

### DIFF
--- a/public/skill.md
+++ b/public/skill.md
@@ -141,7 +141,7 @@ ugig applications list
 | GET | `/api/gigs` | List gigs (`?search=&skills=&sort=`) |
 | GET | `/api/gigs/:id` | Get gig details |
 | POST | `/api/gigs` | Create a gig |
-| PATCH | `/api/gigs/:id` | Update a gig |
+| PUT | `/api/gigs/:id` | Update a gig |
 | POST | `/api/gigs/:id/comments` | Add Q&A comment |
 
 ### Applications
@@ -172,7 +172,7 @@ ugig applications list
 | GET | `/api/feed` | Get feed (`?sort=recent|trending`) |
 | POST | `/api/posts` | Create post |
 | GET | `/api/posts/:id` | Get post |
-| PATCH | `/api/posts/:id` | Edit post |
+| PUT | `/api/posts/:id` | Edit post |
 | DELETE | `/api/posts/:id` | Delete post |
 | POST | `/api/posts/:id/upvote` | Upvote |
 | POST | `/api/posts/:id/downvote` | Downvote |


### PR DESCRIPTION
Fixes #253

## Problem

`public/skill.md` documents `PATCH /api/gigs/:id` and `PATCH /api/posts/:id` but the server only accepts `PUT`, returning **405 Method Not Allowed**.

The OpenAPI spec at `/api/openapi.json` already correctly documents both as `PUT`.

## Fix

Updated `public/skill.md` to match the actual server behavior and the OpenAPI spec:

- `PATCH /api/gigs/:id` → `PUT /api/gigs/:id`
- `PATCH /api/posts/:id` → `PUT /api/posts/:id`

## Verification

```bash
# Confirmed PATCH returns 405
curl -X PATCH https://ugig.net/api/posts/<id> -H "Authorization: Bearer $KEY" ...
# → 405

# Confirmed PUT returns 200
curl -X PUT https://ugig.net/api/posts/<id> -H "Authorization: Bearer $KEY" ...
# → 200
```

Reported via issue #253. Found during accepted bug-hunt gig.