### PR TITLE
fix(notifications): clamp invalid pagination ranges

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -19,8 +19,10 @@ export async function GET(request: NextRequest) {
 
     const searchParams = request.nextUrl.searchParams;
     const unreadOnly = searchParams.get("unread") === "true";
-    const limit = Math.min(Number(searchParams.get("limit")) || 50, 100);
-    const offset = Number(searchParams.get("offset")) || 0;
+    const parsedLimit = Number(searchParams.get("limit")) || 50;
+    const parsedOffset = Number(searchParams.get("offset")) || 0;
+    const limit = Math.min(Math.max(parsedLimit, 1), 100);
+    const offset = Math.max(parsedOffset, 0);
 
     let query = supabase
       .from("notifications")

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -19,10 +19,12 @@ export async function GET(request: NextRequest) {
 
     const searchParams = request.nextUrl.searchParams;
     const unreadOnly = searchParams.get("unread") === "true";
-    const parsedLimit = Number(searchParams.get("limit")) || 50;
-    const parsedOffset = Number(searchParams.get("offset")) || 0;
-    const limit = Math.min(Math.max(parsedLimit, 1), 100);
-    const offset = Math.max(parsedOffset, 0);
+    const parsedLimit = parseInt(searchParams.get("limit") || "50", 10);
+    const parsedOffset = parseInt(searchParams.get("offset") || "0", 10);
+    const limit = Number.isFinite(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), 100)
+      : 50;
+    const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
 
     let query = supabase
       .from("notifications")


### PR DESCRIPTION
## Summary
- clamps notification offset to a minimum of 0 before building the Supabase range
- also bounds limit to 1..100 so invalid values cannot create inverted ranges

Fixes #297.

## Verification
- Inspected src/app/api/notifications/route.ts and confirmed range inputs are bounded before `.range(...)`.
- Full local test suite not run in this environment because the repo was updated through the GitHub API without a full dependency checkout.