### PR TITLE
fix(bounties): clamp list pagination params

### DIFF
--- a/src/app/api/bounties/route.test.ts
+++ b/src/app/api/bounties/route.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+const mockFrom = vi.fn();
+
+const supabaseClient = {
+  from: mockFrom,
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(supabaseClient)),
+}));
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+}));
+
+function makeRequest(searchParams?: Record<string, string>) {
+  let url = "http://localhost/api/bounties";
+  if (searchParams) {
+    url += `?${new URLSearchParams(searchParams).toString()}`;
+  }
+  return new NextRequest(url, { method: "GET" });
+}
+
+function bountyListChain(result = { data: [], error: null }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ["select", "eq", "order", "range"]) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.range.mockResolvedValue(result);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/bounties", () => {
+  it("falls back for invalid pagination params", async () => {
+    const query = bountyListChain();
+    mockFrom.mockReturnValue(query);
+
+    const res = await GET(makeRequest({ limit: "0", page: "-2" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(query.range).toHaveBeenCalledWith(0, 49);
+    expect(json.data).toEqual([]);
+  });
+
+  it("falls back for fractional pagination params", async () => {
+    const query = bountyListChain();
+    mockFrom.mockReturnValue(query);
+
+    await GET(makeRequest({ limit: "1.9", page: "2.5" }));
+
+    expect(query.range).toHaveBeenCalledWith(0, 49);
+  });
+
+  it("caps large limits", async () => {
+    const query = bountyListChain();
+    mockFrom.mockReturnValue(query);
+
+    await GET(makeRequest({ limit: "500", page: "2" }));
+
+    expect(query.range).toHaveBeenCalledWith(100, 199);
+  });
+
+  it("keeps valid pagination params", async () => {
+    const query = bountyListChain();
+    mockFrom.mockReturnValue(query);
+
+    await GET(makeRequest({ limit: "25", page: "3" }));
+
+    expect(query.range).toHaveBeenCalledWith(50, 74);
+  });
+
+  it("applies requested status filter", async () => {
+    const query = bountyListChain();
+    mockFrom.mockReturnValue(query);
+
+    await GET(makeRequest({ status: "closed" }));
+
+    expect(query.eq).toHaveBeenCalledWith("status", "closed");
+  });
+});

--- a/src/app/api/bounties/route.ts
+++ b/src/app/api/bounties/route.ts
@@ -4,13 +4,24 @@ import { createClient } from "@/lib/supabase/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createBountySchema } from "@/lib/bounties";
 
-// GET /api/bounties — public list of open bounties
+function parsePositiveInt(value: string | null, fallback: number, max?: number): number {
+  if (!value || !/^\d+$/.test(value)) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return max === undefined ? parsed : Math.min(parsed, max);
+}
+
+// GET /api/bounties - public list of open bounties
 export async function GET(request: NextRequest) {
   try {
     const params = request.nextUrl.searchParams;
     const status = params.get("status") || "open";
-    const limit = Math.min(Number(params.get("limit") || 50), 100);
-    const page = Math.max(Number(params.get("page") || 1), 1);
+    const limit = parsePositiveInt(params.get("limit"), 50, 100);
+    const page = parsePositiveInt(params.get("page"), 1);
     const offset = (page - 1) * limit;
 
     const supabase = await createClient();
@@ -37,7 +48,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// POST /api/bounties — create a bounty
+// POST /api/bounties - create a bounty
 export async function POST(request: NextRequest) {
   try {
     const auth = await getAuthContext(request);


### PR DESCRIPTION
Fixes #289

## Summary
- reject non-positive or invalid bounties list limits by falling back to 50
- preserve the existing max limit of 100
- reject non-positive or invalid pages by falling back to page 1
- add route tests for invalid pagination, limit capping, valid pagination, and status filtering

## Validation
- corepack pnpm test -- src/app/api/bounties/route.test.ts
- node_modules\.bin\tsc.CMD -p tsconfig.json --noEmit
