### PR TITLE
fix(feed): clamp lounge page pagination

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/layout/Header";
 import { CreatePostForm } from "@/components/feed/CreatePostForm";
 import { FeedSortTabs } from "@/components/feed/FeedSortTabs";
 import { FeedList } from "@/components/feed/FeedList";
+import { parsePageParam } from "@/lib/pagination";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -24,7 +25,7 @@ async function FeedContent({ searchParams }: FeedPageProps) {
   const resolvedParams = await searchParams;
   const sort = resolvedParams.sort || "hot";
   const tag = resolvedParams.tag || undefined;
-  const page = Number(resolvedParams.page) || 1;
+  const page = parsePageParam(resolvedParams.page);
 
   const supabase = await createClient();
 

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -13,6 +13,7 @@ describe("parsePageParam", () => {
     expect(parsePageParam("0")).toBe(1);
     expect(parsePageParam("abc")).toBe(1);
     expect(parsePageParam("Infinity")).toBe(1);
+    expect(parsePageParam("-Infinity")).toBe(1);
   });
 
   it("truncates fractional page values", () => {

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -12,6 +12,7 @@ describe("parsePageParam", () => {
     expect(parsePageParam("-1")).toBe(1);
     expect(parsePageParam("0")).toBe(1);
     expect(parsePageParam("abc")).toBe(1);
+    expect(parsePageParam("Infinity")).toBe(1);
   });
 
   it("truncates fractional page values", () => {


### PR DESCRIPTION
## Summary
- route the server-rendered lounge feed page through the existing bounded `parsePageParam` helper
- prevent negative, non-finite, fractional, or extreme `page` values from producing unsafe Supabase ranges
- add explicit regression coverage for a non-finite page value

Fixes #358.

Paid task context: https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e

## Verification
- `.\node_modules\.bin\vitest.CMD run src/lib/pagination.test.ts`
- `.\node_modules\.bin\eslint.CMD src/app/feed/page.tsx src/lib/pagination.test.ts`
- `git diff --check`

## Existing upstream check blockers
- `.\node_modules\.bin\tsc.CMD --noEmit` reaches unrelated existing errors in `src/app/api/affiliates/offers/route.test.ts:53` and `src/app/api/applications/[id]/route.test.ts:21`.
- `corepack pnpm run build` compiles successfully and progresses through static generation when given a process-local dummy OpenAI key, then stops because the local checkout has no Supabase service-role configuration.