### PR TITLE
fix(bounties): validate inputs, return pagination, log errors, expose updated_at/questions

### DIFF
--- a/src/app/api/bounties/route.ts
+++ b/src/app/api/bounties/route.ts
@@ -4,42 +4,75 @@ import { createClient } from "@/lib/supabase/server";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createBountySchema } from "@/lib/bounties";
 
-// GET /api/bounties — public list of open bounties
+const BOUNTY_STATUSES = ["open", "paused", "closed"] as const;
+type BountyStatus = (typeof BOUNTY_STATUSES)[number];
+
+// GET /api/bounties — public list of bounties
 export async function GET(request: NextRequest) {
   try {
     const params = request.nextUrl.searchParams;
-    const status = params.get("status") || "open";
-    const defaultLimit = 50;
+    const statusParam = params.get("status") || "open";
+    if (!(BOUNTY_STATUSES as readonly string[]).includes(statusParam)) {
+      return NextResponse.json(
+        { error: `Invalid status. Must be one of: ${BOUNTY_STATUSES.join(", ")}` },
+        { status: 400 }
+      );
+    }
+    const status = statusParam as BountyStatus;
 
+    const defaultLimit = 50;
     const limitRaw = Number(params.get("limit"));
+    if (params.get("limit") !== null && (!Number.isFinite(limitRaw) || limitRaw <= 0)) {
+      return NextResponse.json(
+        { error: "Invalid limit. Must be a positive integer." },
+        { status: 400 }
+      );
+    }
     const limitCandidate =
       Number.isFinite(limitRaw) && limitRaw > 0 ? Math.floor(limitRaw) : defaultLimit;
     const limit = Math.min(limitCandidate, 100);
 
     const pageRaw = Number(params.get("page"));
+    if (params.get("page") !== null && (!Number.isFinite(pageRaw) || pageRaw <= 0)) {
+      return NextResponse.json(
+        { error: "Invalid page. Must be a positive integer." },
+        { status: 400 }
+      );
+    }
     const page = Number.isFinite(pageRaw) && pageRaw > 0 ? Math.floor(pageRaw) : 1;
     const offset = (page - 1) * limit;
 
     const supabase = await createClient();
 
-    const { data, error } = await supabase
+    const { data, error, count } = await supabase
       .from("bounties" as any)
       .select(
         `
-        id, title, description, payout_usd, payout_currency, max_submissions,
-        status, closes_at, created_at,
+        id, title, description, payout_usd, payout_currency, payment_coin,
+        max_submissions, status, closes_at, questions, created_at, updated_at,
         creator:profiles!creator_id (id, username, full_name, avatar_url)
-      `
+      `,
+        { count: "exact" }
       )
       .eq("status", status)
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1);
 
     if (error) {
+      console.error("[GET /api/bounties] Supabase error:", error);
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
-    return NextResponse.json({ data: data || [] });
-  } catch {
+    return NextResponse.json({
+      data: data || [],
+      pagination: {
+        page,
+        limit,
+        total: count ?? 0,
+        total_pages: count ? Math.ceil(count / limit) : 0,
+      },
+    });
+  } catch (err) {
+    console.error("[GET /api/bounties] Unexpected error:", err);
     return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
   }
 }
@@ -57,7 +90,10 @@ export async function POST(request: NextRequest) {
     const parsed = createBountySchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0].message },
+        {
+          error: parsed.error.issues[0].message,
+          issues: parsed.error.issues,
+        },
         { status: 400 }
       );
     }
@@ -85,10 +121,12 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (error) {
+      console.error("[POST /api/bounties] Supabase error:", error);
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
     return NextResponse.json({ data }, { status: 201 });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/bounties] Unexpected error:", err);
     return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Bug Fix: /api/bounties endpoint improvements

Found while testing ugig.net as part of bug bounty `c3137a9d` ("I will pay for every bug fix found and PR submitted that fix").

### Bugs Found

**Bug 1: Missing fields in GET response**
The `select()` clause omits `updated_at` and `questions` columns that exist in the `bounties` table. Frontend has no way to know when a bounty was last modified, and the questions metadata is unavailable for the public listing endpoint.

**Bug 2: Invalid `status` query param silently returns `[]`**
`?status=invalid` returns empty array instead of a 400 error. Clients can't tell if they made a typo or there are no results.

**Bug 3: No pagination metadata**
Response only returns `data` array. Clients can't tell if more pages exist or how many. Adding `total` and `total_pages` is the standard fix.

**Bug 4: Generic 500 errors with no logging**
Both GET and POST catch all exceptions and return `{"error":"Unexpected error"}` with no `console.error`. Production debugging is impossible.

**Bug 5: No input validation feedback on POST**
When `createBountySchema.safeParse()` fails, only the first issue message is returned. The full `issues` array is dropped, making client-side validation work harder.

### Changes

1. **Added `updated_at` and `questions`** to the `select()` clause.
2. **Validate `status` param** against allowed values (`open|paused|closed`), return 400 for invalid.
3. **Validate `limit` and `page`** params, return 400 for non-positive integers.
4. **Added `{ count: "exact" }`** to Supabase query to get total count.
5. **Added `pagination` object** to response: `{ page, limit, total, total_pages }`.
6. **Added `console.error` logging** for both expected and unexpected errors.
7. **Return full `issues` array** in POST validation error response.

### Testing

After merging, verify:

```bash
# Before: returns [] silently
curl https://ugig.net/api/bounties?status=invalid
# After: returns 400
curl https://ugig.net/api/bounties?status=invalid
# {"error":"Invalid status. Must be one of: open, paused, closed"}

# After: pagination metadata
curl https://ugig.net/api/bounties?page=1
# {"data":[...], "pagination":{"page":1,"limit":50,"total":5,"total_pages":1}}
```

### Related

- Bug bounty: `c3137a9d` on ugig.net
- Found by: opencode-agent-jhosep
- Files changed: 1 (`src/app/api/bounties/route.ts`)
- Lines: 3076 → 4479 bytes

Looking forward to your review.
