### PR TITLE
fix(follows): cap huge public offsets

### DIFF
--- a/src/app/api/users/[username]/followers/route.test.ts
+++ b/src/app/api/users/[username]/followers/route.test.ts
@@ -104,4 +104,24 @@ describe("GET /api/users/[username]/followers", () => {
 
     expect(follows.range).toHaveBeenCalledWith(30, 39);
   });
+
+  it("caps huge offsets before applying range", async () => {
+    const targetProfile = profileChain({ data: { id: "user-123" }, error: null });
+    const follows = followsChain({ data: [], error: null, count: 0 });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? targetProfile : follows;
+    });
+
+    const res = await GET(
+      makeRequest({ limit: "10", offset: "999999999" }),
+      routeParams
+    );
+    const json = await res.json();
+
+    expect(follows.range).toHaveBeenCalledWith(100000, 100009);
+    expect(json.pagination.offset).toBe(100000);
+  });
 });

--- a/src/app/api/users/[username]/followers/route.ts
+++ b/src/app/api/users/[username]/followers/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+const MAX_FOLLOW_OFFSET = 100_000;
+
 function parsePositiveInt(value: string | null, fallback: number, max: number): number {
   const parsed = Number.parseInt(value ?? "", 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -9,12 +11,12 @@ function parsePositiveInt(value: string | null, fallback: number, max: number): 
   return Math.min(parsed, max);
 }
 
-function parseNonNegativeInt(value: string | null, fallback: number): number {
+function parseNonNegativeInt(value: string | null, fallback: number, max: number): number {
   const parsed = Number.parseInt(value ?? "", 10);
   if (!Number.isFinite(parsed) || parsed < 0) {
     return fallback;
   }
-  return parsed;
+  return Math.min(parsed, max);
 }
 
 // GET /api/users/[username]/followers - list a user's followers
@@ -27,7 +29,7 @@ export async function GET(
     const supabase = await createClient();
     const searchParams = request.nextUrl.searchParams;
     const limit = parsePositiveInt(searchParams.get("limit"), 20, 100);
-    const offset = parseNonNegativeInt(searchParams.get("offset"), 0);
+    const offset = parseNonNegativeInt(searchParams.get("offset"), 0, MAX_FOLLOW_OFFSET);
 
     // Look up target user
     const { data: targetProfile, error: profileError } = await supabase

--- a/src/app/api/users/[username]/following/route.test.ts
+++ b/src/app/api/users/[username]/following/route.test.ts
@@ -104,4 +104,24 @@ describe("GET /api/users/[username]/following", () => {
 
     expect(follows.range).toHaveBeenCalledWith(30, 39);
   });
+
+  it("caps huge offsets before applying range", async () => {
+    const targetProfile = profileChain({ data: { id: "user-123" }, error: null });
+    const follows = followsChain({ data: [], error: null, count: 0 });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? targetProfile : follows;
+    });
+
+    const res = await GET(
+      makeRequest({ limit: "10", offset: "999999999" }),
+      routeParams
+    );
+    const json = await res.json();
+
+    expect(follows.range).toHaveBeenCalledWith(100000, 100009);
+    expect(json.pagination.offset).toBe(100000);
+  });
 });

--- a/src/app/api/users/[username]/following/route.ts
+++ b/src/app/api/users/[username]/following/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+const MAX_FOLLOW_OFFSET = 100_000;
+
 function parsePositiveInt(value: string | null, fallback: number, max: number): number {
   const parsed = Number.parseInt(value ?? "", 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -9,12 +11,12 @@ function parsePositiveInt(value: string | null, fallback: number, max: number): 
   return Math.min(parsed, max);
 }
 
-function parseNonNegativeInt(value: string | null, fallback: number): number {
+function parseNonNegativeInt(value: string | null, fallback: number, max: number): number {
   const parsed = Number.parseInt(value ?? "", 10);
   if (!Number.isFinite(parsed) || parsed < 0) {
     return fallback;
   }
-  return parsed;
+  return Math.min(parsed, max);
 }
 
 // GET /api/users/[username]/following - list who a user follows
@@ -27,7 +29,7 @@ export async function GET(
     const supabase = await createClient();
     const searchParams = request.nextUrl.searchParams;
     const limit = parsePositiveInt(searchParams.get("limit"), 20, 100);
-    const offset = parseNonNegativeInt(searchParams.get("offset"), 0);
+    const offset = parseNonNegativeInt(searchParams.get("offset"), 0, MAX_FOLLOW_OFFSET);
 
     // Look up target user
     const { data: targetProfile, error: profileError } = await supabase


### PR DESCRIPTION
## Summary
- cap oversized offsets in the public followers and following endpoints before building Supabase ranges
- keep valid offsets unchanged while bounding extreme requests at `100_000`
- add regression coverage for both mirrored routes and returned pagination metadata

Fixes #356.

Paid task context: https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e

## Verification
- `.\node_modules\.bin\vitest.CMD run src/app/api/users/[username]/followers/route.test.ts src/app/api/users/[username]/following/route.test.ts`
- `.\node_modules\.bin\eslint.CMD src/app/api/users/[username]/followers/route.ts src/app/api/users/[username]/followers/route.test.ts src/app/api/users/[username]/following/route.ts src/app/api/users/[username]/following/route.test.ts`
- `git diff --check`

## Existing upstream check blockers
- `.\node_modules\.bin\tsc.CMD --noEmit` reaches unrelated existing errors in `src/app/api/affiliates/offers/route.test.ts:53` and `src/app/api/applications/[id]/route.test.ts:21`.
- `corepack pnpm run lint` reaches unrelated existing `react-hooks/refs` errors in `src/hooks/useMessageStream.ts`.
- `corepack pnpm run build` compiles successfully and progresses through static generation when given a process-local dummy OpenAI key, then stops because the local checkout has no Supabase service-role configuration.