### PR TITLE
test(webhooks): hoist delivery route mocks

### DIFF
--- a/src/app/api/webhooks/[id]/deliveries/route.test.ts
+++ b/src/app/api/webhooks/[id]/deliveries/route.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
-const mockFrom = vi.fn();
-const mockGetAuthContext = vi.fn();
+const { mockFrom, mockGetAuthContext } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockGetAuthContext: vi.fn(),
+}));
 
 vi.mock("@/lib/auth/get-user", () => ({
   getAuthContext: mockGetAuthContext,


### PR DESCRIPTION
## Summary
- initialize webhook-deliveries route mocks with `vi.hoisted()`
- fix the Vitest temporal-dead-zone failure introduced with the pagination coverage
- restore execution of all four delivery pagination regression tests

## Paid task
https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e

## Verification
- `pnpm exec vitest run 'src/app/api/webhooks/[id]/deliveries/route.test.ts'`
- `pnpm exec eslint 'src/app/api/webhooks/[id]/deliveries/route.test.ts'`
- `git diff --check`