### PR TITLE
fix(prompts): clamp invalid page query values

### DIFF
--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -15,7 +15,8 @@ export async function GET(request: NextRequest) {
     const category = url.searchParams.get("category") || "";
     const tag = url.searchParams.get("tag") || "";
     const sort = url.searchParams.get("sort") || "newest";
-    const page = parseInt(url.searchParams.get("page") || "1");
+    const parsedPage = parseInt(url.searchParams.get("page") || "1", 10);
+    const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
     const limit = 20;
     const offset = (page - 1) * limit;
 


### PR DESCRIPTION
## Summary
- clamps the public prompts list page query to a minimum of 1
- keeps invalid, zero, negative, or NaN page values from producing negative Supabase ranges

Fixes #298.

## Verification
- Inspected src/app/api/prompts/route.ts and confirmed offset now derives from a positive page number.
- Full local test suite not run in this environment because the repo was updated through the GitHub API without a full dependency checkout.