### PR TITLE
fix(pages): clamp public listing page values

### DIFF
--- a/src/app/affiliates/page.tsx
+++ b/src/app/affiliates/page.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Megaphone, Users, TrendingUp, Zap } from "lucide-react";
 import { SKILL_CATEGORIES } from "@/lib/constants";
+import { parsePageParam } from "@/lib/pagination";
 
 export const metadata: Metadata = {
   title: "Affiliate Marketplace | ugig.net",
@@ -60,10 +61,10 @@ function commissionUsdHint(offer: {
   price_sats: number;
 }, btcUsd: number | null): string | null {
   if (offer.commission_type === "percentage" && offer.price_sats > 0) {
-    return `≈ $${(offer.price_sats * offer.commission_rate).toFixed(2)} USD`;
+    return `â‰ˆ $${(offer.price_sats * offer.commission_rate).toFixed(2)} USD`;
   }
   if (offer.commission_type === "flat" && offer.commission_flat_sats > 0 && btcUsd) {
-    return `≈ $${((offer.commission_flat_sats / 1e8) * btcUsd).toFixed(2)} USD`;
+    return `â‰ˆ $${((offer.commission_flat_sats / 1e8) * btcUsd).toFixed(2)} USD`;
   }
   return null;
 }
@@ -141,7 +142,7 @@ async function AffiliatesList({ searchParams }: { searchParams: AffiliatesPagePr
       query = query.order("created_at", { ascending: false });
   }
 
-  const page = parseInt(queryParams.page || "1");
+  const page = parsePageParam(queryParams.page);
   const limit = 20;
   const offset = (page - 1) * limit;
   query = query.range(offset, offset + limit - 1);
@@ -240,7 +241,7 @@ async function AffiliatesList({ searchParams }: { searchParams: AffiliatesPagePr
                 </div>
               )}
 
-              {/* product_url domain hint removed — URL is hidden from public listing (#20) */}
+              {/* product_url domain hint removed â€” URL is hidden from public listing (#20) */}
 
               <div className="flex flex-wrap items-center justify-between gap-y-1 text-xs text-muted-foreground mt-auto pt-2 border-t border-border/50">
                 <div className="flex items-center gap-1.5 min-w-0 truncate">

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { FolderOpen, ExternalLink, Zap, ThumbsUp, MessageSquare } from "lucide-react";
+import { parsePageParam } from "@/lib/pagination";
 
 export const metadata: Metadata = {
   title: "Project Directory | ugig.net",
@@ -39,7 +40,7 @@ async function DirectoryList({
   const queryParams = await searchParams;
   const supabase = await createClient();
 
-  const page = parseInt(queryParams.page || "1");
+  const page = parsePageParam(queryParams.page);
   const limit = 21;
   const offset = (page - 1) * limit;
 
@@ -84,7 +85,7 @@ async function DirectoryList({
           <Link href="/directory/new">
             <Button size="sm">
               <Zap className="h-4 w-4 mr-1" />
-              List Your Project — 50 ⚡
+              List Your Project â€” 50 âš¡
             </Button>
           </Link>
         </div>
@@ -293,12 +294,12 @@ export default async function DirectoryPage({
             <Link href="/directory/new">
               <Button size="sm">
                 <Zap className="h-4 w-4 mr-1" />
-                List Your Project — 50 ⚡
+                List Your Project â€” 50 âš¡
               </Button>
             </Link>
           </div>
           <p className="text-muted-foreground mb-8">
-            Discover projects built by the community. List yours for 50 ⚡
+            Discover projects built by the community. List yours for 50 âš¡
             sats.
           </p>
 
@@ -337,7 +338,7 @@ export default async function DirectoryPage({
                   })}`}
                   className="ml-1 hover:text-destructive"
                 >
-                  ✕
+                  âœ•
                 </Link>
               </Badge>
             </div>

--- a/src/app/for-hire/[[...tags]]/page.tsx
+++ b/src/app/for-hire/[[...tags]]/page.tsx
@@ -7,6 +7,7 @@ import { GigFiltersWithTags } from "@/components/gigs/GigFiltersWithTags";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import { parsePageParam } from "@/lib/pagination";
 import { Briefcase } from "lucide-react";
 
 interface GigsPageProps {
@@ -38,7 +39,7 @@ export async function generateMetadata({ params }: GigsPageProps): Promise<Metad
     };
   }
 
-  const title = "I will... — Find People Ready to Work | ugig.net";
+  const title = "I will... â€” Find People Ready to Work | ugig.net";
   const description = "Browse professionals and AI agents offering their services. Find someone who will do exactly what you need.";
   return {
     title,
@@ -113,7 +114,7 @@ async function GigsList({
       expandedTags.add(tag.toLowerCase());
       expandedTags.add(tag.charAt(0).toUpperCase() + tag.slice(1)); // Title case
       expandedTags.add(tag.toUpperCase());
-      // Handle multi-word: "node.js" → "Node.js", "next.js" → "Next.js"
+      // Handle multi-word: "node.js" â†’ "Node.js", "next.js" â†’ "Next.js"
       expandedTags.add(tag.replace(/\b\w/g, c => c.toUpperCase()));
     }
     query = query.overlaps("skills_required", [...expandedTags]);
@@ -135,7 +136,7 @@ async function GigsList({
   }
 
   // Pagination
-  const page = parseInt(queryParams.page || "1");
+  const page = parsePageParam(queryParams.page);
   const limit = 20;
   const offset = (page - 1) * limit;
   query = query.range(offset, offset + limit - 1);
@@ -250,7 +251,7 @@ export default async function ForHirePage({ params, searchParams }: GigsPageProp
           <h1 className="text-3xl font-bold mb-2">I will...</h1>
           <p className="text-muted-foreground mb-8">
             People and agents offering their services. Want to hire instead?{" "}
-            <a href="/gigs" className="text-primary hover:underline">Post a gig →</a>
+            <a href="/gigs" className="text-primary hover:underline">Post a gig â†’</a>
           </p>
 
           <Suspense fallback={<div className="h-48" />}>

--- a/src/app/gigs/[[...tags]]/page.tsx
+++ b/src/app/gigs/[[...tags]]/page.tsx
@@ -7,6 +7,7 @@ import { GigFiltersWithTags } from "@/components/gigs/GigFiltersWithTags";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import { parsePageParam } from "@/lib/pagination";
 import { Briefcase } from "lucide-react";
 
 interface GigsPageProps {
@@ -119,7 +120,7 @@ async function GigsList({
       expandedTags.add(tag.toLowerCase());
       expandedTags.add(tag.charAt(0).toUpperCase() + tag.slice(1)); // Title case
       expandedTags.add(tag.toUpperCase());
-      // Handle multi-word: "node.js" → "Node.js", "next.js" → "Next.js"
+      // Handle multi-word: "node.js" â†’ "Node.js", "next.js" â†’ "Next.js"
       expandedTags.add(tag.replace(/\b\w/g, c => c.toUpperCase()));
     }
     query = query.overlaps("skills_required", [...expandedTags]);
@@ -141,7 +142,7 @@ async function GigsList({
   }
 
   // Pagination
-  const page = parseInt(queryParams.page || "1");
+  const page = parsePageParam(queryParams.page);
   const limit = 20;
   const offset = (page - 1) * limit;
   query = query.range(offset, offset + limit - 1);
@@ -257,7 +258,7 @@ export default async function GigsPage({ params, searchParams }: GigsPageProps) 
           <h1 className="text-3xl font-bold mb-2">Gigs (Hiring)</h1>
           <p className="text-muted-foreground mb-8">
             Clients posting work they need done. Looking for work instead?{" "}
-            <a href="/for-hire" className="text-primary hover:underline">Browse &quot;I will...&quot; listings →</a>
+            <a href="/for-hire" className="text-primary hover:underline">Browse &quot;I will...&quot; listings â†’</a>
           </p>
 
           <Suspense fallback={<div className="h-48" />}>

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -10,18 +10,19 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Server, Star, Download, Zap } from "lucide-react";
 import { MCP_CATEGORIES } from "@/lib/constants";
 import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
+import { parsePageParam } from "@/lib/pagination";
 
 export const metadata: Metadata = {
   title: "MCP Server Marketplace | ugig.net",
   description:
-    "Browse MCP servers — tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
+    "Browse MCP servers â€” tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
   alternates: {
     canonical: "/mcp",
   },
   openGraph: {
     title: "MCP Server Marketplace | ugig.net",
     description:
-      "Browse MCP servers — tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
+      "Browse MCP servers â€” tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
     url: "/mcp",
     type: "website",
   },
@@ -29,7 +30,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "MCP Server Marketplace | ugig.net",
     description:
-      "Browse MCP servers — tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
+      "Browse MCP servers â€” tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
   },
 };
 
@@ -55,7 +56,7 @@ async function McpList({ searchParams }: { searchParams: McpPageProps["searchPar
   const queryParams = await searchParams;
   const [supabase, btcUsd] = await Promise.all([createClient(), fetchBtcRate()]);
 
-  const page = parseInt(queryParams.page || "1");
+  const page = parsePageParam(queryParams.page);
   const limit = 21;
   const offset = (page - 1) * limit;
 
@@ -155,7 +156,7 @@ async function McpList({ searchParams }: { searchParams: McpPageProps["searchPar
                   </Badge>
                   {btcUsd && (
                     <p className="text-[10px] text-muted-foreground mt-0.5">
-                      ≈ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
+                      â‰ˆ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
                     </p>
                   )}
                 </div>
@@ -314,7 +315,7 @@ export default async function McpPage({ searchParams }: McpPageProps) {
             </Link>
           </div>
           <p className="text-muted-foreground mb-8">
-            Browse MCP servers — tools, integrations, and APIs for AI agents.
+            Browse MCP servers â€” tools, integrations, and APIs for AI agents.
           </p>
 
           {/* Filters */}
@@ -401,7 +402,7 @@ export default async function McpPage({ searchParams }: McpPageProps) {
                   ...(queryParams.category ? { category: queryParams.category } : {}),
                   ...(queryParams.sort ? { sort: queryParams.sort } : {}),
                 })}`} className="ml-1 hover:text-destructive">
-                  ✕
+                  âœ•
                 </Link>
               </Badge>
             </div>

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -10,18 +10,19 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { FileText, Star, Download, Zap } from "lucide-react";
 import { PROMPT_CATEGORIES } from "@/lib/constants";
 import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
+import { parsePageParam } from "@/lib/pagination";
 
 export const metadata: Metadata = {
   title: "Prompt Marketplace | ugig.net",
   description:
-    "Browse AI prompts — expertly crafted prompts for coding, writing, analysis, creative work, and more.",
+    "Browse AI prompts â€” expertly crafted prompts for coding, writing, analysis, creative work, and more.",
   alternates: {
     canonical: "/prompts",
   },
   openGraph: {
     title: "Prompt Marketplace | ugig.net",
     description:
-      "Browse AI prompts — expertly crafted prompts for coding, writing, analysis, creative work, and more.",
+      "Browse AI prompts â€” expertly crafted prompts for coding, writing, analysis, creative work, and more.",
     url: "/prompts",
     type: "website",
   },
@@ -29,7 +30,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Prompt Marketplace | ugig.net",
     description:
-      "Browse AI prompts — expertly crafted prompts for coding, writing, analysis, creative work, and more.",
+      "Browse AI prompts â€” expertly crafted prompts for coding, writing, analysis, creative work, and more.",
   },
 };
 
@@ -55,7 +56,7 @@ async function PromptList({ searchParams }: { searchParams: PromptsPageProps["se
   const queryParams = await searchParams;
   const [supabase, btcUsd] = await Promise.all([createClient(), fetchBtcRate()]);
 
-  const page = parseInt(queryParams.page || "1");
+  const page = parsePageParam(queryParams.page);
   const limit = 21;
   const offset = (page - 1) * limit;
 
@@ -155,7 +156,7 @@ async function PromptList({ searchParams }: { searchParams: PromptsPageProps["se
                   </Badge>
                   {btcUsd && (
                     <p className="text-[10px] text-muted-foreground mt-0.5">
-                      ≈ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
+                      â‰ˆ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
                     </p>
                   )}
                 </div>
@@ -324,7 +325,7 @@ export default async function PromptsPage({ searchParams }: PromptsPageProps) {
             </Link>
           </div>
           <p className="text-muted-foreground mb-8">
-            Browse AI prompts — expertly crafted for coding, writing, analysis, and more.
+            Browse AI prompts â€” expertly crafted for coding, writing, analysis, and more.
           </p>
 
           {/* Filters */}
@@ -411,7 +412,7 @@ export default async function PromptsPage({ searchParams }: PromptsPageProps) {
                   ...(queryParams.category ? { category: queryParams.category } : {}),
                   ...(queryParams.sort ? { sort: queryParams.sort } : {}),
                 })}`} className="ml-1 hover:text-destructive">
-                  ✕
+                  âœ•
                 </Link>
               </Badge>
             </div>

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Package, Star, Download, Zap, ShieldCheck, ShieldAlert, ShieldX, Shield } from "lucide-react";
 import { SKILL_CATEGORIES, SUPPORTED_AGENT_OPTIONS } from "@/lib/constants";
+import { parsePageParam } from "@/lib/pagination";
 
 export const metadata: Metadata = {
   title: "AI Agent Skills Marketplace | ugig.net",
@@ -54,7 +55,7 @@ async function SkillsList({ searchParams }: { searchParams: SkillsPageProps["sea
   const queryParams = await searchParams;
   const [supabase, btcUsd] = await Promise.all([createClient(), fetchBtcRate()]);
 
-  const page = parseInt(queryParams.page || "1");
+  const page = parsePageParam(queryParams.page);
   const limit = 21;
   const offset = (page - 1) * limit;
 
@@ -154,7 +155,7 @@ async function SkillsList({ searchParams }: { searchParams: SkillsPageProps["sea
                   </Badge>
                   {btcUsd && (
                     <p className="text-[10px] text-muted-foreground mt-0.5">
-                      ≈ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
+                      â‰ˆ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
                     </p>
                   )}
                 </div>
@@ -312,7 +313,7 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
             </Link>
           </div>
           <p className="text-muted-foreground mb-8">
-            Browse agent skills — install tools, automations, and workflows.
+            Browse agent skills â€” install tools, automations, and workflows.
           </p>
 
           {/* Filters */}
@@ -390,7 +391,7 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
                   })}`}
                   className="text-xs text-muted-foreground hover:text-destructive flex items-center ml-1"
                 >
-                  ✕ clear
+                  âœ• clear
                 </Link>
               )}
             </div>
@@ -429,7 +430,7 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
                   ...(queryParams.category ? { category: queryParams.category } : {}),
                   ...(queryParams.sort ? { sort: queryParams.sort } : {}),
                 })}`} className="ml-1 hover:text-destructive">
-                  ✕
+                  âœ•
                 </Link>
               </Badge>
             </div>

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { parsePageParam } from "./pagination";
+
+describe("parsePageParam", () => {
+  it("defaults missing values to page 1", () => {
+    expect(parsePageParam(undefined)).toBe(1);
+    expect(parsePageParam(null)).toBe(1);
+    expect(parsePageParam("")).toBe(1);
+  });
+
+  it("clamps invalid low values to page 1", () => {
+    expect(parsePageParam("-1")).toBe(1);
+    expect(parsePageParam("0")).toBe(1);
+    expect(parsePageParam("abc")).toBe(1);
+  });
+
+  it("truncates fractional page values", () => {
+    expect(parsePageParam("2.9")).toBe(2);
+  });
+
+  it("caps very large page values", () => {
+    expect(parsePageParam("999999999")).toBe(100_000);
+  });
+});

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,11 @@
+const DEFAULT_MAX_PAGE = 100_000;
+
+export function parsePageParam(
+  value: string | null | undefined,
+  maxPage = DEFAULT_MAX_PAGE
+) {
+  const parsed = parseInt(value || "1", 10);
+  return Number.isFinite(parsed)
+    ? Math.min(Math.max(parsed, 1), maxPage)
+    : 1;
+}


### PR DESCRIPTION
## Summary
- add a shared `parsePageParam` helper for public listing pages
- clamp invalid, negative, and extremely large `page` query values before computing pagination offsets
- cover the helper with regression tests for malformed, negative, and oversized page values

Fixes #336.

## Verification
- Not run locally: this Codex workspace has Node available but no npm/package runner installed, so I could not execute the repo test suite here.