### PR TITLE
Escape public listing search filters

### DIFF
--- a/src/app/affiliates/page.tsx
+++ b/src/app/affiliates/page.tsx
@@ -9,6 +9,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Megaphone, Users, TrendingUp, Zap } from "lucide-react";
 import { SKILL_CATEGORIES } from "@/lib/constants";
 import { parsePageParam } from "@/lib/pagination";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 
 export const metadata: Metadata = {
   title: "Affiliate Marketplace | ugig.net",
@@ -115,8 +116,9 @@ async function AffiliatesList({ searchParams }: { searchParams: AffiliatesPagePr
   // Limit search param length to prevent oversized queries (#57)
   const searchTerm = queryParams.search?.slice(0, 200);
   if (searchTerm) {
+    const safeSearchTerm = escapePostgrestSearchValue(searchTerm);
     query = query.or(
-      `title.ilike.%${searchTerm}%,description.ilike.%${searchTerm}%`
+      `title.ilike.%${safeSearchTerm}%,description.ilike.%${safeSearchTerm}%`
     );
   }
 

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { FolderOpen, ExternalLink, Zap, ThumbsUp, MessageSquare } from "lucide-react";
 import { parsePageParam } from "@/lib/pagination";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 
 export const metadata: Metadata = {
   title: "Project Directory | ugig.net",
@@ -53,8 +54,9 @@ async function DirectoryList({
     .eq("status", "active");
 
   if (queryParams.search) {
+    const safeSearch = escapePostgrestSearchValue(queryParams.search);
     query = query.or(
-      `title.ilike.%${queryParams.search}%,description.ilike.%${queryParams.search}%`
+      `title.ilike.%${safeSearch}%,description.ilike.%${safeSearch}%`
     );
   }
 

--- a/src/app/for-hire/[[...tags]]/page.tsx
+++ b/src/app/for-hire/[[...tags]]/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
 import { parsePageParam } from "@/lib/pagination";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 import { Briefcase } from "lucide-react";
 
 interface GigsPageProps {
@@ -90,8 +91,9 @@ async function GigsList({
 
   // Filter by search query
   if (queryParams.search) {
+    const safeSearch = escapePostgrestSearchValue(queryParams.search);
     query = query.or(
-      `title.ilike.%${queryParams.search}%,description.ilike.%${queryParams.search}%`
+      `title.ilike.%${safeSearch}%,description.ilike.%${safeSearch}%`
     );
   }
 

--- a/src/app/gigs/[[...tags]]/page.tsx
+++ b/src/app/gigs/[[...tags]]/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
 import { parsePageParam } from "@/lib/pagination";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 import { Briefcase } from "lucide-react";
 
 interface GigsPageProps {
@@ -91,8 +92,9 @@ async function GigsList({
 
   // Filter by search query
   if (queryParams.search) {
+    const safeSearch = escapePostgrestSearchValue(queryParams.search);
     query = query.or(
-      `title.ilike.%${queryParams.search}%,description.ilike.%${queryParams.search}%`
+      `title.ilike.%${safeSearch}%,description.ilike.%${safeSearch}%`
     );
   }
 

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -11,6 +11,7 @@ import { Server, Star, Download, Zap } from "lucide-react";
 import { MCP_CATEGORIES } from "@/lib/constants";
 import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
 import { parsePageParam } from "@/lib/pagination";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 
 export const metadata: Metadata = {
   title: "MCP Server Marketplace | ugig.net",
@@ -69,8 +70,9 @@ async function McpList({ searchParams }: { searchParams: McpPageProps["searchPar
     .eq("status", "active");
 
   if (queryParams.search) {
+    const safeSearch = escapePostgrestSearchValue(queryParams.search);
     query = query.or(
-      `title.ilike.%${queryParams.search}%,description.ilike.%${queryParams.search}%,tagline.ilike.%${queryParams.search}%`
+      `title.ilike.%${safeSearch}%,description.ilike.%${safeSearch}%,tagline.ilike.%${safeSearch}%`
     );
   }
 

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -11,6 +11,7 @@ import { FileText, Star, Download, Zap } from "lucide-react";
 import { PROMPT_CATEGORIES } from "@/lib/constants";
 import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
 import { parsePageParam } from "@/lib/pagination";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 
 export const metadata: Metadata = {
   title: "Prompt Marketplace | ugig.net",
@@ -69,8 +70,9 @@ async function PromptList({ searchParams }: { searchParams: PromptsPageProps["se
     .eq("status", "active");
 
   if (queryParams.search) {
+    const safeSearch = escapePostgrestSearchValue(queryParams.search);
     query = query.or(
-      `title.ilike.%${queryParams.search}%,description.ilike.%${queryParams.search}%,tagline.ilike.%${queryParams.search}%`
+      `title.ilike.%${safeSearch}%,description.ilike.%${safeSearch}%,tagline.ilike.%${safeSearch}%`
     );
   }
 

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -10,6 +10,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Package, Star, Download, Zap, ShieldCheck, ShieldAlert, ShieldX, Shield } from "lucide-react";
 import { SKILL_CATEGORIES, SUPPORTED_AGENT_OPTIONS } from "@/lib/constants";
 import { parsePageParam } from "@/lib/pagination";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 
 export const metadata: Metadata = {
   title: "AI Agent Skills Marketplace | ugig.net",
@@ -68,8 +69,9 @@ async function SkillsList({ searchParams }: { searchParams: SkillsPageProps["sea
     .eq("status", "active");
 
   if (queryParams.search) {
+    const safeSearch = escapePostgrestSearchValue(queryParams.search);
     query = query.or(
-      `title.ilike.%${queryParams.search}%,description.ilike.%${queryParams.search}%,tagline.ilike.%${queryParams.search}%`
+      `title.ilike.%${safeSearch}%,description.ilike.%${safeSearch}%,tagline.ilike.%${safeSearch}%`
     );
   }
 

--- a/src/lib/security/sanitize.test.ts
+++ b/src/lib/security/sanitize.test.ts
@@ -54,8 +54,8 @@ describe("sanitizeSearchParams", () => {
 
 describe("escapePostgrestSearchValue", () => {
   it("escapes LIKE wildcards and PostgREST filter punctuation", () => {
-    expect(escapePostgrestSearchValue("100%_match,(v1.2)")).toBe(
-      "100\\%\\_match\\,\\(v1\\.2\\)"
+    expect(escapePostgrestSearchValue("100%_match*,(v1.2)")).toBe(
+      "100\\%\\_match\\*\\,\\(v1\\.2\\)"
     );
   });
 });

--- a/src/lib/security/sanitize.ts
+++ b/src/lib/security/sanitize.ts
@@ -46,8 +46,9 @@ export function sanitizeSearchParams(
 /**
  * Escape user text before interpolating it into a PostgREST filter string.
  * PostgREST uses punctuation such as commas, periods, and parentheses as
- * filter syntax, while SQL LIKE treats % and _ as wildcards.
+ * filter syntax, while SQL LIKE treats % and _ as wildcards. PostgREST also
+ * accepts * as a % alias in like/ilike filters.
  */
 export function escapePostgrestSearchValue(value: string): string {
-  return value.replace(/[\\%_,().]/g, (char) => `\\${char}`);
+  return value.replace(/[\\%*_,().]/g, (char) => `\\${char}`);
 }


### PR DESCRIPTION
Fixes #408.

Changes:
- escape public listing search terms before composing PostgREST .or(...) filters
- cover directory, skills, prompts, MCP, affiliate, gigs, and for-hire pages
- extend the shared helper regression test for PostgREST's * wildcard alias

Validation:
- vitest run src/lib/security/sanitize.test.ts
- tsc --noEmit