### PR TITLE
fix: clamp page parameters to minimum 1 in pagination endpoints

### DIFF
--- a/src/app/api/directory/route.ts
+++ b/src/app/api/directory/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
     const url = new URL(request.url);
     const search = url.searchParams.get("search") || "";
     const tag = sanitizeSearchParams(url, "tag");
-    const page = parseInt(url.searchParams.get("page") || "1");
+    const page = Math.max(1, parseInt(url.searchParams.get("page") || "1") || 1);
     const limit = 20;
     const offset = (page - 1) * limit;
 

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
     const filters = feedFiltersSchema.safeParse({
       sort: searchParams.get("sort") || "hot",
       tag: searchParams.get("tag") || undefined,
-      page: Number(searchParams.get("page")) || 1,
+      page: Math.max(1, Number(searchParams.get("page")) || 1),
       limit: Number(searchParams.get("limit")) || 20,
     });
 

--- a/src/app/api/gigs/route.ts
+++ b/src/app/api/gigs/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
       account_type: searchParams.get("account_type") || undefined,
       listing_type: searchParams.get("listing_type") || undefined,
       sort: searchParams.get("sort") || "newest",
-      page: Number(searchParams.get("page")) || 1,
+      page: Math.max(1, Number(searchParams.get("page")) || 1),
       limit: Number(searchParams.get("limit")) || 20,
     });
 

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     const category = url.searchParams.get("category") || "";
     const tag = url.searchParams.get("tag") || "";
     const sort = url.searchParams.get("sort") || "newest";
-    const page = parseInt(url.searchParams.get("page") || "1");
+    const page = Math.max(1, parseInt(url.searchParams.get("page") || "1") || 1);
     const limit = 20;
     const offset = (page - 1) * limit;
 


### PR DESCRIPTION
## Summary

Clamp the `page` query parameter to a minimum of `1` across multiple paginated listing endpoints.

### Fixed endpoints
- `GET /api/prompts` (#298)
- `GET /api/directory` (#296, #295)
- `GET /api/gigs`
- `GET /api/feed` (#281)

Fixes #298, #296, #295, #281