### PR TITLE
fix(video-calls): clamp list limit

### DIFF
--- a/src/app/api/video-calls/route.test.ts
+++ b/src/app/api/video-calls/route.test.ts
@@ -156,6 +156,38 @@ describe("GET /api/video-calls", () => {
     expect(res.status).toBe(200);
     expect(limitSpy).toHaveBeenCalledWith(20);
   });
+
+  it("uses default limit when the parameter is missing", async () => {
+    const userId = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+    const limitSpy = vi.fn(() => Promise.resolve({ data: [], error: null }));
+
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: userId, authMethod: "session" },
+      supabase: supabaseClient,
+    } as unknown as AuthContext);
+    mockVideoCallList(limitSpy);
+
+    const res = await GET(makeGetRequest());
+
+    expect(res.status).toBe(200);
+    expect(limitSpy).toHaveBeenCalledWith(20);
+  });
+
+  it("caps large limit values before querying", async () => {
+    const userId = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+    const limitSpy = vi.fn(() => Promise.resolve({ data: [], error: null }));
+
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: userId, authMethod: "session" },
+      supabase: supabaseClient,
+    } as unknown as AuthContext);
+    mockVideoCallList(limitSpy);
+
+    const res = await GET(makeGetRequest({ limit: "999" }));
+
+    expect(res.status).toBe(200);
+    expect(limitSpy).toHaveBeenCalledWith(50);
+  });
 });
 
 // ════════════════════════════════════════════════════════════════════

--- a/src/app/api/video-calls/route.test.ts
+++ b/src/app/api/video-calls/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
-import { POST } from "./route";
+import { GET, POST } from "./route";
 
 // ── Mocks ──────────────────────────────────────────────────────────
 
@@ -65,6 +65,14 @@ function makeRequest(body: Record<string, unknown>) {
   });
 }
 
+function makeGetRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/video-calls");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
 function chainResult(result: { data: unknown; error: unknown }) {
   const chain: Record<string, unknown> = {};
   for (const m of [
@@ -93,6 +101,61 @@ function chainResult(result: { data: unknown; error: unknown }) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("GET /api/video-calls", () => {
+  function mockVideoCallList(limitSpy: ReturnType<typeof vi.fn>) {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "video_calls") {
+        return {
+          select: () => ({
+            or: () => ({
+              order: () => ({
+                limit: limitSpy,
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: () => ({
+          in: () => Promise.resolve({ data: [], error: null }),
+        }),
+      };
+    });
+  }
+
+  it("clamps invalid limit values before querying", async () => {
+    const userId = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+    const limitSpy = vi.fn(() => Promise.resolve({ data: [], error: null }));
+
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: userId, authMethod: "session" },
+      supabase: supabaseClient,
+    } as unknown as AuthContext);
+    mockVideoCallList(limitSpy);
+
+    const res = await GET(makeGetRequest({ limit: "-5" }));
+
+    expect(res.status).toBe(200);
+    expect(limitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("uses default limit for non-numeric input", async () => {
+    const userId = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+    const limitSpy = vi.fn(() => Promise.resolve({ data: [], error: null }));
+
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: userId, authMethod: "session" },
+      supabase: supabaseClient,
+    } as unknown as AuthContext);
+    mockVideoCallList(limitSpy);
+
+    const res = await GET(makeGetRequest({ limit: "abc" }));
+
+    expect(res.status).toBe(200);
+    expect(limitSpy).toHaveBeenCalledWith(20);
+  });
 });
 
 // ════════════════════════════════════════════════════════════════════

--- a/src/app/api/video-calls/route.ts
+++ b/src/app/api/video-calls/route.ts
@@ -11,6 +11,12 @@ const createVideoCallSchema = z.object({
   scheduled_at: z.string().datetime().optional(),
 });
 
+function parseLimit(value: string | null) {
+  const parsed = Number(value && value.trim() !== "" ? value : 20);
+  const finiteValue = Number.isFinite(parsed) ? parsed : 20;
+  return Math.min(Math.max(Math.trunc(finiteValue), 1), 50);
+}
+
 // GET /api/video-calls - List user's video calls
 export async function GET(request: NextRequest) {
   try {
@@ -22,7 +28,7 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const upcoming = searchParams.get("upcoming") === "true";
-    const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 50);
+    const limit = parseLimit(searchParams.get("limit"));
 
     let query = supabase
       .from("video_calls")


### PR DESCRIPTION
## Summary
- normalize GET /api/video-calls limit to finite integer bounds before querying
- clamp negative values to 1 and non-numeric values to the default 20
- add regression coverage for invalid negative and non-numeric limit inputs

Fixes #326.

## Testing
- Not run locally: this workspace has Node but no npm/pnpm/npx/corepack available to install or invoke Vitest.