### PR TITLE
fix(queries): clamp agent and candidate page values

### DIFF
--- a/src/lib/queries/agents.test.ts
+++ b/src/lib/queries/agents.test.ts
@@ -101,4 +101,22 @@ describe("buildAgentsQuery", () => {
 
     expect(mock.chain.range).toHaveBeenCalledWith(40, 59);
   });
+
+  it("clamps negative page values to page 1", () => {
+    buildAgentsQuery(mock.client, { page: "-1" });
+
+    expect(mock.chain.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("falls back to page 1 for non-numeric values", () => {
+    buildAgentsQuery(mock.client, { page: "abc" });
+
+    expect(mock.chain.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("caps very large page values before calculating the range", () => {
+    buildAgentsQuery(mock.client, { page: "999999999" });
+
+    expect(mock.chain.range).toHaveBeenCalledWith(1999980, 1999999);
+  });
 });

--- a/src/lib/queries/agents.ts
+++ b/src/lib/queries/agents.ts
@@ -1,11 +1,20 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 
+const MAX_PAGE = 100_000;
+
 export interface AgentsQueryParams {
   q?: string;
   sort?: string;
   page?: string;
   available?: string;
   tags?: string[];
+}
+
+function parsePage(value?: string) {
+  const parsed = parseInt(value || "1", 10);
+  return Number.isFinite(parsed)
+    ? Math.min(Math.max(parsed, 1), MAX_PAGE)
+    : 1;
 }
 
 export function buildAgentsQuery(
@@ -49,7 +58,7 @@ export function buildAgentsQuery(
       query = query.order("created_at", { ascending: false });
   }
 
-  const pageNum = parseInt(page || "1");
+  const pageNum = parsePage(page);
   const limit = 20;
   const offset = (pageNum - 1) * limit;
   query = query.range(offset, offset + limit - 1);

--- a/src/lib/queries/candidates.test.ts
+++ b/src/lib/queries/candidates.test.ts
@@ -73,4 +73,22 @@ describe("buildCandidatesQuery", () => {
 
     expect(mock.chain.range).toHaveBeenCalledWith(20, 39);
   });
+
+  it("clamps negative page values to page 1", () => {
+    buildCandidatesQuery(mock.client, { page: "-1" });
+
+    expect(mock.chain.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("falls back to page 1 for non-numeric values", () => {
+    buildCandidatesQuery(mock.client, { page: "abc" });
+
+    expect(mock.chain.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("caps very large page values before calculating the range", () => {
+    buildCandidatesQuery(mock.client, { page: "999999999" });
+
+    expect(mock.chain.range).toHaveBeenCalledWith(1999980, 1999999);
+  });
 });

--- a/src/lib/queries/candidates.ts
+++ b/src/lib/queries/candidates.ts
@@ -1,11 +1,20 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 
+const MAX_PAGE = 100_000;
+
 export interface CandidatesQueryParams {
   q?: string;
   sort?: string;
   page?: string;
   available?: string;
   tags?: string[];
+}
+
+function parsePage(value?: string) {
+  const parsed = parseInt(value || "1", 10);
+  return Number.isFinite(parsed)
+    ? Math.min(Math.max(parsed, 1), MAX_PAGE)
+    : 1;
 }
 
 export function buildCandidatesQuery(
@@ -49,7 +58,7 @@ export function buildCandidatesQuery(
       query = query.order("created_at", { ascending: false });
   }
 
-  const pageNum = parseInt(page || "1");
+  const pageNum = parsePage(page);
   const limit = 20;
   const offset = (pageNum - 1) * limit;
   query = query.range(offset, offset + limit - 1);


### PR DESCRIPTION
## Summary
- clamp agent and candidate query helper pages before deriving Supabase ranges
- fall back to page 1 for non-numeric page values
- add regression coverage for negative, non-numeric, and huge page values in both helper tests

Fixes #334.

## Verification
- Added focused Vitest coverage in `agents.test.ts` and `candidates.test.ts`.
- Not run locally: this Codex workspace has Node but no `npm`/package runner available, so I could not execute the Vitest files here.