### PR TITLE
fix(pages): repair pagination follow-ups

### DIFF
--- a/src/app/affiliates/page.tsx
+++ b/src/app/affiliates/page.tsx
@@ -61,10 +61,10 @@ function commissionUsdHint(offer: {
   price_sats: number;
 }, btcUsd: number | null): string | null {
   if (offer.commission_type === "percentage" && offer.price_sats > 0) {
-    return `â‰ˆ $${(offer.price_sats * offer.commission_rate).toFixed(2)} USD`;
+    return `≈ $${(offer.price_sats * offer.commission_rate).toFixed(2)} USD`;
   }
   if (offer.commission_type === "flat" && offer.commission_flat_sats > 0 && btcUsd) {
-    return `â‰ˆ $${((offer.commission_flat_sats / 1e8) * btcUsd).toFixed(2)} USD`;
+    return `≈ $${((offer.commission_flat_sats / 1e8) * btcUsd).toFixed(2)} USD`;
   }
   return null;
 }
@@ -241,7 +241,7 @@ async function AffiliatesList({ searchParams }: { searchParams: AffiliatesPagePr
                 </div>
               )}
 
-              {/* product_url domain hint removed â€” URL is hidden from public listing (#20) */}
+              {/* product_url domain hint removed — URL is hidden from public listing (#20) */}
 
               <div className="flex flex-wrap items-center justify-between gap-y-1 text-xs text-muted-foreground mt-auto pt-2 border-t border-border/50">
                 <div className="flex items-center gap-1.5 min-w-0 truncate">

--- a/src/app/api/users/[username]/reviews/route.ts
+++ b/src/app/api/users/[username]/reviews/route.ts
@@ -52,12 +52,21 @@ export async function GET(
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
+    const { data: allRatings, error: ratingsError } = await supabase
+      .from("reviews")
+      .select("rating")
+      .eq("reviewee_id", profile.id);
+
+    if (ratingsError) {
+      return NextResponse.json({ error: ratingsError.message }, { status: 400 });
+    }
+
     // Calculate average rating from all reviews
     const totalReviews = count || 0;
     let averageRating = 0;
-    if (reviews && reviews.length > 0) {
-      const sumRatings = reviews.reduce((sum, r) => sum + r.rating, 0);
-      averageRating = totalReviews > 0 ? sumRatings / reviews.length : 0;
+    if (allRatings && allRatings.length > 0) {
+      const sumRatings = allRatings.reduce((sum, review) => sum + review.rating, 0);
+      averageRating = sumRatings / allRatings.length;
     }
 
     return NextResponse.json({

--- a/src/app/api/users/[username]/reviews/route.ts
+++ b/src/app/api/users/[username]/reviews/route.ts
@@ -52,19 +52,27 @@ export async function GET(
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
-    const { data: allRatings, error: ratingsError } = await supabase
-      .from("reviews")
-      .select("rating")
-      .eq("reviewee_id", profile.id);
-
-    if (ratingsError) {
-      return NextResponse.json({ error: ratingsError.message }, { status: 400 });
-    }
-
     // Calculate average rating from all reviews
     const totalReviews = count || 0;
     let averageRating = 0;
-    if (allRatings && allRatings.length > 0) {
+    if (totalReviews > 0) {
+      const { data: allRatings, error: ratingsError } = await supabase
+        .from("reviews")
+        .select("rating")
+        .eq("reviewee_id", profile.id)
+        .range(0, totalReviews - 1);
+
+      if (ratingsError) {
+        return NextResponse.json({ error: ratingsError.message }, { status: 400 });
+      }
+
+      if (!allRatings || allRatings.length !== totalReviews) {
+        return NextResponse.json(
+          { error: "Unable to calculate average rating" },
+          { status: 500 }
+        );
+      }
+
       const sumRatings = allRatings.reduce((sum, review) => sum + review.rating, 0);
       averageRating = sumRatings / allRatings.length;
     }

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -85,7 +85,7 @@ async function DirectoryList({
           <Link href="/directory/new">
             <Button size="sm">
               <Zap className="h-4 w-4 mr-1" />
-              List Your Project â€” 50 âš¡
+              List Your Project — 50 ⚡
             </Button>
           </Link>
         </div>
@@ -294,12 +294,12 @@ export default async function DirectoryPage({
             <Link href="/directory/new">
               <Button size="sm">
                 <Zap className="h-4 w-4 mr-1" />
-                List Your Project â€” 50 âš¡
+                List Your Project — 50 ⚡
               </Button>
             </Link>
           </div>
           <p className="text-muted-foreground mb-8">
-            Discover projects built by the community. List yours for 50 âš¡
+            Discover projects built by the community. List yours for 50 ⚡
             sats.
           </p>
 
@@ -338,7 +338,7 @@ export default async function DirectoryPage({
                   })}`}
                   className="ml-1 hover:text-destructive"
                 >
-                  âœ•
+                  ✕
                 </Link>
               </Badge>
             </div>

--- a/src/app/for-hire/[[...tags]]/page.tsx
+++ b/src/app/for-hire/[[...tags]]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({ params }: GigsPageProps): Promise<Metad
     };
   }
 
-  const title = "I will... â€” Find People Ready to Work | ugig.net";
+  const title = "I will... — Find People Ready to Work | ugig.net";
   const description = "Browse professionals and AI agents offering their services. Find someone who will do exactly what you need.";
   return {
     title,
@@ -114,7 +114,7 @@ async function GigsList({
       expandedTags.add(tag.toLowerCase());
       expandedTags.add(tag.charAt(0).toUpperCase() + tag.slice(1)); // Title case
       expandedTags.add(tag.toUpperCase());
-      // Handle multi-word: "node.js" â†’ "Node.js", "next.js" â†’ "Next.js"
+      // Handle multi-word: "node.js" → "Node.js", "next.js" → "Next.js"
       expandedTags.add(tag.replace(/\b\w/g, c => c.toUpperCase()));
     }
     query = query.overlaps("skills_required", [...expandedTags]);
@@ -251,7 +251,7 @@ export default async function ForHirePage({ params, searchParams }: GigsPageProp
           <h1 className="text-3xl font-bold mb-2">I will...</h1>
           <p className="text-muted-foreground mb-8">
             People and agents offering their services. Want to hire instead?{" "}
-            <a href="/gigs" className="text-primary hover:underline">Post a gig â†’</a>
+            <a href="/gigs" className="text-primary hover:underline">Post a gig →</a>
           </p>
 
           <Suspense fallback={<div className="h-48" />}>

--- a/src/app/gigs/[[...tags]]/page.tsx
+++ b/src/app/gigs/[[...tags]]/page.tsx
@@ -120,7 +120,7 @@ async function GigsList({
       expandedTags.add(tag.toLowerCase());
       expandedTags.add(tag.charAt(0).toUpperCase() + tag.slice(1)); // Title case
       expandedTags.add(tag.toUpperCase());
-      // Handle multi-word: "node.js" â†’ "Node.js", "next.js" â†’ "Next.js"
+      // Handle multi-word: "node.js" → "Node.js", "next.js" → "Next.js"
       expandedTags.add(tag.replace(/\b\w/g, c => c.toUpperCase()));
     }
     query = query.overlaps("skills_required", [...expandedTags]);
@@ -258,7 +258,7 @@ export default async function GigsPage({ params, searchParams }: GigsPageProps) 
           <h1 className="text-3xl font-bold mb-2">Gigs (Hiring)</h1>
           <p className="text-muted-foreground mb-8">
             Clients posting work they need done. Looking for work instead?{" "}
-            <a href="/for-hire" className="text-primary hover:underline">Browse &quot;I will...&quot; listings â†’</a>
+            <a href="/for-hire" className="text-primary hover:underline">Browse &quot;I will...&quot; listings →</a>
           </p>
 
           <Suspense fallback={<div className="h-48" />}>

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -15,14 +15,14 @@ import { parsePageParam } from "@/lib/pagination";
 export const metadata: Metadata = {
   title: "MCP Server Marketplace | ugig.net",
   description:
-    "Browse MCP servers â€” tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
+    "Browse MCP servers — tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
   alternates: {
     canonical: "/mcp",
   },
   openGraph: {
     title: "MCP Server Marketplace | ugig.net",
     description:
-      "Browse MCP servers â€” tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
+      "Browse MCP servers — tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
     url: "/mcp",
     type: "website",
   },
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "MCP Server Marketplace | ugig.net",
     description:
-      "Browse MCP servers â€” tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
+      "Browse MCP servers — tools, integrations, and APIs that AI agents can connect to via the Model Context Protocol.",
   },
 };
 
@@ -156,7 +156,7 @@ async function McpList({ searchParams }: { searchParams: McpPageProps["searchPar
                   </Badge>
                   {btcUsd && (
                     <p className="text-[10px] text-muted-foreground mt-0.5">
-                      â‰ˆ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
+                      ≈ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
                     </p>
                   )}
                 </div>
@@ -315,7 +315,7 @@ export default async function McpPage({ searchParams }: McpPageProps) {
             </Link>
           </div>
           <p className="text-muted-foreground mb-8">
-            Browse MCP servers â€” tools, integrations, and APIs for AI agents.
+            Browse MCP servers — tools, integrations, and APIs for AI agents.
           </p>
 
           {/* Filters */}
@@ -402,7 +402,7 @@ export default async function McpPage({ searchParams }: McpPageProps) {
                   ...(queryParams.category ? { category: queryParams.category } : {}),
                   ...(queryParams.sort ? { sort: queryParams.sort } : {}),
                 })}`} className="ml-1 hover:text-destructive">
-                  âœ•
+                  ✕
                 </Link>
               </Badge>
             </div>

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -15,14 +15,14 @@ import { parsePageParam } from "@/lib/pagination";
 export const metadata: Metadata = {
   title: "Prompt Marketplace | ugig.net",
   description:
-    "Browse AI prompts â€” expertly crafted prompts for coding, writing, analysis, creative work, and more.",
+    "Browse AI prompts — expertly crafted prompts for coding, writing, analysis, creative work, and more.",
   alternates: {
     canonical: "/prompts",
   },
   openGraph: {
     title: "Prompt Marketplace | ugig.net",
     description:
-      "Browse AI prompts â€” expertly crafted prompts for coding, writing, analysis, creative work, and more.",
+      "Browse AI prompts — expertly crafted prompts for coding, writing, analysis, creative work, and more.",
     url: "/prompts",
     type: "website",
   },
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Prompt Marketplace | ugig.net",
     description:
-      "Browse AI prompts â€” expertly crafted prompts for coding, writing, analysis, creative work, and more.",
+      "Browse AI prompts — expertly crafted prompts for coding, writing, analysis, creative work, and more.",
   },
 };
 
@@ -156,7 +156,7 @@ async function PromptList({ searchParams }: { searchParams: PromptsPageProps["se
                   </Badge>
                   {btcUsd && (
                     <p className="text-[10px] text-muted-foreground mt-0.5">
-                      â‰ˆ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
+                      ≈ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
                     </p>
                   )}
                 </div>
@@ -325,7 +325,7 @@ export default async function PromptsPage({ searchParams }: PromptsPageProps) {
             </Link>
           </div>
           <p className="text-muted-foreground mb-8">
-            Browse AI prompts â€” expertly crafted for coding, writing, analysis, and more.
+            Browse AI prompts — expertly crafted for coding, writing, analysis, and more.
           </p>
 
           {/* Filters */}
@@ -412,7 +412,7 @@ export default async function PromptsPage({ searchParams }: PromptsPageProps) {
                   ...(queryParams.category ? { category: queryParams.category } : {}),
                   ...(queryParams.sort ? { sort: queryParams.sort } : {}),
                 })}`} className="ml-1 hover:text-destructive">
-                  âœ•
+                  ✕
                 </Link>
               </Badge>
             </div>

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -155,7 +155,7 @@ async function SkillsList({ searchParams }: { searchParams: SkillsPageProps["sea
                   </Badge>
                   {btcUsd && (
                     <p className="text-[10px] text-muted-foreground mt-0.5">
-                      â‰ˆ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
+                      ≈ ${((listing.price_sats / 1e8) * btcUsd).toFixed(2)}
                     </p>
                   )}
                 </div>
@@ -313,7 +313,7 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
             </Link>
           </div>
           <p className="text-muted-foreground mb-8">
-            Browse agent skills â€” install tools, automations, and workflows.
+            Browse agent skills — install tools, automations, and workflows.
           </p>
 
           {/* Filters */}
@@ -391,7 +391,7 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
                   })}`}
                   className="text-xs text-muted-foreground hover:text-destructive flex items-center ml-1"
                 >
-                  âœ• clear
+                  ✕ clear
                 </Link>
               )}
             </div>
@@ -430,7 +430,7 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
                   ...(queryParams.category ? { category: queryParams.category } : {}),
                   ...(queryParams.sort ? { sort: queryParams.sort } : {}),
                 })}`} className="ml-1 hover:text-destructive">
-                  âœ•
+                  ✕
                 </Link>
               </Badge>
             </div>

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -19,6 +19,6 @@ describe("parsePageParam", () => {
   });
 
   it("caps very large page values", () => {
-    expect(parsePageParam("999999999")).toBe(100_000);
+    expect(parsePageParam("999999999")).toBe(1_000);
   });
 });

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,4 +1,4 @@
-const DEFAULT_MAX_PAGE = 100_000;
+const DEFAULT_MAX_PAGE = 1_000;
 
 export function parsePageParam(
   value: string | null | undefined,


### PR DESCRIPTION
## Summary
- restore corrupted Unicode characters on public listing pages after the pagination merge
- tighten `parsePageParam` default max page from 100,000 to 1,000 and update coverage
- compute username review averages from all ratings instead of the current page slice

Fixes #340.

## Verification
- Not run locally: this Codex workspace has Node available but no npm/package runner installed, so I could not execute the repo test suite here.
- Checked the touched files for mojibake (`?`, `?`, replacement char) and found no matches after the repair.