### PR TITLE
fix(referrals): normalize invite duplicate checks

### DIFF
--- a/src/app/api/referrals/route.test.ts
+++ b/src/app/api/referrals/route.test.ts
@@ -55,6 +55,30 @@ function makeServiceClientWithNoExistingReferrals() {
   };
 }
 
+function makeServiceClientWithExistingReferrals(existingEmails: string[]) {
+  let referralsQueryCount = 0;
+
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockImplementation(() => {
+            referralsQueryCount += 1;
+            if (referralsQueryCount <= 2) {
+              return Promise.resolve({ count: 0, error: null });
+            }
+            return Promise.resolve({ data: [], error: null });
+          }),
+          in: vi.fn().mockResolvedValue({
+            data: existingEmails.map((referred_email) => ({ referred_email })),
+            error: null,
+          }),
+        }),
+      }),
+    })),
+  };
+}
+
 function makeGetRequest() {
   return new NextRequest("http://localhost/api/referrals", { method: "GET" });
 }
@@ -240,6 +264,36 @@ describe("POST /api/referrals", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toContain("No valid email");
+  });
+
+  it("normalizes duplicate invite checks before inserting or sending", async () => {
+    mockCreateServiceClient.mockReturnValue(makeServiceClientWithExistingReferrals(["friend@test.com"]));
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user1" },
+      supabase: mockSupabase,
+    });
+
+    const mockSelectChain = {
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { referral_code: "testuser", username: "testuser", full_name: "Test User" },
+          error: null,
+        }),
+      }),
+    };
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "profiles") return { select: () => mockSelectChain };
+      if (table === "referrals") return { insert: mockInsert };
+      return {};
+    });
+
+    const res = await POST(makePostRequest({ emails: [" Friend@Test.com "] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("already been invited");
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
   });
 
   // Regression test for #143: Invalid emails should return 400 before rate-limit check

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -126,7 +126,7 @@ export async function POST(request: NextRequest) {
       .from("referrals")
       .select("referred_email")
       .eq("referrer_id", user.id)
-      .in("referred_email", normalizedEmails);
+      .in("referred_email", validEmails);
 
     const alreadyInvited = new Set((existingInvites || []).map((r: any) => r.referred_email));
 
@@ -156,7 +156,7 @@ export async function POST(request: NextRequest) {
 
     const referralRows = newValidEmails.map((email: string) => ({
       referrer_id: user.id,
-      referred_email: email.trim().toLowerCase(),
+      referred_email: email,
       referral_code: referralCode,
       status: "pending" as const,
     }));

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -79,7 +79,8 @@ export async function POST(request: NextRequest) {
     // Validate email syntax BEFORE rate-limit checks (#143)
     // Only valid emails should count toward throttle limits
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    const validEmails = emails.filter((e: string) => typeof e === "string" && emailRegex.test(e.trim().toLowerCase()));
+    const normalizedEmails = emails.map((e: string) => e.trim().toLowerCase());
+    const validEmails = normalizedEmails.filter((e: string) => emailRegex.test(e));
 
     if (validEmails.length === 0) {
       return NextResponse.json(
@@ -121,7 +122,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Prevent duplicate invites to same email
-    const normalizedEmails = emails.map((e: string) => e.trim().toLowerCase());
     const { data: existingInvites } = await (svc as AnySupabase)
       .from("referrals")
       .select("referred_email")


### PR DESCRIPTION
Fixes #279.

The Invite Friends endpoint now normalizes submitted email strings once, then uses those normalized values consistently for:

- syntax validation
- hourly/daily rate-limit counting
- duplicate lookup
- filtering out already-invited emails
- inserted referral rows and outbound invite sends

This prevents a previously invited address like `friend@test.com` from bypassing the app-level duplicate filter as ` Friend@Test.com `.

Added regression coverage that verifies the normalized duplicate path returns the intended `already been invited` response without inserting or sending email.

Verification: static inspection plus focused regression test changes. I could not run the full repo test suite in this projectless workspace because the full dependency checkout is not present here.