### PR TITLE
fix(coinpay): map coin.chain field in coinToPaymentCurrency

### DIFF
--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -281,7 +281,7 @@ export function coinToPaymentCurrency(coin: SupportedCoin): SupportedCurrency | 
     normalizeCoinSymbol(coin.symbol) ||
     normalizeCoinSymbol(coin.code) ||
     normalizeCoinSymbol(coin.currency) ||
-    normalizeCoinSymbol(coin.id);
+    normalizeCoinSymbol(coin.id) || normalizeCoinSymbol(coin.chain);
   const chain =
     normalizeCoinSymbol(coin.chain) ||
     normalizeCoinSymbol(coin.network) ||


### PR DESCRIPTION
CoinPay OAuth userinfo returns wallets as { address, chain: "BTC" } but coinToPaymentCurrency() only checks coin.symbol/code/currency/id — never coin.chain. This causes the symbol to be empty and the wallet to be dropped, resulting in workerWallets = [] and the 409 error when creating invoices.

Fix: include coin.chain in the symbol lookup so { chain: "BTC" } correctly maps to "btc".

Fixes #301