### PR TITLE
fix: make postinstall cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "precommit": "pnpm lint && pnpm type-check && pnpm test:run && pnpm build",
-    "postinstall": "pnpm dlx @socketsecurity/socket-patch apply --silent --ecosystems npm && git rev-parse --is-inside-work-tree > /dev/null 2>&1 && git config core.hooksPath hooks || true",
+    "postinstall": "node scripts/postinstall.mjs",
     "version:patch": "node scripts/version-bump.js patch",
     "version:minor": "node scripts/version-bump.js minor",
     "version:major": "node scripts/version-bump.js major",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process";
+
+function quoteCmdArg(value) {
+  if (/^[A-Za-z0-9_./:@=+-]+$/.test(value)) {
+    return value;
+  }
+
+  return `"${value.replace(/(["^&|<>])/g, "^$1")}"`;
+}
+
+function spawn(command, args, options) {
+  if (process.platform === "win32") {
+    const commandLine = [command, ...args].map(quoteCmdArg).join(" ");
+    return spawnSync("cmd.exe", ["/d", "/s", "/c", commandLine], options);
+  }
+
+  return spawnSync(command, args, options);
+}
+
+function runBestEffort(command, args, description) {
+  const result = spawn(command, args, {
+    stdio: "inherit",
+    windowsHide: true,
+  });
+
+  if (result.error || result.status !== 0) {
+    const detail = result.error?.message ?? `exit code ${result.status}`;
+    console.warn(`[postinstall] Skipping ${description}: ${detail}`);
+    return false;
+  }
+
+  return true;
+}
+
+runBestEffort(
+  "pnpm",
+  ["dlx", "@socketsecurity/socket-patch", "apply", "--silent", "--ecosystems", "npm"],
+  "Socket package patching"
+);
+
+const insideGitRepo = spawn("git", ["rev-parse", "--is-inside-work-tree"], {
+  stdio: "ignore",
+  windowsHide: true,
+});
+
+if (!insideGitRepo.error && insideGitRepo.status === 0) {
+  runBestEffort("git", ["config", "core.hooksPath", "hooks"], "Git hooks setup");
+}


### PR DESCRIPTION
Fixes #261.

This replaces the root `postinstall` shell chain with a small cross-platform Node script.

Why:
- the current script ends with Unix-only `|| true`
- on Windows, the fallback can fail with `'true' is not recognized as an internal or external command`
- Socket patching and Git hook setup are best-effort setup steps, so failure there should warn and continue instead of breaking install

What changed:
- `package.json` now runs `node scripts/postinstall.mjs`
- `scripts/postinstall.mjs` runs Socket patching best-effort
- if the checkout is inside a Git repo, it configures `core.hooksPath hooks` best-effort
- no app runtime code is touched

Validation run on Windows:
- `node --check scripts/postinstall.mjs`
- `node scripts/postinstall.mjs`
- `prettier --check package.json scripts/postinstall.mjs`
- `git diff --check -- package.json scripts/postinstall.mjs`

Submitted for the active Ugig request to test the repo, file a bug, and submit a PR fix: https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e

Bug report: #261