### PR TITLE
fix(users): default malformed search limits

### DIFF
--- a/src/app/api/users/search/route.test.ts
+++ b/src/app/api/users/search/route.test.ts
@@ -156,4 +156,16 @@ describe("GET /api/users/search", () => {
     await GET(makeRequest("/api/users/search?q=test"));
     expect(mockLimit).toHaveBeenCalledWith(10);
   });
+
+  it("uses default limit for malformed limit values", async () => {
+    vi.mocked(getAuthContext).mockResolvedValue({
+      user: { id: "user-1", authMethod: "session" },
+      supabase: supabaseClient as any,
+    });
+
+    mockLimit.mockResolvedValue({ data: [], error: null });
+
+    await GET(makeRequest("/api/users/search?q=test&limit=abc"));
+    expect(mockLimit).toHaveBeenCalledWith(10);
+  });
 });

--- a/src/app/api/users/search/route.test.ts
+++ b/src/app/api/users/search/route.test.ts
@@ -168,4 +168,20 @@ describe("GET /api/users/search", () => {
     await GET(makeRequest("/api/users/search?q=test&limit=abc"));
     expect(mockLimit).toHaveBeenCalledWith(10);
   });
+
+  it.each([
+    ["0", 1],
+    ["-1", 1],
+    ["Infinity", 10],
+  ])("normalizes edge-case limit value %s", async (value, expectedLimit) => {
+    vi.mocked(getAuthContext).mockResolvedValue({
+      user: { id: "user-1", authMethod: "session" },
+      supabase: supabaseClient as any,
+    });
+
+    mockLimit.mockResolvedValue({ data: [], error: null });
+
+    await GET(makeRequest(`/api/users/search?q=test&limit=${value}`));
+    expect(mockLimit).toHaveBeenCalledWith(expectedLimit);
+  });
 });

--- a/src/app/api/users/search/route.ts
+++ b/src/app/api/users/search/route.ts
@@ -11,8 +11,10 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const query = (searchParams.get("q") || "").trim();
-    const limitParam = parseInt(searchParams.get("limit") || "10", 10);
-    const limit = Math.min(Math.max(1, limitParam || 10), 20);
+    const parsedLimit = parseInt(searchParams.get("limit") || "10", 10);
+    const limit = Number.isFinite(parsedLimit)
+      ? Math.min(Math.max(1, parsedLimit), 20)
+      : 10;
 
     if (!query || query.length < 1) {
       return NextResponse.json({ users: [] });


### PR DESCRIPTION
Fixes #344.

This keeps `/api/users/search` from passing `NaN` into `supabase.limit(...)` when callers send malformed `limit` values. Valid numeric limits still clamp to 1..20, and malformed values now fall back to the default limit of 10.

I also added regression coverage for `limit=abc`.

Verification: local dependency install is unavailable in this workspace, so I validated the targeted source/test changes and will follow the PR checks.