### PR TITLE
fix(users): cap huge follow-list offsets before Supabase range queries

### DIFF
--- a/src/app/api/users/[username]/followers/route.ts
+++ b/src/app/api/users/[username]/followers/route.ts
@@ -27,7 +27,7 @@ export async function GET(
     const supabase = await createClient();
     const searchParams = request.nextUrl.searchParams;
     const limit = parsePositiveInt(searchParams.get("limit"), 20, 100);
-    const offset = parseNonNegativeInt(searchParams.get("offset"), 0);
+    const offset = Math.min(parseNonNegativeInt(searchParams.get("offset"), 0), 100_000);
 
     // Look up target user
     const { data: targetProfile, error: profileError } = await supabase

--- a/src/app/api/users/[username]/following/route.ts
+++ b/src/app/api/users/[username]/following/route.ts
@@ -27,7 +27,7 @@ export async function GET(
     const supabase = await createClient();
     const searchParams = request.nextUrl.searchParams;
     const limit = parsePositiveInt(searchParams.get("limit"), 20, 100);
-    const offset = parseNonNegativeInt(searchParams.get("offset"), 0);
+    const offset = Math.min(parseNonNegativeInt(searchParams.get("offset"), 0), 100_000);
 
     // Look up target user
     const { data: targetProfile, error: profileError } = await supabase


### PR DESCRIPTION
Fixes #356

Caps `offset` at `100_000` for `GET /api/users/[username]/followers` and `GET /api/users/[username]/following` before building the Supabase `.range()` call, matching the pagination-hardening pattern used across other public endpoints.