### PR TITLE
fix(gigs): stabilize budget number formatting

### DIFF
--- a/src/app/gigs/[id]/page.tsx
+++ b/src/app/gigs/[id]/page.tsx
@@ -283,7 +283,7 @@ export default async function GigPage({ params }: GigPageProps) {
     const coinNote = coin ? ` (paid in ${coin})` : "";
 
     const fmt = (val: number) => {
-      if (isSats) return `${val.toLocaleString()} sats`;
+      if (isSats) return `${val.toLocaleString("en-US")} sats`;
       return `${formatCurrency(val)} USD`;
     };
 

--- a/src/components/gigs/GigCard.tsx
+++ b/src/components/gigs/GigCard.tsx
@@ -63,7 +63,7 @@ export function GigCard({
     const coinNote = coin ? ` (paid in ${coin})` : "";
 
     const fmt = (val: number) => {
-      if (isSats) return `${val.toLocaleString()} sats`;
+      if (isSats) return `${val.toLocaleString("en-US")} sats`;
       return `${formatCurrency(val)} USD`;
     };
 

--- a/src/components/gigs/GigCardSats.test.tsx
+++ b/src/components/gigs/GigCardSats.test.tsx
@@ -33,8 +33,8 @@ function getBudgetDisplay(gig: {
   const coinNote = coin ? ` (paid in ${coin})` : "";
 
   const fmt = (val: number) => {
-    if (isSats) return `${val.toLocaleString()} sats`;
-    return `$${val.toLocaleString()} USD`;
+    if (isSats) return `${val.toLocaleString("en-US")} sats`;
+    return `$${val.toLocaleString("en-US")} USD`;
   };
 
   if (gig.budget_type === "revenue_share") {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -340,10 +340,10 @@ export function formatBudgetAmount(amount: number, paymentCoin?: string | null):
     if (paymentCoin === "BTC" && amount < 1) {
       return `₿${amount}`;
     }
-    return `${amount.toLocaleString()} sats`;
+    return `${amount.toLocaleString("en-US")} sats`;
   }
   // Default: USD
-  return `$${amount.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`;
+  return `$${amount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`;
 }
 
 /** Get the currency label for display */


### PR DESCRIPTION
## Summary
- pin shared budget amount formatting to `en-US` rather than the host locale
- keep gig cards and gig detail pages consistent for sats-denominated amounts
- update the extracted gig-card regression helper so formatter suites stay deterministic across environments

## Paid task
https://ugig.net/gigs/abd6b2a0-e728-48cf-a46f-f99e419ed94e

## Verification
- `pnpm exec vitest run src/types/budget-display.test.ts src/components/gigs/GigCardSats.test.tsx`
- `pnpm exec eslint src/types/index.ts src/components/gigs/GigCard.tsx 'src/app/gigs/[id]/page.tsx' src/components/gigs/GigCardSats.test.tsx`
- `git diff --check`