### PR TITLE
fix(referrals): normalize invite email dedupe

### DIFF
--- a/src/app/api/referrals/route.test.ts
+++ b/src/app/api/referrals/route.test.ts
@@ -34,7 +34,7 @@ const mockSupabase = {
   })),
 };
 
-function makeServiceClientWithNoExistingReferrals() {
+function makeServiceClientWithNoExistingReferrals(existingInvites: { referred_email: string }[] = []) {
   let referralsQueryCount = 0;
 
   return {
@@ -46,9 +46,9 @@ function makeServiceClientWithNoExistingReferrals() {
             if (referralsQueryCount <= 2) {
               return Promise.resolve({ count: 0, error: null });
             }
-            return Promise.resolve({ data: [], error: null });
+            return Promise.resolve({ data: existingInvites, error: null });
           }),
-          in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          in: vi.fn().mockResolvedValue({ data: existingInvites, error: null }),
         }),
       }),
     })),
@@ -114,6 +114,12 @@ describe("POST /api/referrals", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateServiceClient.mockReturnValue(makeServiceClientWithNoExistingReferrals());
+    mockReferralInviteEmail.mockReturnValue({
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+    mockSendEmail.mockResolvedValue({ success: true });
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -185,6 +191,64 @@ describe("POST /api/referrals", () => {
     });
     expect(mockSendEmail).toHaveBeenCalledWith({
       to: "friend@test.com",
+      subject: "Join ugig.net",
+      html: "<p>Join</p>",
+      text: "Join",
+    });
+  });
+
+  it("normalizes invite emails before duplicate checks, inserts, and sends", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+    mockCreateServiceClient.mockReturnValue(
+      makeServiceClientWithNoExistingReferrals([
+        { referred_email: "existing@test.com" },
+      ])
+    );
+
+    const mockSelectChain = {
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { referral_code: "testuser", username: "testuser", full_name: "Test User" },
+          error: null,
+        }),
+      }),
+    };
+    const mockInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        data: [{ id: "ref1", referred_email: "new@test.com", status: "pending" }],
+        error: null,
+      }),
+    });
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "profiles") return { select: () => mockSelectChain };
+      if (table === "referrals") return { insert: mockInsert };
+      return {};
+    });
+
+    const res = await POST(makePostRequest({
+      emails: [
+        " Existing@Test.com ",
+        "NEW@Test.com",
+        " new@test.com ",
+      ],
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockInsert).toHaveBeenCalledWith([
+      {
+        referrer_id: "user1",
+        referred_email: "new@test.com",
+        referral_code: "testuser",
+        status: "pending",
+      },
+    ]);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledWith({
+      to: "new@test.com",
       subject: "Join ugig.net",
       html: "<p>Join</p>",
       text: "Join",

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -163,7 +163,7 @@ export async function POST(request: NextRequest) {
 
     const referralRows = newValidEmails.map((email: string) => ({
       referrer_id: user.id,
-      referred_email: email.trim().toLowerCase(),
+      referred_email: email,
       referral_code: referralCode,
       status: "pending" as const,
     }));

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -79,7 +79,13 @@ export async function POST(request: NextRequest) {
     // Validate email syntax BEFORE rate-limit checks (#143)
     // Only valid emails should count toward throttle limits
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    const validEmails = emails.filter((e: string) => typeof e === "string" && emailRegex.test(e.trim().toLowerCase()));
+    const validEmails = Array.from(
+      new Set(
+        emails
+          .map((e: string) => e.trim().toLowerCase())
+          .filter((email: string) => emailRegex.test(email))
+      )
+    );
 
     if (validEmails.length === 0) {
       return NextResponse.json(
@@ -121,14 +127,15 @@ export async function POST(request: NextRequest) {
     }
 
     // Prevent duplicate invites to same email
-    const normalizedEmails = emails.map((e: string) => e.trim().toLowerCase());
     const { data: existingInvites } = await (svc as AnySupabase)
       .from("referrals")
       .select("referred_email")
       .eq("referrer_id", user.id)
-      .in("referred_email", normalizedEmails);
+      .in("referred_email", validEmails);
 
-    const alreadyInvited = new Set((existingInvites || []).map((r: any) => r.referred_email));
+    const alreadyInvited = new Set(
+      (existingInvites || []).map((r: any) => String(r.referred_email).trim().toLowerCase())
+    );
 
     // Get user's referral code
     const { data: profile } = await (supabase as any)
@@ -145,7 +152,7 @@ export async function POST(request: NextRequest) {
     const inviterName = profile.full_name || profile.username || "Someone";
 
     // Filter valid emails that aren't already invited (#143)
-    const newValidEmails = validEmails.filter((e: string) => !alreadyInvited.has(e));
+    const newValidEmails = validEmails.filter((email: string) => !alreadyInvited.has(email));
 
     if (newValidEmails.length === 0) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary

- normalize Invite Friends emails once before rate-limit counting, duplicate lookup, inserts, and email sends
- dedupe repeated emails within the same request after trimming/lowercasing
- add regression coverage for an existing invited email submitted again with whitespace/case changes

Fixes #279

## Payment
- Solana wallet: Dy4yMkjCfupxaURt6iTMUrxqSDEmAJPPkKF66QahxJZD

## Test plan

- `npx.cmd vitest run src/app/api/referrals/route.test.ts`
- `git diff --check -- src/app/api/referrals/route.ts src/app/api/referrals/route.test.ts`
