### PR TITLE
feat(escrow): add arbiter_address support for 2-of-3 multisig escrow

### DIFF
--- a/src/app/api/gigs/[id]/escrow/route.ts
+++ b/src/app/api/gigs/[id]/escrow/route.ts
@@ -8,6 +8,7 @@ const createEscrowSchema = z.object({
   currency: z.enum(["usdc_pol", "usdc_sol", "pol", "sol", "btc", "eth", "usdc_eth", "usdt"]),
   depositor_address: z.string().min(10, "Depositor wallet address is required"),
   beneficiary_address: z.string().min(10, "Beneficiary wallet address is required"),
+  arbiter_address: z.string().min(10).optional(),
 });
 
 // GET /api/gigs/[id]/escrow - Get escrow status for a gig
@@ -70,7 +71,7 @@ export async function POST(
       );
     }
 
-    const { application_id, currency, depositor_address, beneficiary_address } = validationResult.data;
+    const { application_id, currency, depositor_address, beneficiary_address, arbiter_address } = validationResult.data;
 
     // Get gig — must be poster
     const { data: gig } = await supabase
@@ -161,6 +162,7 @@ export async function POST(
       beneficiary_email: `${workerProfile?.username || application.applicant_id}@ugig.net`,
       depositor_address,
       beneficiary_address,
+      arbiter_address,
       description: `Gig escrow: ${gig.title}`,
       metadata: {
         gig_id: gigId,
@@ -190,6 +192,7 @@ export async function POST(
         currency,
         platform_fee_usd: platformFee,
         platform_fee_rate: platformFeeRate,
+        arbiter_address: arbiter_address || null,
         status: "pending_payment",
         metadata: {
           payment_address: paymentAddress,

--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -739,6 +739,7 @@ export interface CreateEscrowOptions {
   beneficiary_email: string;
   depositor_address: string;
   beneficiary_address: string;
+  arbiter_address?: string;
   description?: string;
   auto_release_hours?: number;
   webhook_url?: string;
@@ -801,6 +802,7 @@ export async function createEscrow(options: CreateEscrowOptions): Promise<Escrow
       beneficiary_address: options.beneficiary_address,
       depositor_email: options.depositor_email,
       beneficiary_email: options.beneficiary_email,
+      arbiter_address: options.arbiter_address,
       description: options.description,
       auto_release_hours: options.auto_release_hours,
       webhook_url: options.webhook_url || `${appUrl}/api/webhooks/coinpay`,


### PR DESCRIPTION
## Summary

Adds `arbiter_address` support to enable 2-of-3 Multisig escrow via CoinPayPortal. Previously, only the Custodial escrow model was supported.

## Changes

### `src/lib/coinpayportal.ts`
- Added `arbiter_address?: string` to the `CreateEscrowOptions` interface
- Added `arbiter_address: options.arbiter_address` to the API request body sent to CoinPayPortal

### `src/app/api/gigs/[id]/escrow/route.ts`
- Added `arbiter_address: z.string().min(10).optional()` to the Zod validation schema
- Added `arbiter_address` to the destructured params from the validated request body
- Passed `arbiter_address` to the `createEscrow()` call
- Added `arbiter_address: arbiter_address || null` to the `gig_escrows` database insert

## Related

- Closes #255 (Missing multisig escrow support issue)
- Note: There is also a PATCH→PUT bug in `skill.md` (lines 144, 175) — PR #254 by forgou37 addresses that
