### PR TITLE
fix: clarify coin-paid bounty payout labels

### DIFF
--- a/src/lib/bounties.test.ts
+++ b/src/lib/bounties.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { formatBountyPayout } from "./bounties";
+
+describe("formatBountyPayout", () => {
+  it("keeps USD-only bounties unchanged", () => {
+    expect(formatBountyPayout(1, null)).toBe("$1 USD");
+    expect(formatBountyPayout("12.5", undefined)).toBe("$12.5 USD");
+  });
+
+  it("makes coin-paid USD bounties unambiguous", () => {
+    expect(formatBountyPayout(1, "SOL")).toBe(
+      "$1 USD value, paid in SOL equivalent"
+    );
+  });
+
+  it("ignores blank payment coin values", () => {
+    expect(formatBountyPayout(5, "  ")).toBe("$5 USD");
+  });
+});

--- a/src/lib/bounties.ts
+++ b/src/lib/bounties.ts
@@ -3,7 +3,8 @@ import { formatCurrency } from "@/lib/utils";
 
 /**
  * Human label for a bounty payout, matching the gig card style:
- * "$2.00 USD (paid in SOL)" when a coin is set, otherwise "$2.00 USD".
+ * "$2.00 USD value, paid in SOL equivalent" when a coin is set,
+ * otherwise "$2.00 USD".
  * Centralized so browse/detail/dashboard stay consistent.
  */
 export function formatBountyPayout(
@@ -12,7 +13,8 @@ export function formatBountyPayout(
 ): string {
   const amount = Number(amountUsd);
   const usd = `${formatCurrency(amount)} USD`;
-  return paymentCoin ? `${usd} (paid in ${paymentCoin})` : usd;
+  const coin = paymentCoin?.trim();
+  return coin ? `${usd} value, paid in ${coin} equivalent` : usd;
 }
 
 export const questionSchema = z.object({


### PR DESCRIPTION
## Summary
- Clarifies bounty payout labels when a USD-denominated bounty is paid in a coin equivalent.
- Treats blank `payment_coin` values as USD-only.
- Adds unit coverage for payout label formatting.

Fixes #401

## Tests
- `./node_modules/.bin/vitest run src/lib/bounties.test.ts src/lib/utils.test.ts`