### PR TITLE
[codex] Validate affiliate offer text field types

### DIFF
--- a/src/lib/affiliates/validation.test.ts
+++ b/src/lib/affiliates/validation.test.ts
@@ -105,6 +105,19 @@ describe("validateOfferInput", () => {
     expect(result.errors.some((e) => e.includes("price_sats"))).toBe(true);
   });
 
+  it("rejects non-string title, description, and product_url before string sanitizers run", () => {
+    const titleResult = validateOfferInput({ ...validInput, title: 123 as any });
+    const descriptionResult = validateOfferInput({ ...validInput, description: 123 as any });
+    const productUrlResult = validateOfferInput({ ...validInput, product_url: 123 as any });
+
+    expect(titleResult.ok).toBe(false);
+    expect(titleResult.errors.some((e) => e.includes("title") && e.includes("string"))).toBe(true);
+    expect(descriptionResult.ok).toBe(false);
+    expect(descriptionResult.errors.some((e) => e.includes("description") && e.includes("string"))).toBe(true);
+    expect(productUrlResult.ok).toBe(false);
+    expect(productUrlResult.errors.some((e) => e.includes("product_url") && e.includes("string"))).toBe(true);
+  });
+
   it("trims whitespace-only product_url to undefined", () => {
     const result = validateOfferInput({
       ...validInput,

--- a/src/lib/affiliates/validation.ts
+++ b/src/lib/affiliates/validation.ts
@@ -41,26 +41,37 @@ export function validateOfferInput(input: OfferInput): ValidationResult {
   const errors: string[] = [];
 
   // Strip HTML tags from title and description (#26)
-  if (input.title) {
-    input.title = stripHtmlTags(input.title);
-  }
-  if (input.description) {
-    input.description = stripHtmlTags(input.description);
+  if (input.title !== undefined && typeof input.title !== "string") {
+    errors.push("title must be a string");
+  } else {
+    if (input.title) {
+      input.title = stripHtmlTags(input.title);
+    }
+
+    if (!input.title || input.title.trim().length < 3) {
+      errors.push("Title must be at least 3 characters");
+    }
+    if (input.title && input.title.length > 200) {
+      errors.push("Title must be under 200 characters");
+    }
   }
 
-  if (!input.title || input.title.trim().length < 3) {
-    errors.push("Title must be at least 3 characters");
-  }
-  if (input.title && input.title.length > 200) {
-    errors.push("Title must be under 200 characters");
-  }
+  if (input.description !== undefined && typeof input.description !== "string") {
+    errors.push("description must be a string");
+  } else {
+    if (input.description) {
+      input.description = stripHtmlTags(input.description);
+    }
 
-  if (!input.description || input.description.trim().length < 10) {
-    errors.push("Description must be at least 10 characters");
+    if (!input.description || input.description.trim().length < 10) {
+      errors.push("Description must be at least 10 characters");
+    }
   }
 
   // Normalize product_url — trim whitespace, treat blank as null (#18 - XSS prevention)
-  if (input.product_url) {
+  if (input.product_url !== undefined && input.product_url !== null && typeof input.product_url !== "string") {
+    errors.push("product_url must be a string");
+  } else if (input.product_url) {
     input.product_url = input.product_url.trim();
     if (input.product_url.length === 0) {
       input.product_url = undefined;


### PR DESCRIPTION
## Summary

- reject non-string `title`, `description`, and `product_url` values before string sanitizers run
- keep existing title/description HTML stripping and URL validation behavior for valid strings
- add regression coverage for malformed create-offer text fields

Fixes #420.

## Validation

- `npm.cmd run test:run -- src/lib/affiliates/validation.test.ts`
- `npm.cmd run type-check`