### PR TITLE
fix(coinpay): map OAuth wallet cryptocurrency chains

### DIFF
--- a/src/lib/coinpayportal.test.ts
+++ b/src/lib/coinpayportal.test.ts
@@ -4,6 +4,7 @@ import {
   createPayment,
   createInvoice,
   sendInvoice,
+  coinToPaymentCurrency,
   getBusinessWalletCurrencies,
   getSupportedCoins,
   preferredCoinToPaymentCurrency,
@@ -194,6 +195,12 @@ describe("CoinPayPortal supported coins API", () => {
     expect(preferredCoinToPaymentCurrency("POL")).toBe("pol");
     expect(preferredCoinToPaymentCurrency("USDT")).toBe("usdt");
     expect(preferredCoinToPaymentCurrency("USDC")).toBe("usdc_sol");
+  });
+
+  it("maps CoinPay OAuth wallet cryptocurrency and chain fields", () => {
+    expect(coinToPaymentCurrency({ cryptocurrency: "USDC", chain: "POL" })).toBe("usdc_pol");
+    expect(coinToPaymentCurrency({ cryptocurrency: "USDT", chain: "ETH" })).toBe("usdt_eth");
+    expect(coinToPaymentCurrency({ cryptocurrency: "SOL", chain: "SOL" })).toBe("sol");
   });
 
   it("rejects preferred coins CoinPayPortal payment creation cannot represent", async () => {

--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -76,6 +76,7 @@ export interface SupportedCoin {
   symbol?: string;
   code?: string;
   currency?: string;
+  cryptocurrency?: string;
   id?: string;
   name?: string;
   chain?: string;
@@ -281,6 +282,7 @@ export function coinToPaymentCurrency(coin: SupportedCoin): SupportedCurrency | 
     normalizeCoinSymbol(coin.symbol) ||
     normalizeCoinSymbol(coin.code) ||
     normalizeCoinSymbol(coin.currency) ||
+    normalizeCoinSymbol(coin.cryptocurrency) ||
     normalizeCoinSymbol(coin.id);
   const chain =
     normalizeCoinSymbol(coin.chain) ||


### PR DESCRIPTION
Fixes #301.

CoinPay OAuth `/api/oauth/userinfo` wallet payloads can identify a wallet with `cryptocurrency` plus `chain` fields, for example `{ cryptocurrency: "USDC", chain: "POL" }`. `coinToPaymentCurrency` already understood `chain`, but did not consider `cryptocurrency` as the coin symbol source, so those wallets could fail to map to `usdc_pol`, `usdt_eth`, etc.

Changes:

- add `cryptocurrency` to the `SupportedCoin` shape
- consider `coin.cryptocurrency` when deriving the normalized symbol
- add regression coverage for `USDC/POL`, `USDT/ETH`, and `SOL/SOL`

Verification: local dependency checkout is not available here, so I did a targeted static inspection rather than running the full Vitest suite.