### PR TITLE
Preserve availability when sorting agent and candidate directories

### DIFF
--- a/src/app/agents/[[...tags]]/page.tsx
+++ b/src/app/agents/[[...tags]]/page.tsx
@@ -7,6 +7,7 @@ import { AgentLoadMore } from "@/components/agents/AgentLoadMore";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import { buildDirectoryUrl } from "@/lib/directory-url";
 import { Bot } from "lucide-react";
 
 interface AgentsPageProps {
@@ -164,7 +165,12 @@ export default async function AgentsPage({ params, searchParams }: AgentsPagePro
           <div className="flex flex-wrap gap-4 mt-6 mb-6">
             <div className="flex items-center gap-2">
               <span className="text-sm text-muted-foreground">Sort:</span>
-              <SortSelect currentSort={queryParams.sort} tags={tagList} search={queryParams.q} />
+              <SortSelect
+                currentSort={queryParams.sort}
+                tags={tagList}
+                search={queryParams.q}
+                available={queryParams.available === "true"}
+              />
             </div>
             <div className="flex items-center gap-2">
               <AvailabilityToggle
@@ -192,19 +198,15 @@ function SortSelect({
   currentSort,
   tags,
   search,
+  available,
 }: {
   currentSort?: string;
   tags: string[];
   search?: string;
+  available: boolean;
 }) {
-  const buildUrl = (sort: string) => {
-    const params = new URLSearchParams();
-    if (search) params.set("q", search);
-    if (sort && sort !== "newest") params.set("sort", sort);
-    const tagPath = tags.length > 0 ? `/${tags.map(encodeURIComponent).join(",")}` : "";
-    const queryString = params.toString();
-    return `/agents${tagPath}${queryString ? `?${queryString}` : ""}`;
-  };
+  const buildUrl = (sort: string) =>
+    buildDirectoryUrl({ path: "/agents", tags, search, sort, available });
 
   return (
     <div className="flex gap-1">

--- a/src/app/candidates/[[...tags]]/page.tsx
+++ b/src/app/candidates/[[...tags]]/page.tsx
@@ -7,6 +7,7 @@ import { CandidateLoadMore } from "@/components/candidates/CandidateLoadMore";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import { buildDirectoryUrl } from "@/lib/directory-url";
 import { Users } from "lucide-react";
 
 interface CandidatesPageProps {
@@ -164,7 +165,12 @@ export default async function CandidatesPage({ params, searchParams }: Candidate
           <div className="flex flex-wrap gap-4 mt-6 mb-6">
             <div className="flex items-center gap-2">
               <span className="text-sm text-muted-foreground">Sort:</span>
-              <SortSelect currentSort={queryParams.sort} tags={tagList} search={queryParams.q} />
+              <SortSelect
+                currentSort={queryParams.sort}
+                tags={tagList}
+                search={queryParams.q}
+                available={queryParams.available === "true"}
+              />
             </div>
             <div className="flex items-center gap-2">
               <AvailabilityToggle
@@ -192,19 +198,15 @@ function SortSelect({
   currentSort,
   tags,
   search,
+  available,
 }: {
   currentSort?: string;
   tags: string[];
   search?: string;
+  available: boolean;
 }) {
-  const buildUrl = (sort: string) => {
-    const params = new URLSearchParams();
-    if (search) params.set("q", search);
-    if (sort && sort !== "newest") params.set("sort", sort);
-    const tagPath = tags.length > 0 ? `/${tags.map(encodeURIComponent).join(",")}` : "";
-    const queryString = params.toString();
-    return `/candidates${tagPath}${queryString ? `?${queryString}` : ""}`;
-  };
+  const buildUrl = (sort: string) =>
+    buildDirectoryUrl({ path: "/candidates", tags, search, sort, available });
 
   return (
     <div className="flex gap-1">

--- a/src/lib/directory-url.test.ts
+++ b/src/lib/directory-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildDirectoryUrl } from "./directory-url";
+
+describe("buildDirectoryUrl", () => {
+  it("preserves availability while changing directory sort", () => {
+    expect(
+      buildDirectoryUrl({
+        path: "/agents",
+        sort: "rate_high",
+        available: true,
+      })
+    ).toBe("/agents?sort=rate_high&available=true");
+  });
+
+  it("builds candidate URLs with search and encoded tags", () => {
+    expect(
+      buildDirectoryUrl({
+        path: "/candidates",
+        tags: ["Next.js", "AI/ML"],
+        search: "frontend",
+      })
+    ).toBe("/candidates/Next.js,AI%2FML?q=frontend");
+  });
+});

--- a/src/lib/directory-url.ts
+++ b/src/lib/directory-url.ts
@@ -1,0 +1,25 @@
+interface DirectoryUrlOptions {
+  path: "/agents" | "/candidates";
+  tags?: string[];
+  search?: string;
+  sort?: string;
+  available?: boolean;
+}
+
+export function buildDirectoryUrl({
+  path,
+  tags = [],
+  search,
+  sort,
+  available,
+}: DirectoryUrlOptions) {
+  const params = new URLSearchParams();
+  if (search) params.set("q", search);
+  if (sort && sort !== "newest") params.set("sort", sort);
+  if (available) params.set("available", "true");
+
+  const tagPath =
+    tags.length > 0 ? `/${tags.map(encodeURIComponent).join(",")}` : "";
+  const queryString = params.toString();
+  return `${path}${tagPath}${queryString ? `?${queryString}` : ""}`;
+}


### PR DESCRIPTION
## What changed
- build agent and candidate control URLs with a shared helper
- preserve `available=true` when users change directory sort
- keep search and encoded skill tags intact
- add regression coverage for combined directory filters

## Why
Changing directory sort currently drops the active availability filter and silently broadens the results.

## Validation
- `npm run test:run -- src/lib/directory-url.test.ts`
- `npm run type-check`

Fixes #428