### PR TITLE
fix(leaderboard): clamp zap limit values

### DIFF
--- a/src/app/api/leaderboard/zaps/route.test.ts
+++ b/src/app/api/leaderboard/zaps/route.test.ts
@@ -25,10 +25,15 @@ function mockLeaderboardQuery() {
 
   mockFrom.mockImplementation((table: string) => {
     if (table === "zaps") {
+      const query = {
+        gte: vi.fn(() => query),
+        then: (
+          resolve: (value: { data: typeof zaps; error: null }) => void
+        ) => resolve({ data: zaps, error: null }),
+      };
+
       return {
-        select: vi.fn(() =>
-          Promise.resolve({ data: zaps, error: null })
-        ),
+        select: vi.fn(() => query),
       };
     }
 

--- a/src/app/api/leaderboard/zaps/route.test.ts
+++ b/src/app/api/leaderboard/zaps/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET } from "./route";
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/leaderboard/zaps");
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+  return new NextRequest(url, { method: "GET" });
+}
+
+function mockLeaderboardQuery() {
+  const zaps = [
+    { recipient_id: "user-1", sender_id: "sender-1", amount_sats: 100 },
+    { recipient_id: "user-2", sender_id: "sender-2", amount_sats: 50 },
+  ];
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "zaps") {
+      return {
+        select: vi.fn(() =>
+          Promise.resolve({ data: zaps, error: null })
+        ),
+      };
+    }
+
+    return {
+      select: vi.fn(() => ({
+        in: vi.fn(() =>
+          Promise.resolve({
+            data: [
+              { id: "user-1", username: "one", full_name: "User One", avatar_url: null },
+              { id: "user-2", username: "two", full_name: "User Two", avatar_url: null },
+            ],
+          })
+        ),
+      })),
+    };
+  });
+}
+
+describe("GET /api/leaderboard/zaps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clamps negative limits to one row", async () => {
+    mockLeaderboardQuery();
+
+    const response = await GET(makeRequest({ limit: "-5" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.leaderboard).toHaveLength(1);
+    expect(json.leaderboard[0].user.id).toBe("user-1");
+  });
+
+  it("falls back to the default limit for non-numeric values", async () => {
+    mockLeaderboardQuery();
+
+    const response = await GET(makeRequest({ limit: "abc" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.leaderboard).toHaveLength(2);
+  });
+});

--- a/src/app/api/leaderboard/zaps/route.ts
+++ b/src/app/api/leaderboard/zaps/route.ts
@@ -3,14 +3,17 @@ import { createServiceClient } from "@/lib/supabase/service";
 
 /**
  * GET /api/leaderboard/zaps?period=week|month|all&sort=received|sent&limit=25
- * Public endpoint — no auth required.
+ * Public endpoint â€” no auth required.
  */
 export async function GET(request: NextRequest) {
   try {
     const url = new URL(request.url);
     const period = url.searchParams.get("period") || "all";
     const sort = url.searchParams.get("sort") || "received";
-    const limit = Math.min(parseInt(url.searchParams.get("limit") || "25"), 50);
+    const parsedLimit = parseInt(url.searchParams.get("limit") || "25", 10);
+    const limit = Number.isFinite(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), 50)
+      : 25;
 
     const admin = createServiceClient();
 

--- a/src/app/api/leaderboard/zaps/route.ts
+++ b/src/app/api/leaderboard/zaps/route.ts
@@ -3,7 +3,7 @@ import { createServiceClient } from "@/lib/supabase/service";
 
 /**
  * GET /api/leaderboard/zaps?period=week|month|all&sort=received|sent&limit=25
- * Public endpoint â€” no auth required.
+ * Public endpoint - no auth required.
  */
 export async function GET(request: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- clamp `/api/leaderboard/zaps` limit query values to the supported 1..50 range
- fall back to the default 25 when limit is non-numeric
- add route coverage for negative and non-numeric limits

Fixes #332.

## Verification
- Added focused Vitest coverage for `limit=-5` and `limit=abc`.
- Not run locally: this Codex workspace has Node but no `npm`/package runner available, so I could not execute the Vitest file here.