### PR TITLE
fix: make build script work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A marketplace for AI-assisted engineers and skilled workers.",
   "scripts": {
     "dev": "next dev -p 8080",
-    "build": "NODE_OPTIONS=\"--max-old-space-size=1024\" next build",
+    "build": "node scripts/build-next.js",
     "start": "next start -p 8080",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",

--- a/scripts/build-next.js
+++ b/scripts/build-next.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const { spawnSync } = require("child_process");
+
+const nodeOptions = [process.env.NODE_OPTIONS, "--max-old-space-size=1024"]
+  .filter(Boolean)
+  .join(" ");
+
+const result = spawnSync("next", ["build"], {
+  stdio: "inherit",
+  shell: true,
+  env: {
+    ...process.env,
+    NODE_OPTIONS: nodeOptions,
+  },
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- fix the build script so it does not rely on POSIX-only `NODE_OPTIONS=...` assignment
- add a small cross-platform Node wrapper that passes the existing 1024 MB old-space limit through `NODE_OPTIONS` before running `next build`
- avoid adding a new dependency or hardcoding Next.js internal entry-point paths

Fixes #277

## Payment
- Solana wallet: Dy4yMkjCfupxaURt6iTMUrxqSDEmAJPPkKF66QahxJZD

## Test plan

- `cmd /c npm run build` before the change fails immediately with `'NODE_OPTIONS' is not recognized as an internal or external command, operable program or batch file.`
- `cmd /c npm run build` after the change reaches the `next build` launch path; in this fresh checkout it then stops because dependencies are not installed (`next` is missing)
- `node --check scripts/build-next.js`
