### PR TITLE
Show clear filters for empty gig searches

### DIFF
--- a/src/app/gigs/[[...tags]]/page.tsx
+++ b/src/app/gigs/[[...tags]]/page.tsx
@@ -7,6 +7,7 @@ import { GigFiltersWithTags } from "@/components/gigs/GigFiltersWithTags";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import { hasActiveGigFilters } from "@/lib/gigs/filter-state";
 import { parsePageParam } from "@/lib/pagination";
 import { Briefcase } from "lucide-react";
 
@@ -152,18 +153,19 @@ async function GigsList({
   query = query.range(offset, offset + limit - 1);
 
   const { data: gigs, count } = await query;
+  const hasActiveFilters = hasActiveGigFilters(queryParams, tagList);
 
   if (!gigs || gigs.length === 0) {
     return (
       <div className="text-center py-12 bg-muted/30 rounded-lg">
         <Briefcase className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
         <p className="text-muted-foreground mb-2">
-          {tagList.length > 0 || queryParams.search
+          {hasActiveFilters
             ? "No gigs found matching your criteria."
             : "No gigs posted yet. Be the first to post one!"}
         </p>
         <div className="flex items-center justify-center gap-3 mt-4">
-          {tagList.length > 0 && (
+          {hasActiveFilters && (
             <Link href="/gigs" className="text-primary hover:underline">
               Clear filters
             </Link>

--- a/src/lib/gigs/filter-state.test.ts
+++ b/src/lib/gigs/filter-state.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { hasActiveGigFilters } from "./filter-state";
+
+describe("hasActiveGigFilters", () => {
+  it("treats a search query as an active filter", () => {
+    expect(hasActiveGigFilters({ search: "zzzzzzzz-nomatch" })).toBe(true);
+  });
+
+  it("treats supported gig filters as active", () => {
+    expect(hasActiveGigFilters({ category: "Development" })).toBe(true);
+    expect(hasActiveGigFilters({ location_type: "remote" })).toBe(true);
+    expect(hasActiveGigFilters({ budget_type: "fixed" })).toBe(true);
+    expect(hasActiveGigFilters({ sort: "budget_high" })).toBe(true);
+    expect(hasActiveGigFilters({}, ["TypeScript"])).toBe(true);
+  });
+
+  it("ignores empty values and the default sort", () => {
+    expect(
+      hasActiveGigFilters({
+        search: " ",
+        category: "",
+        location_type: "invalid",
+        budget_type: " ",
+        sort: "newest",
+      })
+    ).toBe(false);
+  });
+});

--- a/src/lib/gigs/filter-state.test.ts
+++ b/src/lib/gigs/filter-state.test.ts
@@ -14,13 +14,17 @@ describe("hasActiveGigFilters", () => {
     expect(hasActiveGigFilters({}, ["TypeScript"])).toBe(true);
   });
 
+  it("treats skill query params as active filters", () => {
+    expect(hasActiveGigFilters({ skill: "typescript" })).toBe(true);
+  });
+
   it("ignores empty values and the default sort", () => {
     expect(
       hasActiveGigFilters({
         search: " ",
         category: "",
         location_type: "invalid",
-        budget_type: " ",
+        budget_type: "invalid",
         sort: "newest",
       })
     ).toBe(false);

--- a/src/lib/gigs/filter-state.ts
+++ b/src/lib/gigs/filter-state.ts
@@ -1,0 +1,28 @@
+export interface GigFilterSearchParams {
+  search?: string;
+  category?: string;
+  location_type?: string;
+  budget_type?: string;
+  sort?: string;
+  skill?: string;
+}
+
+const LOCATION_FILTERS = new Set(["remote", "onsite", "hybrid"]);
+const DEFAULT_SORT = "newest";
+
+const hasText = (value?: string) => Boolean(value?.trim());
+
+export function hasActiveGigFilters(
+  queryParams: GigFilterSearchParams,
+  tags: string[] = []
+) {
+  return (
+    tags.some(hasText) ||
+    hasText(queryParams.skill) ||
+    hasText(queryParams.search) ||
+    hasText(queryParams.category) ||
+    hasText(queryParams.budget_type) ||
+    LOCATION_FILTERS.has(queryParams.location_type || "") ||
+    (hasText(queryParams.sort) && queryParams.sort !== DEFAULT_SORT)
+  );
+}

--- a/src/lib/gigs/filter-state.ts
+++ b/src/lib/gigs/filter-state.ts
@@ -8,6 +8,18 @@ export interface GigFilterSearchParams {
 }
 
 const LOCATION_FILTERS = new Set(["remote", "onsite", "hybrid"]);
+const BUDGET_FILTERS = new Set([
+  "fixed",
+  "hourly",
+  "daily",
+  "weekly",
+  "monthly",
+  "yearly",
+  "per_task",
+  "per_unit",
+  "revenue_share",
+  "bounty",
+]);
 const DEFAULT_SORT = "newest";
 
 const hasText = (value?: string) => Boolean(value?.trim());
@@ -21,7 +33,7 @@ export function hasActiveGigFilters(
     hasText(queryParams.skill) ||
     hasText(queryParams.search) ||
     hasText(queryParams.category) ||
-    hasText(queryParams.budget_type) ||
+    BUDGET_FILTERS.has(queryParams.budget_type || "") ||
     LOCATION_FILTERS.has(queryParams.location_type || "") ||
     (hasText(queryParams.sort) && queryParams.sort !== DEFAULT_SORT)
   );


### PR DESCRIPTION
## Summary
- show the Clear filters action on the gigs empty state whenever any supported filter is active
- share the active-filter check across search, category, location type, budget type, sort, and skill tags
- add focused unit coverage for the filter-state helper

## Tests
- ./node_modules/.bin/vitest run src/lib/gigs/filter-state.test.ts
- ./node_modules/.bin/eslint 'src/app/gigs/[[...tags]]/page.tsx' src/lib/gigs/filter-state.ts src/lib/gigs/filter-state.test.ts
- ./node_modules/.bin/tsc --noEmit

Fixes #424