### PR TITLE
fix(resume): defer OpenAI client construction

### DIFF
--- a/src/lib/resume-parser.test.ts
+++ b/src/lib/resume-parser.test.ts
@@ -1,0 +1,16 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("resume-parser module", () => {
+  it("can be imported without an OpenAI API key", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+
+    await expect(import("./resume-parser")).resolves.toHaveProperty(
+      "parseResumeFile"
+    );
+  });
+});

--- a/src/lib/resume-parser.ts
+++ b/src/lib/resume-parser.ts
@@ -34,9 +34,13 @@ export interface ParsedResumeProfile {
   };
 }
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+function getOpenAIClient() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not configured");
+  }
+  return new OpenAI({ apiKey });
+}
 
 // Use OpenAI to parse resume text into structured data
 async function parseWithOpenAI(text: string): Promise<ParsedResumeProfile> {
@@ -79,9 +83,10 @@ Important:
 - For partial URLs like "github.com/user", prepend "https://"
 
 Resume text:
-${text}`;
+  ${text}`;
 
   try {
+    const openai = getOpenAIClient();
     const response = await openai.chat.completions.create({
       model: "gpt-4o-mini",
       messages: [

--- a/src/lib/resume-parser.ts
+++ b/src/lib/resume-parser.ts
@@ -83,7 +83,7 @@ Important:
 - For partial URLs like "github.com/user", prepend "https://"
 
 Resume text:
-  ${text}`;
+${text}`;
 
   try {
     const openai = getOpenAIClient();


### PR DESCRIPTION
## Summary
- defer OpenAI client construction until resume parsing is actually requested
- keep module imports and Next page-data collection working when `OPENAI_API_KEY` is absent
- return a clear configuration error only when the resume parser needs the missing key
- add a regression test that imports the parser without an API key

Paid task: https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e

## Testing
- `corepack pnpm exec vitest run src/lib/resume-parser.test.ts`
- `corepack pnpm exec eslint src/lib/resume-parser.ts src/lib/resume-parser.test.ts`
- `git diff --check`
- `corepack pnpm build` *(now passes `/api/profile/import` page-data collection and proceeds into static generation; later blocked by pre-existing missing Supabase service-role configuration while prerendering `/blog`)*