### PR TITLE
[codex] Validate zap leaderboard filters

### DIFF
--- a/src/app/api/leaderboard/zaps/route.test.ts
+++ b/src/app/api/leaderboard/zaps/route.test.ts
@@ -77,4 +77,22 @@ describe("GET /api/leaderboard/zaps", () => {
     expect(response.status).toBe(200);
     expect(json.leaderboard).toHaveLength(2);
   });
+
+  it("rejects unsupported period values", async () => {
+    const response = await GET(makeRequest({ period: "year" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("Invalid period. Must be: all, month, or week");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported sort values", async () => {
+    const response = await GET(makeRequest({ sort: "top" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("Invalid sort. Must be: received or sent");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/leaderboard/zaps/route.ts
+++ b/src/app/api/leaderboard/zaps/route.ts
@@ -10,6 +10,21 @@ export async function GET(request: NextRequest) {
     const url = new URL(request.url);
     const period = url.searchParams.get("period") || "all";
     const sort = url.searchParams.get("sort") || "received";
+
+    if (!["all", "month", "week"].includes(period)) {
+      return NextResponse.json(
+        { error: "Invalid period. Must be: all, month, or week" },
+        { status: 400 }
+      );
+    }
+
+    if (!["received", "sent"].includes(sort)) {
+      return NextResponse.json(
+        { error: "Invalid sort. Must be: received or sent" },
+        { status: 400 }
+      );
+    }
+
     const parsedLimit = parseInt(url.searchParams.get("limit") || "25", 10);
     const limit = Number.isFinite(parsedLimit)
       ? Math.min(Math.max(parsedLimit, 1), 50)


### PR DESCRIPTION
Fixes #379.

Summary:
- reject unsupported `period` values on `/api/leaderboard/zaps` before querying Supabase
- reject unsupported `sort` values instead of silently falling back to received zaps
- add regression coverage for both invalid query parameters and confirm the DB mock is not called

Validation:
- vitest run src/app/api/leaderboard/zaps/route.test.ts
- tsc --noEmit