### PR TITLE
fix(feed): show poll results to anonymous viewers

### DIFF
--- a/src/components/feed/PostCard.test.tsx
+++ b/src/components/feed/PostCard.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PostWithAuthor } from "@/types";
+import { PostCard } from "./PostCard";
+
+const { pollDisplay } = vi.hoisted(() => ({
+  pollDisplay: vi.fn(() => null),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("./PollDisplay", () => ({
+  PollDisplay: pollDisplay,
+}));
+
+vi.mock("./VoteButtons", () => ({
+  VoteButtons: () => null,
+}));
+
+vi.mock("@/components/zaps/ZapButton", () => ({
+  ZapButton: () => null,
+}));
+
+vi.mock("@/components/ui/MarkdownContent", () => ({
+  MarkdownContent: () => null,
+}));
+
+const pollPost = {
+  id: "post-1",
+  author: null,
+  author_id: null,
+  comments_count: 0,
+  content: "Pick one",
+  created_at: "2026-05-31T00:00:00.000Z",
+  post_type: "poll",
+  score: 0,
+  tags: [],
+  updated_at: "2026-05-31T00:00:00.000Z",
+  url: null,
+  views_count: 0,
+} as unknown as PostWithAuthor;
+
+describe("PostCard poll login state", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders read-only poll results for anonymous viewers", () => {
+    render(<PostCard post={pollPost} />);
+
+    expect(pollDisplay).toHaveBeenCalledWith(
+      expect.objectContaining({ postId: "post-1", isLoggedIn: false }),
+      undefined
+    );
+  });
+
+  it("allows authenticated viewers to vote", () => {
+    render(<PostCard post={pollPost} currentUserId="user-1" />);
+
+    expect(pollDisplay).toHaveBeenCalledWith(
+      expect.objectContaining({ postId: "post-1", isLoggedIn: true }),
+      undefined
+    );
+  });
+});

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -289,7 +289,7 @@ export function PostCard({ post: initialPost, showFollowButtons, followedTags, e
 
         {/* Poll if present */}
         {post.post_type === "poll" && (
-          <PollDisplay postId={post.id} isLoggedIn={true} />
+          <PollDisplay postId={post.id} isLoggedIn={!!currentUserId} />
         )}
 
         {/* URL if present */}


### PR DESCRIPTION
## Summary
- pass the actual viewer login state from `PostCard` into `PollDisplay`
- show read-only poll results to anonymous feed viewers instead of vote controls that silently fail with `401`
- cover anonymous and authenticated integration paths with focused component tests

## Paid task
https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e

## Verification
- `pnpm exec vitest run src/components/feed/PostCard.test.tsx`
- `pnpm exec eslint src/components/feed/PostCard.tsx src/components/feed/PostCard.test.tsx`
- `git diff --check`