### PR TITLE
Scope bounty submissions for API key auth

### DIFF
--- a/src/app/api/bounties/[id]/submissions/route.test.ts
+++ b/src/app/api/bounties/[id]/submissions/route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockFrom = vi.fn();
+
+const supabaseClient = {
+  from: mockFrom,
+};
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getAuthContext } from "@/lib/auth/get-user";
+
+const mockGetAuthContext = vi.mocked(getAuthContext);
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/bounties/bounty-1/submissions", {
+    method: "GET",
+  });
+}
+
+function makeParams() {
+  return { params: Promise.resolve({ id: "bounty-1" }) };
+}
+
+function makeBountyQuery(creatorId: string) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: { id: "bounty-1", creator_id: creatorId },
+    }),
+  };
+}
+
+function makeSubmissionsQuery() {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue({ data: [], error: null }),
+  };
+}
+
+describe("GET /api/bounties/[id]/submissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-1", authMethod: "api_key" },
+      supabase: supabaseClient,
+    } as never);
+  });
+
+  it("filters non-creator API key requests to the caller's submissions", async () => {
+    const bountyQuery = makeBountyQuery("creator-1");
+    const submissionsQuery = makeSubmissionsQuery();
+    mockFrom.mockImplementation((table: string) =>
+      table === "bounties" ? bountyQuery : submissionsQuery
+    );
+
+    const response = await GET(makeRequest(), makeParams());
+
+    expect(response.status).toBe(200);
+    expect(submissionsQuery.eq).toHaveBeenCalledWith("bounty_id", "bounty-1");
+    expect(submissionsQuery.eq).toHaveBeenCalledWith("submitter_id", "user-1");
+  });
+
+  it("allows bounty creators to list all submissions for their bounty", async () => {
+    const bountyQuery = makeBountyQuery("user-1");
+    const submissionsQuery = makeSubmissionsQuery();
+    mockFrom.mockImplementation((table: string) =>
+      table === "bounties" ? bountyQuery : submissionsQuery
+    );
+
+    const response = await GET(makeRequest(), makeParams());
+
+    expect(response.status).toBe(200);
+    expect(submissionsQuery.eq).toHaveBeenCalledWith("bounty_id", "bounty-1");
+    expect(submissionsQuery.eq).not.toHaveBeenCalledWith("submitter_id", "user-1");
+  });
+});

--- a/src/app/api/bounties/[id]/submissions/route.ts
+++ b/src/app/api/bounties/[id]/submissions/route.ts
@@ -15,8 +15,17 @@ export async function GET(
     }
     const { user, supabase } = auth;
 
-    // RLS will filter to (submitter or bounty creator) automatically.
-    const { data, error } = await (supabase as any)
+    const { data: bounty } = await (supabase as any)
+      .from("bounties")
+      .select("id, creator_id")
+      .eq("id", id)
+      .single();
+
+    if (!bounty) {
+      return NextResponse.json({ error: "Bounty not found" }, { status: 404 });
+    }
+
+    let query = (supabase as any)
       .from("bounty_submissions")
       .select(
         `
@@ -24,13 +33,17 @@ export async function GET(
         submitter:profiles!submitter_id (id, username, full_name, avatar_url)
       `
       )
-      .eq("bounty_id", id)
-      .order("created_at", { ascending: false });
+      .eq("bounty_id", id);
+
+    if (bounty.creator_id !== user.id) {
+      query = query.eq("submitter_id", user.id);
+    }
+
+    const { data, error } = await query.order("created_at", { ascending: false });
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
-    void user;
     return NextResponse.json({ data: data || [] });
   } catch {
     return NextResponse.json({ error: "Unexpected error" }, { status: 500 });


### PR DESCRIPTION
Fixes bounty submission visibility under API-key auth by explicitly loading the bounty creator and filtering non-creator requests by submitter_id, avoiding service-role/RLS bypass leakage.

Validation:
- vitest run src/app/api/bounties/[id]/submissions/route.test.ts
- tsc --noEmit