### PR TITLE
fix(directory): clamp invalid page query values

### DIFF
--- a/src/app/api/directory/route.ts
+++ b/src/app/api/directory/route.ts
@@ -15,6 +15,7 @@ import {
 import { sanitizeSearchParams } from "@/lib/security/sanitize";
 
 const LNBITS_INVOICE_KEY = process.env.LNBITS_INVOICE_KEY || "";
+const MAX_DIRECTORY_PAGE = 10_000;
 
 const createListingSchema = z.object({
   title: z.string().min(1).max(100),
@@ -35,7 +36,9 @@ export async function GET(request: NextRequest) {
     const search = url.searchParams.get("search") || "";
     const tag = sanitizeSearchParams(url, "tag");
     const parsedPage = parseInt(url.searchParams.get("page") || "1", 10);
-    const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+    const page = Number.isFinite(parsedPage) && parsedPage > 0
+      ? Math.min(parsedPage, MAX_DIRECTORY_PAGE)
+      : 1;
     const limit = 20;
     const offset = (page - 1) * limit;
 

--- a/src/app/api/directory/route.ts
+++ b/src/app/api/directory/route.ts
@@ -34,7 +34,8 @@ export async function GET(request: NextRequest) {
     const url = new URL(request.url);
     const search = url.searchParams.get("search") || "";
     const tag = sanitizeSearchParams(url, "tag");
-    const page = parseInt(url.searchParams.get("page") || "1");
+    const parsedPage = parseInt(url.searchParams.get("page") || "1", 10);
+    const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
     const limit = 20;
     const offset = (page - 1) * limit;
 


### PR DESCRIPTION
## Summary
- clamps the directory list page query to a minimum of 1
- prevents negative Supabase ranges for invalid, zero, negative, or NaN page values

Fixes #296.

## Verification
- Inspected src/app/api/directory/route.ts and confirmed offset now derives from a positive page number.
- Full local test suite not run in this environment because the repo was updated through the GitHub API without a full dependency checkout.