### PR TITLE
fix: use next/link for internal navigation

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { Header } from "@/components/layout/Header";
 import { createServiceClient } from "@/lib/supabase/service";
 
@@ -18,19 +19,13 @@ async function fetchPost(slug: string): Promise<Row | null> {
   const sb = createServiceClient();
   const { data } = await (sb as any)
     .from("blog_posts")
-    .select(
-      "slug, title, meta_description, content_html, image_url, published_at",
-    )
+    .select("slug, title, meta_description, content_html, image_url, published_at")
     .eq("slug", slug)
     .maybeSingle();
   return (data as Row | null) ?? null;
 }
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const post = await fetchPost(slug);
   if (!post) {
@@ -53,11 +48,7 @@ export async function generateMetadata({
   };
 }
 
-export default async function BlogPost({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
+export default async function BlogPost({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const post = await fetchPost(slug);
   if (!post) notFound();
@@ -66,23 +57,17 @@ export default async function BlogPost({
     <>
       <Header />
       <main className="mx-auto max-w-3xl px-4 sm:px-6 py-12 text-foreground">
-        <a
+        <Link
           href="/blog"
           className="inline-flex items-center text-sm text-muted-foreground hover:text-primary"
         >
           ← Back to posts
-        </a>
-        <p className="mt-4 text-sm text-muted-foreground">
-          {post.published_at.slice(0, 10)}
-        </p>
+        </Link>
+        <p className="mt-4 text-sm text-muted-foreground">{post.published_at.slice(0, 10)}</p>
         <h1 className="mt-2 text-4xl font-extrabold">{post.title}</h1>
         {post.image_url && (
           // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={post.image_url}
-            alt=""
-            className="mt-6 w-full rounded-lg border"
-          />
+          <img src={post.image_url} alt="" className="mt-6 w-full rounded-lg border" />
         )}
         {post.content_html ? (
           // prose handles paragraph color; explicit `prose-a:text-primary`
@@ -93,9 +78,7 @@ export default async function BlogPost({
             dangerouslySetInnerHTML={{ __html: post.content_html }}
           />
         ) : (
-          <p className="mt-6 text-muted-foreground">
-            This post has no body content.
-          </p>
+          <p className="mt-6 text-muted-foreground">This post has no body content.</p>
         )}
       </main>
     </>

--- a/src/app/for-hire/[[...tags]]/page.tsx
+++ b/src/app/for-hire/[[...tags]]/page.tsx
@@ -39,7 +39,8 @@ export async function generateMetadata({ params }: GigsPageProps): Promise<Metad
   }
 
   const title = "I will... — Find People Ready to Work | ugig.net";
-  const description = "Browse professionals and AI agents offering their services. Find someone who will do exactly what you need.";
+  const description =
+    "Browse professionals and AI agents offering their services. Find someone who will do exactly what you need.";
   return {
     title,
     description,
@@ -99,7 +100,10 @@ async function GigsList({
   }
 
   // Filter by location type
-  if (queryParams.location_type && ["remote", "onsite", "hybrid"].includes(queryParams.location_type)) {
+  if (
+    queryParams.location_type &&
+    ["remote", "onsite", "hybrid"].includes(queryParams.location_type)
+  ) {
     query = query.eq("location_type", queryParams.location_type as "remote" | "onsite" | "hybrid");
   }
 
@@ -114,7 +118,7 @@ async function GigsList({
       expandedTags.add(tag.charAt(0).toUpperCase() + tag.slice(1)); // Title case
       expandedTags.add(tag.toUpperCase());
       // Handle multi-word: "node.js" → "Node.js", "next.js" → "Next.js"
-      expandedTags.add(tag.replace(/\b\w/g, c => c.toUpperCase()));
+      expandedTags.add(tag.replace(/\b\w/g, (c) => c.toUpperCase()));
     }
     query = query.overlaps("skills_required", [...expandedTags]);
   }
@@ -250,7 +254,9 @@ export default async function ForHirePage({ params, searchParams }: GigsPageProp
           <h1 className="text-3xl font-bold mb-2">I will...</h1>
           <p className="text-muted-foreground mb-8">
             People and agents offering their services. Want to hire instead?{" "}
-            <a href="/gigs" className="text-primary hover:underline">Post a gig →</a>
+            <Link href="/gigs" className="text-primary hover:underline">
+              Post a gig →
+            </Link>
           </p>
 
           <Suspense fallback={<div className="h-48" />}>
@@ -270,7 +276,6 @@ export default async function ForHirePage({ params, searchParams }: GigsPageProp
           </div>
         </div>
       </main>
-
     </div>
   );
 }

--- a/src/app/gigs/[[...tags]]/page.tsx
+++ b/src/app/gigs/[[...tags]]/page.tsx
@@ -40,7 +40,8 @@ export async function generateMetadata({ params }: GigsPageProps): Promise<Metad
   }
 
   const title = "Browse Gigs | ugig.net";
-  const description = "Find freelance gigs, contract work, and AI-assisted job opportunities on ugig.net.";
+  const description =
+    "Find freelance gigs, contract work, and AI-assisted job opportunities on ugig.net.";
   return {
     title,
     description,
@@ -100,7 +101,10 @@ async function GigsList({
   }
 
   // Filter by location type
-  if (queryParams.location_type && ["remote", "onsite", "hybrid"].includes(queryParams.location_type)) {
+  if (
+    queryParams.location_type &&
+    ["remote", "onsite", "hybrid"].includes(queryParams.location_type)
+  ) {
     query = query.eq("location_type", queryParams.location_type as "remote" | "onsite" | "hybrid");
   }
 
@@ -120,7 +124,7 @@ async function GigsList({
       expandedTags.add(tag.charAt(0).toUpperCase() + tag.slice(1)); // Title case
       expandedTags.add(tag.toUpperCase());
       // Handle multi-word: "node.js" → "Node.js", "next.js" → "Next.js"
-      expandedTags.add(tag.replace(/\b\w/g, c => c.toUpperCase()));
+      expandedTags.add(tag.replace(/\b\w/g, (c) => c.toUpperCase()));
     }
     query = query.overlaps("skills_required", [...expandedTags]);
   }
@@ -257,7 +261,9 @@ export default async function GigsPage({ params, searchParams }: GigsPageProps) 
           <h1 className="text-3xl font-bold mb-2">Gigs (Hiring)</h1>
           <p className="text-muted-foreground mb-8">
             Clients posting work they need done. Looking for work instead?{" "}
-            <a href="/for-hire" className="text-primary hover:underline">Browse &quot;I will...&quot; listings →</a>
+            <Link href="/for-hire" className="text-primary hover:underline">
+              Browse &quot;I will...&quot; listings →
+            </Link>
           </p>
 
           <Suspense fallback={<div className="h-48" />}>
@@ -278,7 +284,6 @@ export default async function GigsPage({ params, searchParams }: GigsPageProps) 
           </div>
         </div>
       </main>
-
     </div>
   );
 }

--- a/src/app/investors/page.tsx
+++ b/src/app/investors/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { Button } from "@/components/ui/button";
@@ -7,8 +8,7 @@ import { ArrowRight, Building2, TrendingUp, ShieldCheck } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Investors | ugig.net",
-  description:
-    "Learn about ugig.net's funding vision, traction, and investor updates.",
+  description: "Learn about ugig.net's funding vision, traction, and investor updates.",
 };
 
 export default function InvestorsPage() {
@@ -24,22 +24,22 @@ export default function InvestorsPage() {
             </Badge>
             <h1 className="text-4xl font-bold tracking-tight">Funding ugig.net</h1>
             <p className="text-muted-foreground text-lg">
-              ugig.net is building a global marketplace for AI agents, human talent,
-              and programmable work. We are selectively speaking with aligned investors.
+              ugig.net is building a global marketplace for AI agents, human talent, and
+              programmable work. We are selectively speaking with aligned investors.
             </p>
             <div className="flex flex-wrap gap-3">
-              <a href="/funding">
+              <Link href="/funding">
                 <Button>
                   Invest / Fund Now
                   <ArrowRight className="h-4 w-4 ml-2" />
                 </Button>
-              </a>
+              </Link>
               <a href="mailto:investors@ugig.net?subject=ugig.net%20Investor%20Inquiry">
                 <Button variant="outline">Contact Investor Relations</Button>
               </a>
-              <a href="/mcp">
+              <Link href="/mcp">
                 <Button variant="outline">Explore MCP Marketplace</Button>
-              </a>
+              </Link>
             </div>
           </section>
 
@@ -50,8 +50,8 @@ export default function InvestorsPage() {
                 <h2 className="font-semibold">Marketplace Infrastructure</h2>
               </div>
               <p className="text-sm text-muted-foreground">
-                Two-sided network for gigs, skills, and MCP servers with integrated
-                payments and programmable escrow.
+                Two-sided network for gigs, skills, and MCP servers with integrated payments and
+                programmable escrow.
               </p>
             </div>
 
@@ -61,8 +61,8 @@ export default function InvestorsPage() {
                 <h2 className="font-semibold">Growth Engine</h2>
               </div>
               <p className="text-sm text-muted-foreground">
-                Built-in distribution loops via social feed, referrals, zaps, and
-                affiliate mechanics.
+                Built-in distribution loops via social feed, referrals, zaps, and affiliate
+                mechanics.
               </p>
             </div>
 
@@ -72,8 +72,8 @@ export default function InvestorsPage() {
                 <h2 className="font-semibold">Trust & Safety</h2>
               </div>
               <p className="text-sm text-muted-foreground">
-                Reputation rails, verification, and security scanning layers designed
-                for AI-native commerce.
+                Reputation rails, verification, and security scanning layers designed for AI-native
+                commerce.
               </p>
             </div>
           </section>
@@ -81,8 +81,7 @@ export default function InvestorsPage() {
           <section className="rounded-lg border border-border p-6 bg-card space-y-3">
             <h2 className="text-xl font-semibold">Investor Updates</h2>
             <p className="text-muted-foreground">
-              For deck requests, fundraising status, and diligence materials, contact us
-              at{" "}
+              For deck requests, fundraising status, and diligence materials, contact us at{" "}
               <a className="text-primary hover:underline" href="mailto:investors@ugig.net">
                 investors@ugig.net
               </a>


### PR DESCRIPTION
Submitted for the active Ugig request to test the repo, file bugs, and submit PR fixes: https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e

Bug report: #263

Fix:
- Replaces raw internal `<a href="/...">` links with `next/link` in the blog detail back link, gigs/for-hire cross-links, and investor page CTA links.
- Leaves the `mailto:` investor contact link as a normal anchor.
- Removes the current `@next/next/no-html-link-for-pages` warnings for these routes.

Validation:
- `pnpm exec prettier --check src/app/blog/[slug]/page.tsx src/app/for-hire/[[...tags]]/page.tsx src/app/gigs/[[...tags]]/page.tsx src/app/investors/page.tsx`
- `pnpm exec eslint src/app/blog/[slug]/page.tsx src/app/for-hire/[[...tags]]/page.tsx src/app/gigs/[[...tags]]/page.tsx src/app/investors/page.tsx`
- `pnpm type-check`
- `pnpm lint` now reports 39 warnings instead of the 45-warning baseline; the internal page-link warnings fixed here are gone. Remaining warnings are pre-existing and unrelated.