### PR TITLE
fix: validate zap leaderboard filters

### DIFF
--- a/src/app/api/leaderboard/zaps/route.test.ts
+++ b/src/app/api/leaderboard/zaps/route.test.ts
@@ -77,4 +77,22 @@ describe("GET /api/leaderboard/zaps", () => {
     expect(response.status).toBe(200);
     expect(json.leaderboard).toHaveLength(2);
   });
+
+  it("rejects unsupported period values before querying", async () => {
+    const response = await GET(makeRequest({ period: "year" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("Invalid period. Must be: week, month, or all");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported sort values before querying", async () => {
+    const response = await GET(makeRequest({ sort: "top" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("Invalid sort. Must be: received or sent");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/leaderboard/zaps/route.ts
+++ b/src/app/api/leaderboard/zaps/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/service";
 
+const VALID_PERIODS = ["week", "month", "all"] as const;
+const VALID_SORTS = ["received", "sent"] as const;
+
 /**
  * GET /api/leaderboard/zaps?period=week|month|all&sort=received|sent&limit=25
  * Public endpoint - no auth required.
@@ -10,6 +13,21 @@ export async function GET(request: NextRequest) {
     const url = new URL(request.url);
     const period = url.searchParams.get("period") || "all";
     const sort = url.searchParams.get("sort") || "received";
+
+    if (!VALID_PERIODS.includes(period as (typeof VALID_PERIODS)[number])) {
+      return NextResponse.json(
+        { error: "Invalid period. Must be: week, month, or all" },
+        { status: 400 }
+      );
+    }
+
+    if (!VALID_SORTS.includes(sort as (typeof VALID_SORTS)[number])) {
+      return NextResponse.json(
+        { error: "Invalid sort. Must be: received or sent" },
+        { status: 400 }
+      );
+    }
+
     const parsedLimit = parseInt(url.searchParams.get("limit") || "25", 10);
     const limit = Number.isFinite(parsedLimit)
       ? Math.min(Math.max(parsedLimit, 1), 50)


### PR DESCRIPTION
## Summary

- closes #379
- validate `period` on `/api/leaderboard/zaps` against `week`, `month`, and `all`
- validate `sort` against `received` and `sent`
- return 400 before querying Supabase for unsupported filter values

## Tests

- `npm run test:run -- src/app/api/leaderboard/zaps/route.test.ts`
