### PR TITLE
fix(coinpayportal): add coin.chain fallback to coinToPaymentCurrency

### DIFF
--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -281,7 +281,8 @@ export function coinToPaymentCurrency(coin: SupportedCoin): SupportedCurrency | 
     normalizeCoinSymbol(coin.symbol) ||
     normalizeCoinSymbol(coin.code) ||
     normalizeCoinSymbol(coin.currency) ||
-    normalizeCoinSymbol(coin.id);
+    normalizeCoinSymbol(coin.id) ||
+    normalizeCoinSymbol(coin.chain);
   const chain =
     normalizeCoinSymbol(coin.chain) ||
     normalizeCoinSymbol(coin.network) ||


### PR DESCRIPTION
CoinPay's /api/oauth/userinfo returns wallets as {address, chain: "SOL"} (not symbol). The symbol computation in coinToPaymentCurrency never checked coin.chain, so SOL wallets were never recognized and invoices failed with "Select a CoinPay receiving wallet" error.