### PR TITLE
fix(invoices): include gig_invoice_items in GET response and POST return

### DIFF
--- a/src/app/api/gigs/[id]/invoice/route.ts
+++ b/src/app/api/gigs/[id]/invoice/route.ts
@@ -57,7 +57,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         `
         *,
         worker:profiles!worker_id(id, username, full_name, avatar_url),
-        poster:profiles!poster_id(id, username, full_name, avatar_url)
+        poster:profiles!poster_id(id, username, full_name, avatar_url),
+        items:gig_invoice_items(id, description, amount_usd, position)
       `
       )
       .eq("gig_id", gigId)
@@ -353,6 +354,11 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
           payment_currency: selectedWallet.currency,
           expires_at: null,
           metadata: invoice.metadata,
+          items: lineItems.map((it, idx) => ({
+            description: it.description ?? "",
+            amount_usd: it.amount,
+            position: idx,
+          })),
         },
       },
       { status: 201 }


### PR DESCRIPTION
Closes #350

## Problem

The `gig_invoice_items` table was added in today's migration (`20260530210000_gig_invoice_items.sql`) but the invoice route doesn't join or return items.

## Changes

**`GET /api/gigs/[id]/invoice`** — adds `items:gig_invoice_items(id, description, amount_usd, position)` to the Supabase select, so fetched invoices include their line-item breakdown.

**`POST /api/gigs/[id]/invoice`** — adds `items` to the `201` response body so callers immediately receive the created line items without a separate fetch.

## Testing

Tested via gig `abd6b2a0` (bug testing + PRs) — creating an itemized invoice and verifying the GET response now includes `items`.