### PR TITLE
fix(wallet): clamp transaction limit

### DIFF
--- a/src/app/api/wallet/transactions/route.test.ts
+++ b/src/app/api/wallet/transactions/route.test.ts
@@ -28,6 +28,7 @@ function makeRequest(params: Record<string, string> = {}) {
 }
 
 async function expectLnbitsLimit(input: Record<string, string>, expected: number) {
+  const expectedBase = process.env.LNBITS_URL || "https://ln.coinpayportal.com";
   const fetchMock = vi.fn().mockResolvedValue({
     ok: true,
     json: () => Promise.resolve([]),
@@ -46,7 +47,7 @@ async function expectLnbitsLimit(input: Record<string, string>, expected: number
 
   expect(res.status).toBe(200);
   expect(fetchMock).toHaveBeenCalledWith(
-    `https://ln.coinpayportal.com/api/v1/payments?limit=${expected}`,
+    `${expectedBase}/api/v1/payments?limit=${expected}`,
     { headers: { "X-Api-Key": "invoice-key" } }
   );
 }
@@ -75,6 +76,10 @@ describe("GET /api/wallet/transactions", () => {
 
   it("uses the default limit when the parameter is missing", async () => {
     await expectLnbitsLimit({}, 50);
+  });
+
+  it("passes through valid in-range limit values", async () => {
+    await expectLnbitsLimit({ limit: "25" }, 25);
   });
 
   it("caps large limit values before calling LNbits", async () => {

--- a/src/app/api/wallet/transactions/route.test.ts
+++ b/src/app/api/wallet/transactions/route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { getUserLnWallet } from "@/lib/lightning/wallet-utils";
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(() => ({ from: vi.fn() })),
+}));
+
+vi.mock("@/lib/lightning/wallet-utils", () => ({
+  getUserLnWallet: vi.fn(),
+}));
+
+const mockGetAuthContext = vi.mocked(getAuthContext);
+const mockGetUserLnWallet = vi.mocked(getUserLnWallet);
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/wallet/transactions");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+async function expectLnbitsLimit(input: Record<string, string>, expected: number) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve([]),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  mockGetAuthContext.mockResolvedValue({
+    user: { id: "user-1", authMethod: "session" },
+    supabase: {} as any,
+  } as any);
+  mockGetUserLnWallet.mockResolvedValue({
+    invoice_key: "invoice-key",
+  } as any);
+
+  const res = await GET(makeRequest(input));
+
+  expect(res.status).toBe(200);
+  expect(fetchMock).toHaveBeenCalledWith(
+    `https://ln.coinpayportal.com/api/v1/payments?limit=${expected}`,
+    { headers: { "X-Api-Key": "invoice-key" } }
+  );
+}
+
+describe("GET /api/wallet/transactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetAuthContext.mockResolvedValue(null);
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(401);
+  });
+
+  it("clamps negative limit values before calling LNbits", async () => {
+    await expectLnbitsLimit({ limit: "-5" }, 1);
+  });
+
+  it("uses the default limit for non-numeric input", async () => {
+    await expectLnbitsLimit({ limit: "abc" }, 50);
+  });
+
+  it("uses the default limit when the parameter is missing", async () => {
+    await expectLnbitsLimit({}, 50);
+  });
+
+  it("caps large limit values before calling LNbits", async () => {
+    await expectLnbitsLimit({ limit: "999" }, 100);
+  });
+});

--- a/src/app/api/wallet/transactions/route.ts
+++ b/src/app/api/wallet/transactions/route.ts
@@ -5,13 +5,19 @@ import { getUserLnWallet } from "@/lib/lightning/wallet-utils";
 
 const LNBITS_URL = process.env.LNBITS_URL || "https://ln.coinpayportal.com";
 
+function parseLimit(value: string | null) {
+  const parsed = Number(value && value.trim() !== "" ? value : 50);
+  const finiteValue = Number.isFinite(parsed) ? parsed : 50;
+  return Math.min(Math.max(Math.trunc(finiteValue), 1), 100);
+}
+
 export async function GET(request: NextRequest) {
   try {
     const auth = await getAuthContext(request);
     if (!auth) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const url = new URL(request.url);
-    const limit = Math.min(parseInt(url.searchParams.get("limit") || "50"), 100);
+    const limit = parseLimit(url.searchParams.get("limit"));
 
     const admin = createServiceClient();
     const lnWallet = await getUserLnWallet(admin, auth.user.id);


### PR DESCRIPTION
## Summary
- normalize wallet transaction limit before building the LNbits payments request URL
- clamp negative values to 1, non-numeric/missing values to 50, and large values to 100
- add route tests covering auth and all limit boundaries

Fixes #328.

## Testing
- Not run locally: this workspace has Node but no npm/pnpm/npx/corepack available to install or invoke Vitest.