### PR TITLE
[codex] Validate affiliate product_url update type

### DIFF
--- a/src/app/api/affiliates/offers/[id]/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/route.test.ts
@@ -187,6 +187,17 @@ describe("PATCH /api/affiliates/offers/[id] - product_url validation (#137)", ()
     expect(body.error).toContain("product_url");
   });
 
+  it("rejects non-string product_url values without falling through to a 500", async () => {
+    const res = await PATCH(
+      makeRequest("offer-1", { product_url: 123 }),
+      makeParams("offer-1")
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("product_url");
+    expect(body.error).toContain("string");
+  });
+
   it("accepts valid https URL in product_url (#137)", async () => {
     // Mock the update chain to succeed
     mockFrom.mockReturnValue(chainable({ id: "offer-1", product_url: "https://example.com/product" }));

--- a/src/app/api/affiliates/offers/[id]/route.ts
+++ b/src/app/api/affiliates/offers/[id]/route.ts
@@ -103,10 +103,14 @@ export async function PATCH(
     if (body.title !== undefined) updateData.title = body.title.trim();
     if (body.description !== undefined) updateData.description = body.description.trim();
     if (body.product_url !== undefined) {
-      if (body.product_url && body.product_url.trim().length > 0 && !isValidUrl(body.product_url.trim())) {
+      if (body.product_url !== null && typeof body.product_url !== "string") {
+        return NextResponse.json({ error: "product_url must be a string" }, { status: 400 });
+      }
+      const productUrl = typeof body.product_url === "string" ? body.product_url.trim() : "";
+      if (productUrl.length > 0 && !isValidUrl(productUrl)) {
         return NextResponse.json({ error: "product_url must use http:// or https:// scheme" }, { status: 400 });
       }
-      updateData.product_url = body.product_url.trim() || null;
+      updateData.product_url = productUrl || null;
     }
     if (body.product_type !== undefined) updateData.product_type = body.product_type;
     if (body.price_sats !== undefined) updateData.price_sats = body.price_sats;


### PR DESCRIPTION
## Summary

- return 400 when affiliate offer `product_url` updates are not strings
- keep empty string / null behavior as clearing the product URL
- add a regression test for `product_url: 123` so malformed JSON does not fall through to the generic 500 path

Fixes #416.

## Validation

- `npm.cmd run test:run -- "src/app/api/affiliates/offers/[id]/route.test.ts"`
- `npm.cmd run type-check`