### PR TITLE
docs: fix CLI option examples

### DIFF
--- a/src/app/docs/cli/page.tsx
+++ b/src/app/docs/cli/page.tsx
@@ -236,7 +236,7 @@ ugig gigs list --skills "TypeScript,Node.js"
 # Filter by budget
 ugig gigs list --min-budget 500 --max-budget 5000
 
-# Sort options: recent, budget_high, budget_low
+# Sort options: newest, oldest, budget_high, budget_low
 ugig gigs list --sort budget_high`}</CodeBlock>
             <CodeBlock title="View gig details">{`ugig gigs get <gig-id>`}</CodeBlock>
             <CodeBlock title="Create a gig">{`ugig gigs create --title "Build a landing page" \\

--- a/src/app/docs/cli/page.tsx
+++ b/src/app/docs/cli/page.tsx
@@ -539,8 +539,8 @@ ugig messages list <conversation-id>`}</CodeBlock>
             <CodeBlock title="Browse feed">{`# View feed
 ugig feed
 
-# Sort by: recent, trending
-ugig feed --sort trending`}</CodeBlock>
+# Sort by: hot, new, top, rising
+ugig feed --sort rising`}</CodeBlock>
             <CodeBlock title="Create posts">{`# Text post
 ugig post create "Just shipped a new feature! 🚀"
 

--- a/src/app/docs/cli/page.tsx
+++ b/src/app/docs/cli/page.tsx
@@ -539,7 +539,7 @@ ugig messages list <conversation-id>`}</CodeBlock>
             <CodeBlock title="Browse feed">{`# View feed
 ugig feed
 
-# Sort by: hot, new, top, rising
+# Sort by: hot, new, top, rising, following
 ugig feed --sort rising`}</CodeBlock>
             <CodeBlock title="Create posts">{`# Text post
 ugig post create "Just shipped a new feature! 🚀"

--- a/src/app/docs/cli/page.tsx
+++ b/src/app/docs/cli/page.tsx
@@ -234,7 +234,7 @@ ugig gigs list --search "react developer"
 ugig gigs list --skills "TypeScript,Node.js"
 
 # Filter by budget
-ugig gigs list --min-budget 500 --max-budget 5000
+ugig gigs list --budget-min 500 --budget-max 5000
 
 # Sort options: newest, oldest, budget_high, budget_low
 ugig gigs list --sort budget_high`}</CodeBlock>


### PR DESCRIPTION
## Summary
- replace the unsupported `recent` gig sort option with the supported `newest` value
- document the missing `oldest` gig sort option so the docs match CLI help and validation
- fix the gig budget filter example from `--min-budget` / `--max-budget` to `--budget-min` / `--budget-max`
- replace the unsupported feed `trending` sort example with implemented feed sort values and a valid `rising` example
- include the `following` feed sort option from the shared validation schema

Fixes #372.

## Verification
- Confirmed `https://ugig.net/api/gigs?sort=recent&limit=1` returns 400
- Confirmed `https://ugig.net/api/gigs?sort=newest&limit=1` returns 200
- Confirmed `https://ugig.net/api/feed?sort=trending&limit=1` returns 400
- Confirmed `https://ugig.net/api/feed?sort=hot&limit=1` returns 200
- Confirmed `https://ugig.net/api/feed?sort=following&limit=1` is accepted as a valid sort and reaches auth handling (401 login required), rather than validation failure
- Confirmed `cli/src/commands/gigs.ts` defines `--budget-min` and `--budget-max`
- Ran `git diff --check -- src/app/docs/cli/page.tsx`

Docs-only change; no build was run.