### PR TITLE
[codex] Clamp popular tag limits

### DIFF
--- a/src/app/api/tags/popular/route.test.ts
+++ b/src/app/api/tags/popular/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve({ from: mockFrom })),
+}));
+
+import { GET } from "./route";
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/tags/popular");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url, { method: "GET" });
+}
+
+function mockPopularTagsData() {
+  const gigs = [
+    { skills_required: ["TypeScript", "API"] },
+    { skills_required: ["TypeScript", "Testing"] },
+    { skills_required: ["Python"] },
+  ];
+  const follows = [
+    { tag: "TypeScript" },
+    { tag: "API" },
+    { tag: "API" },
+  ];
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "gigs") {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => Promise.resolve({ data: gigs, error: null })),
+        })),
+      };
+    }
+
+    if (table === "tag_follows") {
+      return {
+        select: vi.fn(() => Promise.resolve({ data: follows, error: null })),
+      };
+    }
+
+    return {};
+  });
+}
+
+describe("GET /api/tags/popular", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clamps zero limits to one tag", async () => {
+    mockPopularTagsData();
+
+    const response = await GET(makeRequest({ limit: "0" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.tags).toHaveLength(1);
+    expect(json.tags[0].tag).toBe("API");
+  });
+
+  it("uses the default limit for malformed numeric strings", async () => {
+    mockPopularTagsData();
+
+    const response = await GET(makeRequest({ limit: "7px" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.tags).toHaveLength(4);
+  });
+});

--- a/src/app/api/tags/popular/route.ts
+++ b/src/app/api/tags/popular/route.ts
@@ -1,14 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { parsePaginationParam } from "@/lib/api-pagination";
 
 // GET /api/tags/popular — list popular tags with gig and follower counts
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const limit = Math.min(
-      Math.max(parseInt(searchParams.get("limit") || "50", 10) || 50, 1),
-      200
-    );
+    const limit = parsePaginationParam(searchParams.get("limit"), 50, 1, 200);
 
     const supabase = await createClient();
 


### PR DESCRIPTION
Fixes #360.

Summary:
- replace the ad hoc popular-tags limit parser with the shared `parsePaginationParam` helper
- make `limit=0` clamp to the documented minimum of 1 instead of expanding to the default
- make malformed numeric strings fall back to the default limit instead of being partially accepted
- add focused route coverage for zero and malformed limits

Validation:
- vitest run src/app/api/tags/popular/route.test.ts
- tsc --noEmit