### PR TITLE
fix(tags): clamp zero and invalid popular-tags limit with parsePaginationParam

### DIFF
--- a/src/app/api/tags/popular/route.ts
+++ b/src/app/api/tags/popular/route.ts
@@ -1,3 +1,4 @@
+import { parsePaginationParam } from "@/lib/api-pagination";
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
@@ -5,10 +6,7 @@ import { createClient } from "@/lib/supabase/server";
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const limit = Math.min(
-      Math.max(parseInt(searchParams.get("limit") || "50", 10) || 50, 1),
-      200
-    );
+    const limit = parsePaginationParam(searchParams.get("limit"), 50, 1, 200);
 
     const supabase = await createClient();
 


### PR DESCRIPTION
Fixes #360

Replaces the ad-hoc `Math.min(Math.max(parseInt(...) || 50, 1), 200)` with the shared `parsePaginationParam` helper so `limit=0` clamps to `1`, malformed values fall back to `50`, and oversized values cap at `200`.