### PR TITLE
fix: reset zaps history on direction switch

### DIFF
--- a/src/app/dashboard/zaps/page.test.tsx
+++ b/src/app/dashboard/zaps/page.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ZapsPage from "./page";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function jsonResponse(data: unknown) {
+  return {
+    json: () => Promise.resolve(data),
+  };
+}
+
+function zapEntry(overrides = {}) {
+  return {
+    id: "zap-1",
+    amount_sats: 2500,
+    fee_sats: 0,
+    target_type: "post",
+    target_id: "post-1",
+    note: null,
+    created_at: new Date().toISOString(),
+    user: {
+      id: "user-1",
+      username: "alice",
+      name: "Alice",
+      avatar_url: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("ZapsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("clears stale received zaps immediately when switching to sent history", async () => {
+    const user = userEvent.setup();
+    let resolveSentHistory: (value: ReturnType<typeof jsonResponse>) => void = () => {};
+
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ zaps: [zapEntry()], total: 1 }))
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSentHistory = resolve;
+        })
+      );
+
+    render(<ZapsPage />);
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /sent/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+    });
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      "/api/zaps/history?direction=sent&limit=25&offset=0"
+    );
+
+    resolveSentHistory(jsonResponse({ zaps: [], total: 0 }));
+    expect(await screen.findByText(/You haven't zapped anyone yet/)).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/zaps/page.test.tsx
+++ b/src/app/dashboard/zaps/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ZapsPage from "./page";
 
@@ -31,6 +31,14 @@ function zapEntry(overrides = {}) {
   };
 }
 
+function deferredResponse() {
+  let resolveResponse: (value: ReturnType<typeof jsonResponse>) => void = () => {};
+  const promise = new Promise<ReturnType<typeof jsonResponse>>((resolve) => {
+    resolveResponse = resolve;
+  });
+  return { promise, resolveResponse };
+}
+
 describe("ZapsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,15 +47,11 @@ describe("ZapsPage", () => {
 
   it("clears stale received zaps immediately when switching to sent history", async () => {
     const user = userEvent.setup();
-    let resolveSentHistory: (value: ReturnType<typeof jsonResponse>) => void = () => {};
+    const sentHistory = deferredResponse();
 
     mockFetch
       .mockResolvedValueOnce(jsonResponse({ zaps: [zapEntry()], total: 1 }))
-      .mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveSentHistory = resolve;
-        })
-      );
+      .mockReturnValueOnce(sentHistory.promise);
 
     render(<ZapsPage />);
 
@@ -62,7 +66,58 @@ describe("ZapsPage", () => {
       "/api/zaps/history?direction=sent&limit=25&offset=0"
     );
 
-    resolveSentHistory(jsonResponse({ zaps: [], total: 0 }));
+    await act(async () => {
+      sentHistory.resolveResponse(jsonResponse({ zaps: [], total: 0 }));
+    });
     expect(await screen.findByText(/You haven't zapped anyone yet/)).toBeInTheDocument();
+  });
+
+  it("ignores a received-history response that resolves after switching to sent", async () => {
+    const user = userEvent.setup();
+    const receivedHistory = deferredResponse();
+    const sentHistory = deferredResponse();
+
+    mockFetch
+      .mockReturnValueOnce(receivedHistory.promise)
+      .mockReturnValueOnce(sentHistory.promise);
+
+    render(<ZapsPage />);
+
+    await user.click(screen.getByRole("button", { name: /sent/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "/api/zaps/history?direction=sent&limit=25&offset=0"
+      );
+    });
+
+    await act(async () => {
+      sentHistory.resolveResponse(
+        jsonResponse({
+          zaps: [
+            zapEntry({
+              id: "zap-2",
+              amount_sats: 5000,
+              user: {
+                id: "user-2",
+                username: "bob",
+                name: "Bob",
+                avatar_url: null,
+              },
+            }),
+          ],
+          total: 1,
+        })
+      );
+    });
+
+    expect(await screen.findByText("Bob")).toBeInTheDocument();
+
+    await act(async () => {
+      receivedHistory.resolveResponse(jsonResponse({ zaps: [zapEntry()], total: 1 }));
+    });
+
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.queryByText("Alice")).not.toBeInTheDocument();
   });
 });

--- a/src/app/dashboard/zaps/page.tsx
+++ b/src/app/dashboard/zaps/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Zap, ArrowDownLeft, ArrowUpRight } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
@@ -58,26 +58,48 @@ export default function ZapsPage() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [offset, setOffset] = useState(0);
+  const requestSeq = useRef(0);
   const limit = 25;
 
-  async function fetchZaps(off: number) {
+  const fetchZaps = useCallback(async (off: number, reset = false) => {
+    const seq = ++requestSeq.current;
+    if (reset) {
+      setOffset(0);
+      setZaps([]);
+      setTotal(0);
+    }
+    setLoading(true);
     try {
       const res = await fetch(`/api/zaps/history?direction=${direction}&limit=${limit}&offset=${off}`);
       const data = await res.json();
+      if (seq !== requestSeq.current) return;
       if (data.zaps) {
         setZaps((current) => (off === 0 ? data.zaps : [...current, ...data.zaps]));
         setTotal(data.total);
       }
     } catch {
-      // ignore
+      if (seq === requestSeq.current && off === 0) {
+        setZaps([]);
+        setTotal(0);
+      }
     }
-    setLoading(false);
-  }
+    if (seq === requestSeq.current) setLoading(false);
+  }, [direction, limit]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    fetchZaps(0);
-  }, [direction]);
+    fetchZaps(0, true);
+  }, [fetchZaps]);
+
+  function selectDirection(nextDirection: "received" | "sent") {
+    if (nextDirection === direction) return;
+    requestSeq.current += 1;
+    setLoading(true);
+    setOffset(0);
+    setZaps([]);
+    setTotal(0);
+    setDirection(nextDirection);
+  }
 
   function loadMore() {
     const newOffset = offset + limit;
@@ -98,11 +120,7 @@ export default function ZapsPage() {
       {/* Tabs */}
       <div className="flex border-b border-border mb-6">
         <button
-          onClick={() => {
-            setLoading(true);
-            setOffset(0);
-            setDirection("received");
-          }}
+          onClick={() => selectDirection("received")}
           className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
             direction === "received"
               ? "border-amber-500 text-amber-500"
@@ -112,11 +130,7 @@ export default function ZapsPage() {
           <ArrowDownLeft className="h-4 w-4" /> Received
         </button>
         <button
-          onClick={() => {
-            setLoading(true);
-            setOffset(0);
-            setDirection("sent");
-          }}
+          onClick={() => selectDirection("sent")}
           className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
             direction === "sent"
               ? "border-amber-500 text-amber-500"


### PR DESCRIPTION
## Summary
- fixes #269
- reset zaps rows, totals, and pagination when switching between Received and Sent history
- ignore stale in-flight history responses so a slower previous request cannot overwrite the active tab
- add a regression test for the pending-request direction switch case

## Validation
- pnpm test:run src/app/dashboard/zaps/page.test.tsx
- pnpm lint --quiet
- pnpm type-check
- pnpm test:run

Submitted for the active Ugig testing/fix gig: https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e