### PR TITLE
Validate affiliate payout conversion_id before querying conversions

### DIFF
--- a/src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts
@@ -54,6 +54,35 @@ describe("POST /api/affiliates/offers/[id]/conversions/pay", () => {
     vi.clearAllMocks();
   });
 
+  it("rejects non-string conversion_id before querying conversions (#422)", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "seller-1", authMethod: "session" },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "affiliate_offers") {
+        return chainable({
+          id: "offer-1",
+          seller_id: "seller-1",
+        });
+      }
+      return chainable(null);
+    });
+
+    const res = await POST(
+      makePostRequest("offer-1", { conversion_id: { id: "conv-1" } }),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "conversion_id must be a non-empty string",
+    });
+    expect(mockFrom).not.toHaveBeenCalledWith("affiliate_conversions");
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
+    expect(mockInternalTransfer).not.toHaveBeenCalled();
+  });
+
   it("rejects pending conversions before their settlement date", async () => {
     mockGetAuthContext.mockResolvedValue({
       user: { id: "seller-1", authMethod: "session" },

--- a/src/app/api/affiliates/offers/[id]/conversions/pay/route.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/pay/route.ts
@@ -37,15 +37,19 @@ export async function POST(
     const body = await request.json();
     const { conversion_id } = body;
 
-    if (!conversion_id) {
-      return NextResponse.json({ error: "conversion_id is required" }, { status: 400 });
+    if (typeof conversion_id !== "string" || conversion_id.trim() === "") {
+      return NextResponse.json(
+        { error: "conversion_id must be a non-empty string" },
+        { status: 400 }
+      );
     }
+    const conversionId = conversion_id.trim();
 
     // Get the conversion
     const { data: conv } = await (admin as AnySupabase)
       .from("affiliate_conversions")
       .select("id, affiliate_id, commission_sats, status, settles_at")
-      .eq("id", conversion_id)
+      .eq("id", conversionId)
       .eq("offer_id", id)
       .single();
 
@@ -104,7 +108,7 @@ export async function POST(
         status: "paid",
         paid_at: new Date().toISOString(),
       })
-      .eq("id", conversion_id);
+      .eq("id", conversionId);
 
     // Record wallet transactions for both parties
     await (admin as AnySupabase)


### PR DESCRIPTION
## Summary

- reject non-string or blank `conversion_id` values in the affiliate conversion payout endpoint
- trim the validated id before using it in Supabase filters
- add a regression test that proves malformed ids are rejected before querying `affiliate_conversions`

Fixes #422.

## Validation

- `npm.cmd run test:run -- "src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts"`
- `npm.cmd run type-check`