### PR TITLE
Preserve bounty payout metadata when creating payment

### DIFF
--- a/src/app/api/bounties/[id]/submissions/[sid]/pay/route.test.ts
+++ b/src/app/api/bounties/[id]/submissions/[sid]/pay/route.test.ts
@@ -56,7 +56,11 @@ describe("POST /api/bounties/[id]/submissions/[sid]/pay", () => {
         payout_status: "unpaid",
         pay_url: null,
         coinpay_invoice_id: null,
-        metadata: {},
+        metadata: {
+          expired_coinpay_invoice_id: "cp-pay-expired-1",
+          expired_at: "2026-05-22T12:00:00Z",
+          reviewer_note_id: "review-note-1",
+        },
       },
     });
 
@@ -99,6 +103,9 @@ describe("POST /api/bounties/[id]/submissions/[sid]/pay", () => {
       coinpay_invoice_id: "cp-pay-bounty-1",
       pay_url: "https://coinpayportal.com/pay/cp-pay-bounty-1",
       metadata: expect.objectContaining({
+        expired_coinpay_invoice_id: "cp-pay-expired-1",
+        expired_at: "2026-05-22T12:00:00Z",
+        reviewer_note_id: "review-note-1",
         payment_address: "So11111111111111111111111111111111111111112",
         amount_crypto: 0.5,
         payment_currency: "sol",

--- a/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
+++ b/src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts
@@ -104,6 +104,10 @@ export async function POST(
       paymentResult.expires_at || (cpPayment.expires_at as string | undefined) || null;
     const responseCurrency =
       paymentResult.currency || (cpPayment.currency as string | undefined) || paymentCurrency;
+    const existingMetadata =
+      submission.metadata && typeof submission.metadata === "object" && !Array.isArray(submission.metadata)
+        ? (submission.metadata as Record<string, unknown>)
+        : {};
 
     if (!paymentId || !paymentAddress) {
       return NextResponse.json(
@@ -119,6 +123,7 @@ export async function POST(
         coinpay_invoice_id: paymentId,
         pay_url: checkoutUrl,
         metadata: {
+          ...existingMetadata,
           payment_address: paymentAddress,
           amount_crypto: amountCrypto,
           payment_currency: responseCurrency,


### PR DESCRIPTION
## Summary
- preserve existing bounty submission metadata when creating a CoinPay bounty payout
- keep previous audit/sync fields (for example expired payment metadata) while new payment details take precedence
- add a regression assertion covering metadata preservation

## Tests
- pnpm vitest run src/app/api/bounties/[id]/submissions/[sid]/pay/route.test.ts
- pnpm type-check
- pnpm eslint src/app/api/bounties/[id]/submissions/[sid]/pay/route.ts src/app/api/bounties/[id]/submissions/[sid]/pay/route.test.ts