### PR TITLE
fix(activity): clamp pagination params

### DIFF
--- a/src/app/api/activity/route.test.ts
+++ b/src/app/api/activity/route.test.ts
@@ -1,0 +1,76 @@
+// @ts-nocheck - Supabase route mocks are intentionally minimal.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+function makeRequest(query = "") {
+  return new NextRequest(`http://localhost/api/activity${query}`);
+}
+
+function makeSupabase() {
+  const range = vi.fn().mockResolvedValue({
+    data: [{ id: "activity-1" }],
+    error: null,
+    count: 1,
+  });
+  const order = vi.fn().mockReturnValue({ range });
+  const eq = vi.fn().mockReturnValue({ order });
+  const select = vi.fn().mockReturnValue({ eq });
+  const from = vi.fn().mockReturnValue({ select });
+
+  return { supabase: { from }, range };
+}
+
+describe("GET /api/activity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires authentication", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(401);
+  });
+
+  it("clamps invalid pagination values before querying", async () => {
+    const { supabase, range } = makeSupabase();
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-1" },
+      supabase,
+    });
+
+    const res = await GET(makeRequest("?limit=-10&offset=-5"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(range).toHaveBeenCalledWith(0, 19);
+    expect(body.pagination).toEqual({
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("caps large limits at 50", async () => {
+    const { supabase, range } = makeSupabase();
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-1" },
+      supabase,
+    });
+
+    const res = await GET(makeRequest("?limit=500&offset=10"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(range).toHaveBeenCalledWith(10, 59);
+    expect(body.pagination.limit).toBe(50);
+    expect(body.pagination.offset).toBe(10);
+  });
+});

--- a/src/app/api/activity/route.test.ts
+++ b/src/app/api/activity/route.test.ts
@@ -73,4 +73,23 @@ describe("GET /api/activity", () => {
     expect(body.pagination.limit).toBe(50);
     expect(body.pagination.offset).toBe(10);
   });
+
+  it("uses valid pagination values as provided", async () => {
+    const { supabase, range } = makeSupabase();
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-1" },
+      supabase,
+    });
+
+    const res = await GET(makeRequest("?limit=12&offset=24"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(range).toHaveBeenCalledWith(24, 35);
+    expect(body.pagination).toEqual({
+      total: 1,
+      limit: 12,
+      offset: 24,
+    });
+  });
 });

--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -1,6 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 
+function parsePositiveInt(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInt(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 // GET /api/activity - User's own activity feed (includes private activities)
 // When authenticated, returns the user's own activities including private ones
 export async function GET(request: NextRequest) {
@@ -12,8 +22,8 @@ export async function GET(request: NextRequest) {
     const { user, supabase } = auth;
 
     const searchParams = request.nextUrl.searchParams;
-    const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 50);
-    const offset = parseInt(searchParams.get("offset") || "0");
+    const limit = Math.min(parsePositiveInt(searchParams.get("limit"), 20), 50);
+    const offset = parseNonNegativeInt(searchParams.get("offset"), 0);
 
     // Fetch all activities for the authenticated user (including private)
     const { data: activities, error, count } = await supabase


### PR DESCRIPTION
## Summary

- clamp `/api/activity` pagination query params before building the Supabase range
- default invalid/non-positive `limit` to 20 and cap large limits at 50
- default invalid/negative `offset` to 0
- add route coverage for auth, invalid pagination, and capped limits

Fixes #281

## Payment
- Solana wallet: Dy4yMkjCfupxaURt6iTMUrxqSDEmAJPPkKF66QahxJZD

## Test plan

- `npx.cmd vitest run src/app/api/activity/route.test.ts`
- `git diff --check -- src/app/api/activity/route.ts src/app/api/activity/route.test.ts`
