### PR TITLE
Clamp bounty pagination params

### DIFF
--- a/src/app/api/bounties/route.ts
+++ b/src/app/api/bounties/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
       ? Math.min(Math.max(Math.trunc(rawLimit), 1), 100)
       : 50;
     const page = Number.isFinite(rawPage)
-      ? Math.max(Math.trunc(rawPage), 1)
+      ? Math.min(Math.max(Math.trunc(rawPage), 1), 1000)
       : 1;
     const offset = (page - 1) * limit;
 

--- a/src/app/api/bounties/route.ts
+++ b/src/app/api/bounties/route.ts
@@ -9,8 +9,14 @@ export async function GET(request: NextRequest) {
   try {
     const params = request.nextUrl.searchParams;
     const status = params.get("status") || "open";
-    const limit = Math.min(Number(params.get("limit") || 50), 100);
-    const page = Math.max(Number(params.get("page") || 1), 1);
+    const rawLimit = Number(params.get("limit") || 50);
+    const rawPage = Number(params.get("page") || 1);
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(Math.trunc(rawLimit), 1), 100)
+      : 50;
+    const page = Number.isFinite(rawPage)
+      ? Math.max(Math.trunc(rawPage), 1)
+      : 1;
     const offset = (page - 1) * limit;
 
     const supabase = await createClient();


### PR DESCRIPTION
Fixes #289.\n\n## Summary\n- clamp GET /api/bounties limit to the valid 1..100 range\n- default non-finite limit/page values to safe values\n- truncate decimal page/limit before computing Supabase range\n\n## Test\n- npm test -- --runInBand src/app/api/bounties/route.ts *(blocked locally: vitest not installed in clone)*