### PR TITLE
fix(gigs): reject NaN budget_min/budget_max filter values

### DIFF
--- a/src/app/api/gigs/route.ts
+++ b/src/app/api/gigs/route.ts
@@ -18,12 +18,8 @@ export async function GET(request: NextRequest) {
       category: searchParams.get("category") || undefined,
       skills: searchParams.get("skills")?.split(",").filter(Boolean) || undefined,
       budget_type: searchParams.get("budget_type") || undefined,
-      budget_min: searchParams.get("budget_min")
-        ? Number(searchParams.get("budget_min"))
-        : undefined,
-      budget_max: searchParams.get("budget_max")
-        ? Number(searchParams.get("budget_max"))
-        : undefined,
+      budget_min: (() => { const v = Number(searchParams.get("budget_min")); return searchParams.get("budget_min") && Number.isFinite(v) ? v : undefined; })(),
+      budget_max: (() => { const v = Number(searchParams.get("budget_max")); return searchParams.get("budget_max") && Number.isFinite(v) ? v : undefined; })(),
       location_type: searchParams.get("location_type") || undefined,
       account_type: searchParams.get("account_type") || undefined,
       listing_type: searchParams.get("listing_type") || undefined,


### PR DESCRIPTION
Fixes #308.

`Number("abc") === NaN` and `NaN !== undefined`, so `.gte("budget_max", NaN)` was being passed to Supabase when a non-numeric string was supplied for `budget_min` or `budget_max`, silently returning 0 results.

Guarded with `Number.isFinite()` so non-numeric values are treated the same as omitting the parameter entirely.