### PR TITLE
fix(pagination): clamp page/offset params in directory, notifications, and prompts

### DIFF
--- a/src/app/api/directory/route.ts
+++ b/src/app/api/directory/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
     const url = new URL(request.url);
     const search = url.searchParams.get("search") || "";
     const tag = sanitizeSearchParams(url, "tag");
-    const page = parseInt(url.searchParams.get("page") || "1");
+    const page = Math.max(1, parseInt(url.searchParams.get("page") || "1") || 1);
     const limit = 20;
     const offset = (page - 1) * limit;
 

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -19,8 +19,8 @@ export async function GET(request: NextRequest) {
 
     const searchParams = request.nextUrl.searchParams;
     const unreadOnly = searchParams.get("unread") === "true";
-    const limit = Math.min(Number(searchParams.get("limit")) || 50, 100);
-    const offset = Number(searchParams.get("offset")) || 0;
+    const limit = Math.min(Math.max(1, Number(searchParams.get("limit")) || 50), 100);
+    const offset = Math.max(0, Number(searchParams.get("offset")) || 0);
 
     let query = supabase
       .from("notifications")

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     const category = url.searchParams.get("category") || "";
     const tag = url.searchParams.get("tag") || "";
     const sort = url.searchParams.get("sort") || "newest";
-    const page = parseInt(url.searchParams.get("page") || "1");
+    const page = Math.max(1, parseInt(url.searchParams.get("page") || "1") || 1);
     const limit = 20;
     const offset = (page - 1) * limit;
 


### PR DESCRIPTION
Fixes #296, #297, #298.

## Changes

- `GET /api/directory?page=-1` — page is now clamped to minimum 1; negative values no longer compute a negative offset
- `GET /api/notifications?offset=-10` — offset is now clamped to minimum 0; limit is clamped to minimum 1
- `GET /api/prompts?page=-1` — page is now clamped to minimum 1; same fix as directory

All three followed the same pattern: unclamped `parseInt`/`Number` results were passed directly to Supabase `.range()`, causing 500 database errors for negative inputs.