### PR TITLE
fix(feed): clamp invalid lounge feed page values before Supabase range queries

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,3 +1,4 @@
+import { parsePageParam } from "@/lib/pagination";
 /* eslint-disable react-hooks/purity */
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
@@ -24,7 +25,7 @@ async function FeedContent({ searchParams }: FeedPageProps) {
   const resolvedParams = await searchParams;
   const sort = resolvedParams.sort || "hot";
   const tag = resolvedParams.tag || undefined;
-  const page = Number(resolvedParams.page) || 1;
+  const page = parsePageParam(resolvedParams.page);
 
   const supabase = await createClient();
 


### PR DESCRIPTION
Fixes #358

Replaces `Number(resolvedParams.page) || 1` with the shared `parsePageParam` helper already used by /affiliates, /directory, /for-hire, and /gigs.

This ensures negative, non-finite (Infinity/-Infinity), and excessively large page values are normalized before the Supabase `.range()` offset is calculated, matching the pagination-hardening pattern applied across the codebase.

**Tested**: pattern matches existing usage on affiliated listing pages.