### PR TITLE
fix: give avatar images default alt text

### DIFF
--- a/src/components/ui/avatar.test.tsx
+++ b/src/components/ui/avatar.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AvatarImage } from "./avatar";
+
+describe("AvatarImage", () => {
+  it("uses an empty alt attribute by default", () => {
+    const { container } = render(<AvatarImage src="/avatar.png" />);
+
+    expect(container.querySelector("img")).toHaveAttribute("alt", "");
+  });
+
+  it("preserves an explicit alt attribute", () => {
+    render(<AvatarImage src="/avatar.png" alt="Ada Lovelace" />);
+
+    expect(screen.getByRole("img", { name: "Ada Lovelace" })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,46 +1,36 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-const Avatar = React.forwardRef<
-  HTMLSpanElement,
-  React.HTMLAttributes<HTMLSpanElement>
->(({ className, ...props }, ref) => (
-  <span
-    ref={ref}
-    className={cn(
-      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-      className
-    )}
-    {...props}
-  />
-));
+const Avatar = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}
+      {...props}
+    />
+  )
+);
 Avatar.displayName = "Avatar";
 
-const AvatarImage = React.forwardRef<
-  HTMLImageElement,
-  React.ImgHTMLAttributes<HTMLImageElement>
->(({ className, ...props }, ref) => (
-  <img
-    ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
-    {...props}
-  />
-));
+const AvatarImage = React.forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageElement>>(
+  ({ className, alt = "", ...props }, ref) => (
+    <img ref={ref} alt={alt} className={cn("aspect-square h-full w-full", className)} {...props} />
+  )
+);
 AvatarImage.displayName = "AvatarImage";
 
-const AvatarFallback = React.forwardRef<
-  HTMLSpanElement,
-  React.HTMLAttributes<HTMLSpanElement>
->(({ className, ...props }, ref) => (
-  <span
-    ref={ref}
-    className={cn(
-      "flex h-full w-full items-center justify-center rounded-full bg-muted",
-      className
-    )}
-    {...props}
-  />
-));
+const AvatarFallback = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(
+        "flex h-full w-full items-center justify-center rounded-full bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+);
 AvatarFallback.displayName = "AvatarFallback";
 
 export { Avatar, AvatarImage, AvatarFallback };


### PR DESCRIPTION
## Summary

Fixes #259.

`AvatarImage` now defaults missing `alt` text to an empty string while preserving explicit alt text from callers. This keeps decorative avatar images accessible and removes the `jsx-a11y/alt-text` warning for the wrapper without forcing every existing avatar call site to duplicate an empty alt.

## Validation

- `pnpm test:run src/components/ui/avatar.test.tsx` -> 2 passed
- `pnpm type-check` -> passed
- `pnpm exec prettier --check src/components/ui/avatar.tsx src/components/ui/avatar.test.tsx` -> passed
- `pnpm exec eslint src/components/ui/avatar.tsx src/components/ui/avatar.test.tsx` -> 0 errors, remaining existing `@next/next/no-img-element` warning only
- `git diff --check` -> clean