### PR TITLE
Preserve directory filters

### DIFF
--- a/src/app/agents/[[...tags]]/page.tsx
+++ b/src/app/agents/[[...tags]]/page.tsx
@@ -7,6 +7,10 @@ import { AgentLoadMore } from "@/components/agents/AgentLoadMore";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import {
+  buildDirectoryFilterUrl,
+  hasActiveDirectoryFilters,
+} from "@/lib/directory/filter-state";
 import { Bot } from "lucide-react";
 
 interface AgentsPageProps {
@@ -80,18 +84,19 @@ async function AgentsList({
   if (queryParams.available) fetchParams.set("available", queryParams.available);
   if (tagList.length > 0) fetchParams.set("tags", tagList.join(","));
   const fetchUrl = `/api/agents?${fetchParams.toString()}`;
+  const hasActiveFilters = hasActiveDirectoryFilters(queryParams, tagList);
 
   if (!agents || agents.length === 0) {
     return (
       <div className="text-center py-12 bg-muted/30 rounded-lg">
         <Bot className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
         <p className="text-muted-foreground mb-2">
-          {tagList.length > 0
+          {hasActiveFilters
             ? "No agents found matching your criteria."
             : "No AI agents registered yet. Register yours and be the first!"}
         </p>
         <div className="flex items-center justify-center gap-3 mt-4">
-          {tagList.length > 0 && (
+          {hasActiveFilters && (
             <Link href="/agents" className="text-primary hover:underline">
               Clear filters
             </Link>
@@ -157,14 +162,24 @@ export default async function AgentsPage({ params, searchParams }: AgentsPagePro
           </p>
 
           <Suspense fallback={<div className="h-48" />}>
-            <AgentFilters activeTags={tagList} search={queryParams.q} />
+            <AgentFilters
+              activeTags={tagList}
+              available={queryParams.available}
+              search={queryParams.q}
+              sort={queryParams.sort}
+            />
           </Suspense>
 
           {/* Sort & Availability filters */}
           <div className="flex flex-wrap gap-4 mt-6 mb-6">
             <div className="flex items-center gap-2">
               <span className="text-sm text-muted-foreground">Sort:</span>
-              <SortSelect currentSort={queryParams.sort} tags={tagList} search={queryParams.q} />
+              <SortSelect
+                available={queryParams.available}
+                currentSort={queryParams.sort}
+                tags={tagList}
+                search={queryParams.q}
+              />
             </div>
             <div className="flex items-center gap-2">
               <AvailabilityToggle
@@ -189,22 +204,18 @@ export default async function AgentsPage({ params, searchParams }: AgentsPagePro
 }
 
 function SortSelect({
+  available,
   currentSort,
   tags,
   search,
 }: {
+  available?: string;
   currentSort?: string;
   tags: string[];
   search?: string;
 }) {
-  const buildUrl = (sort: string) => {
-    const params = new URLSearchParams();
-    if (search) params.set("q", search);
-    if (sort && sort !== "newest") params.set("sort", sort);
-    const tagPath = tags.length > 0 ? `/${tags.map(encodeURIComponent).join(",")}` : "";
-    const queryString = params.toString();
-    return `/agents${tagPath}${queryString ? `?${queryString}` : ""}`;
-  };
+  const buildUrl = (sort: string) =>
+    buildDirectoryFilterUrl("agents", tags, { available, q: search, sort });
 
   return (
     <div className="flex gap-1">
@@ -247,15 +258,12 @@ function AvailabilityToggle({
   search?: string;
   sort?: string;
 }) {
-  const buildUrl = (available: boolean) => {
-    const params = new URLSearchParams();
-    if (search) params.set("q", search);
-    if (sort) params.set("sort", sort);
-    if (available) params.set("available", "true");
-    const tagPath = tags.length > 0 ? `/${tags.map(encodeURIComponent).join(",")}` : "";
-    const queryString = params.toString();
-    return `/agents${tagPath}${queryString ? `?${queryString}` : ""}`;
-  };
+  const buildUrl = (available: boolean) =>
+    buildDirectoryFilterUrl("agents", tags, {
+      available: available ? "true" : undefined,
+      q: search,
+      sort,
+    });
 
   return (
     <Link href={buildUrl(!isAvailable)}>

--- a/src/app/candidates/[[...tags]]/page.tsx
+++ b/src/app/candidates/[[...tags]]/page.tsx
@@ -7,6 +7,10 @@ import { CandidateLoadMore } from "@/components/candidates/CandidateLoadMore";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
+import {
+  buildDirectoryFilterUrl,
+  hasActiveDirectoryFilters,
+} from "@/lib/directory/filter-state";
 import { Users } from "lucide-react";
 
 interface CandidatesPageProps {
@@ -80,18 +84,19 @@ async function CandidatesList({
   if (queryParams.available) fetchParams.set("available", queryParams.available);
   if (tagList.length > 0) fetchParams.set("tags", tagList.join(","));
   const fetchUrl = `/api/candidates?${fetchParams.toString()}`;
+  const hasActiveFilters = hasActiveDirectoryFilters(queryParams, tagList);
 
   if (!candidates || candidates.length === 0) {
     return (
       <div className="text-center py-12 bg-muted/30 rounded-lg">
         <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
         <p className="text-muted-foreground mb-2">
-          {tagList.length > 0
+          {hasActiveFilters
             ? "No candidates found matching your criteria."
             : "No candidates have signed up yet. Join and be the first!"}
         </p>
         <div className="flex items-center justify-center gap-3 mt-4">
-          {tagList.length > 0 && (
+          {hasActiveFilters && (
             <Link href="/candidates" className="text-primary hover:underline">
               Clear filters
             </Link>
@@ -157,14 +162,24 @@ export default async function CandidatesPage({ params, searchParams }: Candidate
           </p>
 
           <Suspense fallback={<div className="h-48" />}>
-            <CandidateFilters activeTags={tagList} search={queryParams.q} />
+            <CandidateFilters
+              activeTags={tagList}
+              available={queryParams.available}
+              search={queryParams.q}
+              sort={queryParams.sort}
+            />
           </Suspense>
 
           {/* Sort & Availability filters */}
           <div className="flex flex-wrap gap-4 mt-6 mb-6">
             <div className="flex items-center gap-2">
               <span className="text-sm text-muted-foreground">Sort:</span>
-              <SortSelect currentSort={queryParams.sort} tags={tagList} search={queryParams.q} />
+              <SortSelect
+                available={queryParams.available}
+                currentSort={queryParams.sort}
+                tags={tagList}
+                search={queryParams.q}
+              />
             </div>
             <div className="flex items-center gap-2">
               <AvailabilityToggle
@@ -189,22 +204,18 @@ export default async function CandidatesPage({ params, searchParams }: Candidate
 }
 
 function SortSelect({
+  available,
   currentSort,
   tags,
   search,
 }: {
+  available?: string;
   currentSort?: string;
   tags: string[];
   search?: string;
 }) {
-  const buildUrl = (sort: string) => {
-    const params = new URLSearchParams();
-    if (search) params.set("q", search);
-    if (sort && sort !== "newest") params.set("sort", sort);
-    const tagPath = tags.length > 0 ? `/${tags.map(encodeURIComponent).join(",")}` : "";
-    const queryString = params.toString();
-    return `/candidates${tagPath}${queryString ? `?${queryString}` : ""}`;
-  };
+  const buildUrl = (sort: string) =>
+    buildDirectoryFilterUrl("candidates", tags, { available, q: search, sort });
 
   return (
     <div className="flex gap-1">
@@ -247,15 +258,12 @@ function AvailabilityToggle({
   search?: string;
   sort?: string;
 }) {
-  const buildUrl = (available: boolean) => {
-    const params = new URLSearchParams();
-    if (search) params.set("q", search);
-    if (sort) params.set("sort", sort);
-    if (available) params.set("available", "true");
-    const tagPath = tags.length > 0 ? `/${tags.map(encodeURIComponent).join(",")}` : "";
-    const queryString = params.toString();
-    return `/candidates${tagPath}${queryString ? `?${queryString}` : ""}`;
-  };
+  const buildUrl = (available: boolean) =>
+    buildDirectoryFilterUrl("candidates", tags, {
+      available: available ? "true" : undefined,
+      q: search,
+      sort,
+    });
 
   return (
     <Link href={buildUrl(!isAvailable)}>

--- a/src/components/agents/AgentFilters.tsx
+++ b/src/components/agents/AgentFilters.tsx
@@ -6,29 +6,33 @@ import { Search, X, Plus } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { buildDirectoryFilterUrl } from "@/lib/directory/filter-state";
 import { SKILLS, AI_TOOLS } from "@/types";
 
 interface AgentFiltersProps {
   activeTags: string[];
+  available?: string;
   search?: string;
+  sort?: string;
 }
 
-export function AgentFilters({ activeTags, search }: AgentFiltersProps) {
+export function AgentFilters({
+  activeTags,
+  available,
+  search,
+  sort,
+}: AgentFiltersProps) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState(search || "");
   const [showAllSkills, setShowAllSkills] = useState(false);
   const [showAllTools, setShowAllTools] = useState(false);
 
-  const buildUrl = (tags: string[], newSearch?: string) => {
-    const params = new URLSearchParams();
-    if (newSearch) {
-      params.set("q", newSearch);
-    }
-    if (tags.length > 0) {
-      return `/agents/${tags.map(encodeURIComponent).join(",")}${params.toString() ? `?${params.toString()}` : ""}`;
-    }
-    return `/agents${params.toString() ? `?${params.toString()}` : ""}`;
-  };
+  const buildUrl = (tags: string[], newSearch?: string) =>
+    buildDirectoryFilterUrl("agents", tags, {
+      available,
+      q: newSearch,
+      sort,
+    });
 
   const addTag = (tag: string) => {
     if (!activeTags.includes(tag)) {

--- a/src/components/candidates/CandidateFilters.tsx
+++ b/src/components/candidates/CandidateFilters.tsx
@@ -6,31 +6,37 @@ import { Search, X, Plus } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { buildDirectoryFilterUrl } from "@/lib/directory/filter-state";
 import { SKILLS, AI_TOOLS } from "@/types";
 
 interface CandidateFiltersProps {
   activeTags: string[];
+  available?: string;
   search?: string;
+  sort?: string;
   accountType?: string;
   onAccountTypeChange?: (type: string | undefined) => void;
 }
 
-export function CandidateFilters({ activeTags, search, accountType, onAccountTypeChange }: CandidateFiltersProps) {
+export function CandidateFilters({
+  activeTags,
+  available,
+  search,
+  sort,
+  accountType,
+  onAccountTypeChange,
+}: CandidateFiltersProps) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState(search || "");
   const [showAllSkills, setShowAllSkills] = useState(false);
   const [showAllTools, setShowAllTools] = useState(false);
 
-  const buildUrl = (tags: string[], newSearch?: string) => {
-    const params = new URLSearchParams();
-    if (newSearch) {
-      params.set("q", newSearch);
-    }
-    if (tags.length > 0) {
-      return `/candidates/${tags.map(encodeURIComponent).join(",")}${params.toString() ? `?${params.toString()}` : ""}`;
-    }
-    return `/candidates${params.toString() ? `?${params.toString()}` : ""}`;
-  };
+  const buildUrl = (tags: string[], newSearch?: string) =>
+    buildDirectoryFilterUrl("candidates", tags, {
+      available,
+      q: newSearch,
+      sort,
+    });
 
   const addTag = (tag: string) => {
     if (!activeTags.includes(tag)) {

--- a/src/lib/directory/filter-state.test.ts
+++ b/src/lib/directory/filter-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDirectoryFilterUrl,
+  hasActiveDirectoryFilters,
+} from "./filter-state";
+
+describe("hasActiveDirectoryFilters", () => {
+  it("treats search, availability, and tags as active filters", () => {
+    expect(hasActiveDirectoryFilters({ q: "nomatch" })).toBe(true);
+    expect(hasActiveDirectoryFilters({ available: "true" })).toBe(true);
+    expect(hasActiveDirectoryFilters({}, ["TypeScript"])).toBe(true);
+  });
+
+  it("ignores empty values, inactive availability, and sort-only changes", () => {
+    expect(
+      hasActiveDirectoryFilters({
+        q: " ",
+        available: "false",
+        sort: "rate_high",
+      })
+    ).toBe(false);
+  });
+});
+
+describe("buildDirectoryFilterUrl", () => {
+  it("preserves active filters when building sort links", () => {
+    expect(
+      buildDirectoryFilterUrl("agents", ["React"], {
+        q: " alice ",
+        available: "true",
+        sort: "rate_high",
+      })
+    ).toBe("/agents/React?q=alice&available=true&sort=rate_high");
+  });
+
+  it("omits inactive filters and the default sort", () => {
+    expect(
+      buildDirectoryFilterUrl("candidates", [], {
+        q: " ",
+        available: "false",
+        sort: "newest",
+      })
+    ).toBe("/candidates");
+  });
+});

--- a/src/lib/directory/filter-state.ts
+++ b/src/lib/directory/filter-state.ts
@@ -1,0 +1,40 @@
+export interface DirectoryFilterSearchParams {
+  q?: string;
+  sort?: string;
+  available?: string;
+}
+
+const DEFAULT_SORT = "newest";
+
+const hasText = (value?: string) => Boolean(value?.trim());
+
+export function hasActiveDirectoryFilters(
+  queryParams: DirectoryFilterSearchParams,
+  tags: string[] = []
+) {
+  return (
+    tags.some(hasText) ||
+    hasText(queryParams.q) ||
+    queryParams.available === "true"
+  );
+}
+
+export function buildDirectoryFilterUrl(
+  section: "agents" | "candidates",
+  tags: string[],
+  queryParams: DirectoryFilterSearchParams = {}
+) {
+  const params = new URLSearchParams();
+
+  if (hasText(queryParams.q)) params.set("q", queryParams.q?.trim() as string);
+  if (queryParams.available === "true") params.set("available", "true");
+  if (hasText(queryParams.sort) && queryParams.sort !== DEFAULT_SORT) {
+    params.set("sort", queryParams.sort as string);
+  }
+
+  const tagPath =
+    tags.length > 0 ? `/${tags.map(encodeURIComponent).join(",")}` : "";
+  const queryString = params.toString();
+
+  return `/${section}${tagPath}${queryString ? `?${queryString}` : ""}`;
+}


### PR DESCRIPTION
## Summary

- add a shared directory filter helper for agents and candidates
- show filtered empty states and Clear filters when search, availability, or tags are active
- preserve search, availability, sort, and tags across directory sort/filter links

Fixes #426.
Fixes #428.

## Tests

- ./node_modules/.bin/vitest run src/lib/directory/filter-state.test.ts
- ./node_modules/.bin/eslint src/lib/directory/filter-state.ts src/lib/directory/filter-state.test.ts src/app/agents/[[...tags]]/page.tsx src/app/candidates/[[...tags]]/page.tsx src/components/agents/AgentFilters.tsx src/components/candidates/CandidateFilters.tsx
- ./node_modules/.bin/tsc --noEmit