### PR TITLE
[codex] Redact sensitive profile and resume logs

### DIFF
--- a/src/app/api/profile/import/route.ts
+++ b/src/app/api/profile/import/route.ts
@@ -53,17 +53,17 @@ export async function POST(request: NextRequest) {
 
     // Log what was parsed for debugging
     console.log("Resume parsed:", {
-      full_name: parsed.full_name,
-      bio: parsed.bio ? `${parsed.bio.slice(0, 100)}...` : null,
+      has_full_name: Boolean(parsed.full_name),
+      has_bio: Boolean(parsed.bio),
       skills_count: parsed.skills?.length || 0,
-      skills_sample: parsed.skills?.slice(0, 5),
       work_history_count: parsed.work_history?.length || 0,
-      work_history_sample: parsed.work_history?.slice(0, 2).map(w => ({
-        company: w.company,
-        position: w.position,
-        start_date: w.start_date,
-      })),
-      location: parsed.location,
+      has_location: Boolean(parsed.location),
+      has_contact: Boolean(
+        parsed.contact?.website ||
+          parsed.contact?.linkedin_url ||
+          parsed.contact?.github_url ||
+          parsed.contact?.twitter_url
+      ),
     });
 
     // Also log if no work history was found to help debug
@@ -174,7 +174,6 @@ export async function POST(request: NextRequest) {
           work_history_entries: parsed.work_history?.length || 0,
           work_history_sample: parsed.work_history?.slice(0, 2) || [],
           text_length: parsed._debug?.text_length || 0,
-          text_preview: parsed._debug?.text_preview || "",
           has_experience_section: parsed._debug?.has_experience_section || false,
         },
       }),

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -51,10 +51,8 @@ export async function PUT(request: NextRequest) {
     if (!rl.allowed) return rateLimitExceeded(rl);
 
     const body = await request.json();
-    console.log("Profile update request body:", JSON.stringify(body, null, 2));
 
     const validationResult = profileSchema.safeParse(body);
-    console.log("Validation result:", validationResult.success, validationResult.data);
 
     if (!validationResult.success) {
       return NextResponse.json(
@@ -114,7 +112,6 @@ export async function PUT(request: NextRequest) {
       profile_completed: isComplete,
       updated_at: new Date().toISOString(),
     };
-    console.log("Updating profile with wallet_addresses:", JSON.stringify(validationResult.data.wallet_addresses, null, 2));
 
     const { data: profile, error } = await supabase
       .from("profiles")
@@ -128,8 +125,6 @@ export async function PUT(request: NextRequest) {
       console.error("Error details:", JSON.stringify(error, null, 2));
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
-
-    console.log("Profile saved, wallet_addresses:", JSON.stringify(profile?.wallet_addresses, null, 2));
 
     // Log profile update activity
     void logActivity(supabase, {

--- a/src/lib/resume-parser.ts
+++ b/src/lib/resume-parser.ts
@@ -109,8 +109,6 @@ ${text}`;
       full_name: parsed.full_name,
       skills_count: parsed.skills?.length || 0,
       work_history_count: parsed.work_history?.length || 0,
-      location: parsed.location,
-      contact: parsed.contact,
     });
 
     // Validate and normalize the response
@@ -170,11 +168,6 @@ export async function parseResumeFile(buffer: Buffer, mimeType: string): Promise
 
   // Check if experience section exists (for debug info)
   const hasExperienceSection = /(?:work experience|experience|work history|employment|professional experience)/i.test(text);
-
-  // Log the raw text for debugging
-  console.log("=== RAW TEXT PREVIEW ===");
-  console.log(text.slice(0, 2000));
-  console.log("========================");
 
   // Parse with OpenAI
   const parsed = await parseWithOpenAI(text);

--- a/src/lib/resume-parser.ts
+++ b/src/lib/resume-parser.ts
@@ -30,7 +30,6 @@ export interface ParsedResumeProfile {
   contact: ParsedContact;
   _debug?: {
     text_length: number;
-    text_preview: string;
     has_experience_section: boolean;
   };
 }
@@ -106,7 +105,7 @@ ${text}`;
 
     const parsed = JSON.parse(content);
     console.log("OpenAI parsed resume:", {
-      full_name: parsed.full_name,
+      has_full_name: Boolean(parsed.full_name),
       skills_count: parsed.skills?.length || 0,
       work_history_count: parsed.work_history?.length || 0,
     });
@@ -177,7 +176,6 @@ export async function parseResumeFile(buffer: Buffer, mimeType: string): Promise
     ...parsed,
     _debug: {
       text_length: text.length,
-      text_preview: text.slice(0, 1500),
       has_experience_section: hasExperienceSection,
     },
   };


### PR DESCRIPTION
## Summary
- remove debug logging of full profile update payloads, validation data, and wallet addresses
- stop logging raw resume text previews and parsed contact/location fields during resume import
- address review feedback by removing remaining resume PII from parser/import debug logs and dropping raw text from `_debug`

Fixes #274.

## Why
These paths handle profile data, wallet addresses, and resume/contact details. Dumping those values to server logs creates avoidable privacy exposure for routine user actions.

## Validation
- `node_modules/.bin/tsc.cmd --noEmit`
- `git diff --check -- src/lib/resume-parser.ts src/app/api/profile/import/route.ts`
- No dedicated `src/app/api/profile/import/route.test.ts` exists in this repo.

Note: `corepack pnpm install --frozen-lockfile` installed dependencies, but the repo postinstall script failed under PowerShell because it invokes Unix-style `pnpm`/`true` commands. TypeScript validation was run directly after install.