### PR TITLE
fix(zaps): clamp history pagination ranges

### DIFF
--- a/src/app/api/zaps/history/route.ts
+++ b/src/app/api/zaps/history/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
       .range(offset, offset + limit - 1) as any;
 
     if (!zaps || zaps.length === 0) {
-      return NextResponse.json({ zaps: [], total: 0 });
+      return NextResponse.json({ zaps: [], total: count || 0 });
     }
 
     // Fetch profiles for the other party

--- a/src/app/api/zaps/history/route.ts
+++ b/src/app/api/zaps/history/route.ts
@@ -14,8 +14,13 @@ export async function GET(request: NextRequest) {
 
     const url = new URL(request.url);
     const direction = url.searchParams.get("direction") || "received";
-    const limit = Math.min(parseInt(url.searchParams.get("limit") || "50"), 100);
-    const offset = parseInt(url.searchParams.get("offset") || "0");
+    const parsedLimit = parseInt(url.searchParams.get("limit") || "50", 10);
+    const parsedOffset = parseInt(url.searchParams.get("offset") || "0", 10);
+    const limit = Number.isFinite(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), 100)
+      : 50;
+    const offset =
+      Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
 
     const admin = createServiceClient();
     const userId = auth.user.id;
@@ -30,7 +35,7 @@ export async function GET(request: NextRequest) {
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1) as any;
 
-    if (!zaps) {
+    if (!zaps || zaps.length === 0) {
       return NextResponse.json({ zaps: [], total: 0 });
     }
 


### PR DESCRIPTION
Fixes #293.

This clamps `limit` and `offset` before passing them into Supabase `.range(...)`:

- invalid or non-positive `limit` falls back into a safe 1..100 range
- invalid or negative `offset` falls back to 0
- empty zap result sets now return immediately without doing a profile lookup for an empty id list

Verification: inspected the route and kept the change scoped to query parsing plus the empty-results guard. Full test suite was not run because this workspace does not have a full dependency checkout.