### PR TITLE
fix: skip 400 responses in getCoinpayGlobalWalletTokens to allow fall…

### DIFF
--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -561,7 +561,7 @@ export async function getCoinpayGlobalWalletTokens(
     if (!response.ok) {
       const text = await response.text().catch(() => "");
       errors.push(`${url.pathname}: ${response.status}${text ? ` ${text.slice(0, 120)}` : ""}`);
-      if ([401, 403, 404].includes(response.status)) continue;
+      if ([400, 401, 403, 404].includes(response.status)) continue;
       throw new Error(`CoinPay get-tokens failed: ${response.status}`);
     }
 


### PR DESCRIPTION
…back URLs

The getCoinpayGlobalWalletTokens function tries 3 CoinPay API endpoints in order but throws on HTTP 400 instead of continuing to the next URL. Adding 400 to the skip list allows fallback to /api/wallets and /api/businesses/{id} when /api/get-tokens returns 400.