### PR TITLE
Handle malformed JSON in message send API

### DIFF
--- a/src/app/api/messages/send/route.test.ts
+++ b/src/app/api/messages/send/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  getAuthContext: vi.fn(),
+  createAdminClient: vi.fn(),
+  sendEmail: vi.fn(),
+  newMessageEmail: vi.fn(),
+  dispatchWebhookAsync: vi.fn(),
+  isEmailNotificationEnabled: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: mocks.getAuthContext,
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: mocks.createAdminClient,
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendEmail: mocks.sendEmail,
+  newMessageEmail: mocks.newMessageEmail,
+}));
+
+vi.mock("@/lib/webhooks/dispatch", () => ({
+  dispatchWebhookAsync: mocks.dispatchWebhookAsync,
+}));
+
+vi.mock("@/lib/notification-settings", () => ({
+  isEmailNotificationEnabled: mocks.isEmailNotificationEnabled,
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: string) {
+  return new NextRequest("http://localhost/api/messages/send", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+}
+
+describe("POST /api/messages/send", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for malformed JSON instead of a generic 500", async () => {
+    mocks.getAuthContext.mockResolvedValue({
+      user: { id: "sender-1" },
+      supabase: {},
+    });
+
+    const response = await POST(makeRequest("{"));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Invalid JSON body");
+  });
+});

--- a/src/app/api/messages/send/route.ts
+++ b/src/app/api/messages/send/route.ts
@@ -20,7 +20,13 @@ export async function POST(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
     const validationResult = sendMessageSchema.safeParse(body);
 
     if (!validationResult.success) {


### PR DESCRIPTION
## Summary
- return a 400 Invalid JSON body response when POST /api/messages/send receives malformed JSON
- keep the existing Zod validation path unchanged for parsed request bodies
- add regression coverage for the malformed JSON case

Closes #410

## Testing
- ./node_modules/.bin/vitest run src/app/api/messages/send/route.test.ts
- ./node_modules/.bin/eslint src/app/api/messages/send/route.ts src/app/api/messages/send/route.test.ts

Note: the local pre-commit hook could not run through pnpm because pnpm failed before lint with a cache sqlite error (unable to open database file). I ran the scoped Vitest and ESLint commands directly through node_modules instead.