### PR TITLE
Show clear filters for empty agent and candidate searches

### DIFF
--- a/src/app/agents/[[...tags]]/page.tsx
+++ b/src/app/agents/[[...tags]]/page.tsx
@@ -7,6 +7,7 @@ import { AgentLoadMore } from "@/components/agents/AgentLoadMore";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import { hasActiveDirectoryFilters } from "@/lib/directory/filter-state";
 import { Bot } from "lucide-react";
 
 interface AgentsPageProps {
@@ -72,6 +73,7 @@ async function AgentsList({
   });
 
   const { data: agents, count } = await query;
+  const hasActiveFilters = hasActiveDirectoryFilters(queryParams, tagList);
 
   // Build fetch URL for Load More
   const fetchParams = new URLSearchParams();
@@ -86,12 +88,12 @@ async function AgentsList({
       <div className="text-center py-12 bg-muted/30 rounded-lg">
         <Bot className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
         <p className="text-muted-foreground mb-2">
-          {tagList.length > 0
+          {hasActiveFilters
             ? "No agents found matching your criteria."
             : "No AI agents registered yet. Register yours and be the first!"}
         </p>
         <div className="flex items-center justify-center gap-3 mt-4">
-          {tagList.length > 0 && (
+          {hasActiveFilters && (
             <Link href="/agents" className="text-primary hover:underline">
               Clear filters
             </Link>

--- a/src/app/candidates/[[...tags]]/page.tsx
+++ b/src/app/candidates/[[...tags]]/page.tsx
@@ -7,6 +7,7 @@ import { CandidateLoadMore } from "@/components/candidates/CandidateLoadMore";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import { hasActiveDirectoryFilters } from "@/lib/directory/filter-state";
 import { Users } from "lucide-react";
 
 interface CandidatesPageProps {
@@ -72,6 +73,7 @@ async function CandidatesList({
   });
 
   const { data: candidates, count } = await query;
+  const hasActiveFilters = hasActiveDirectoryFilters(queryParams, tagList);
 
   // Build fetch URL for Load More
   const fetchParams = new URLSearchParams();
@@ -86,12 +88,12 @@ async function CandidatesList({
       <div className="text-center py-12 bg-muted/30 rounded-lg">
         <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
         <p className="text-muted-foreground mb-2">
-          {tagList.length > 0
+          {hasActiveFilters
             ? "No candidates found matching your criteria."
             : "No candidates have signed up yet. Join and be the first!"}
         </p>
         <div className="flex items-center justify-center gap-3 mt-4">
-          {tagList.length > 0 && (
+          {hasActiveFilters && (
             <Link href="/candidates" className="text-primary hover:underline">
               Clear filters
             </Link>

--- a/src/lib/directory/filter-state.test.ts
+++ b/src/lib/directory/filter-state.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { hasActiveDirectoryFilters } from "./filter-state";
+
+describe("hasActiveDirectoryFilters", () => {
+  it("detects filters that can narrow directory results", () => {
+    expect(hasActiveDirectoryFilters({ q: "nomatch" })).toBe(true);
+    expect(hasActiveDirectoryFilters({ available: "true" })).toBe(true);
+    expect(hasActiveDirectoryFilters({}, ["TypeScript"])).toBe(true);
+  });
+
+  it("ignores empty and inactive values", () => {
+    expect(hasActiveDirectoryFilters({})).toBe(false);
+    expect(hasActiveDirectoryFilters({ q: " ", available: "false" }, [""])).toBe(
+      false
+    );
+  });
+});

--- a/src/lib/directory/filter-state.ts
+++ b/src/lib/directory/filter-state.ts
@@ -1,0 +1,17 @@
+export interface DirectoryFilterSearchParams {
+  q?: string;
+  available?: string;
+}
+
+const hasText = (value?: string) => Boolean(value?.trim());
+
+export function hasActiveDirectoryFilters(
+  queryParams: DirectoryFilterSearchParams,
+  tags: string[] = []
+) {
+  return (
+    tags.some(hasText) ||
+    hasText(queryParams.q) ||
+    queryParams.available === "true"
+  );
+}


### PR DESCRIPTION
## What changed
- detect active search, availability, and skill filters with a shared directory helper
- show accurate filtered-result empty states on agent and candidate directories
- offer a Clear filters link for every filter that can narrow results
- add focused unit coverage for active and inactive filter states

## Why
Filtered agent and candidate searches can return no results while incorrectly claiming that no profiles have registered and leaving users without a reset action.

## Validation
- `npm run test:run -- src/lib/directory/filter-state.test.ts`
- `npm run type-check`

Fixes #426