### PR TITLE
fix(activity): clamp public user pagination params

### DIFF
--- a/src/app/api/users/[username]/activity/route.test.ts
+++ b/src/app/api/users/[username]/activity/route.test.ts
@@ -1,0 +1,112 @@
+// @ts-nocheck - Supabase route mocks are intentionally minimal.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+const mockFrom = vi.fn();
+
+const supabaseClient = {
+  from: mockFrom,
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(supabaseClient)),
+}));
+
+const routeParams = { params: Promise.resolve({ username: "testuser" }) };
+
+function makeRequest(query = "") {
+  return new NextRequest(`http://localhost/api/users/testuser/activity${query}`);
+}
+
+function makeProfileChain(profile: { id: string } | null = { id: "user-1" }) {
+  const single = vi.fn().mockResolvedValue({
+    data: profile,
+    error: profile ? null : { message: "not found" },
+  });
+  const eq = vi.fn().mockReturnValue({ single });
+  const select = vi.fn().mockReturnValue({ eq });
+
+  return { select, eq, single };
+}
+
+function makeActivitiesChain() {
+  const range = vi.fn().mockResolvedValue({
+    data: [{ id: "activity-1" }],
+    error: null,
+    count: 1,
+  });
+  const order = vi.fn().mockReturnValue({ range });
+  const isPublicEq = vi.fn().mockReturnValue({ order });
+  const userEq = vi.fn().mockReturnValue({ eq: isPublicEq });
+  const select = vi.fn().mockReturnValue({ eq: userEq });
+
+  return { select, userEq, isPublicEq, order, range };
+}
+
+function mockActivityRequest(profile = { id: "user-1" }) {
+  const profileChain = makeProfileChain(profile);
+  const activitiesChain = makeActivitiesChain();
+
+  mockFrom.mockImplementation((table: string) =>
+    table === "profiles" ? profileChain : activitiesChain
+  );
+
+  return { profileChain, activitiesChain };
+}
+
+describe("GET /api/users/:username/activity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 when the profile is missing", async () => {
+    mockActivityRequest(null);
+
+    const res = await GET(makeRequest(), routeParams);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("clamps invalid pagination values before querying", async () => {
+    const { activitiesChain } = mockActivityRequest();
+
+    const res = await GET(makeRequest("?limit=0&offset=-5"), routeParams);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(activitiesChain.range).toHaveBeenCalledWith(0, 19);
+    expect(body.pagination).toEqual({
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("caps large limits at 50", async () => {
+    const { activitiesChain } = mockActivityRequest();
+
+    const res = await GET(makeRequest("?limit=500&offset=10"), routeParams);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(activitiesChain.range).toHaveBeenCalledWith(10, 59);
+    expect(body.pagination.limit).toBe(50);
+    expect(body.pagination.offset).toBe(10);
+  });
+
+  it("uses valid pagination values as provided", async () => {
+    const { activitiesChain } = mockActivityRequest();
+
+    const res = await GET(makeRequest("?limit=12&offset=24"), routeParams);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(activitiesChain.range).toHaveBeenCalledWith(24, 35);
+    expect(body.pagination).toEqual({
+      total: 1,
+      limit: 12,
+      offset: 24,
+    });
+  });
+});

--- a/src/app/api/users/[username]/activity/route.ts
+++ b/src/app/api/users/[username]/activity/route.ts
@@ -1,6 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+function parsePositiveInt(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInt(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 // GET /api/users/:username/activity - Public activity feed for a user
 export async function GET(
   request: NextRequest,
@@ -9,8 +19,8 @@ export async function GET(
   try {
     const { username } = await params;
     const searchParams = request.nextUrl.searchParams;
-    const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 50);
-    const offset = parseInt(searchParams.get("offset") || "0");
+    const limit = Math.min(parsePositiveInt(searchParams.get("limit"), 20), 50);
+    const offset = parseNonNegativeInt(searchParams.get("offset"), 0);
 
     const supabase = await createClient();
 


### PR DESCRIPTION
## Summary
- fixes invalid limit / offset handling in the public user activity endpoint
- defaults non-positive limits to 20, caps large limits at 50, and clamps negative offsets to 0
- adds route tests for missing profiles, invalid pagination, large limit caps, and valid pagination

Closes #283

## Validation
- corepack pnpm test -- src/app/api/users/[username]/activity/route.test.ts
- node_modules\.bin\tsc.CMD -p tsconfig.json --noEmit

Submitted for the ugig bounty: I will pay for every bug fix found and PR submitted that fixes it.

Solana wallet for bounty payout:
Dy4yMkjCfupxaURt6iTMUrxqSDEmAJPPkKF66QahxJZD