### PR TITLE
Return 400 for malformed wallet address JSON

### DIFF
--- a/src/app/api/profile/wallet-addresses/route.test.ts
+++ b/src/app/api/profile/wallet-addresses/route.test.ts
@@ -4,7 +4,7 @@ vi.mock("@/lib/auth/get-user", () => ({
   getAuthContext: vi.fn(),
 }));
 
-import { GET } from "./route";
+import { GET, PUT } from "./route";
 import { getAuthContext } from "@/lib/auth/get-user";
 import * as serviceModule from "@/lib/supabase/service";
 
@@ -17,6 +17,14 @@ function req(params?: Record<string, string>) {
     Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
   }
   return { url: url.toString(), headers: new Headers() } as any;
+}
+
+function putReq(json: () => Promise<unknown>) {
+  return {
+    url: "http://localhost/api/profile/wallet-addresses",
+    headers: new Headers(),
+    json,
+  } as any;
 }
 
 describe("GET /api/profile/wallet-addresses", () => {
@@ -149,5 +157,26 @@ describe("GET /api/profile/wallet-addresses", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.poster_addresses).toEqual([]);
+  });
+});
+
+describe("PUT /api/profile/wallet-addresses", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 for malformed JSON before updating wallet addresses", async () => {
+    const update = vi.fn();
+    const sb = {
+      from: vi.fn().mockReturnValue({
+        update,
+      }),
+    };
+    (getAuthContext as any).mockResolvedValue({ user: { id: USER_ID }, supabase: sb });
+
+    const res = await PUT(putReq(() => Promise.reject(new SyntaxError("bad json"))));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON body");
+    expect(update).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/profile/wallet-addresses/route.ts
+++ b/src/app/api/profile/wallet-addresses/route.ts
@@ -111,7 +111,13 @@ export async function PUT(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
     const parsed = z.object({
       wallet_addresses: z.array(walletAddressSchema).max(20),
     }).safeParse(body);


### PR DESCRIPTION
## Summary

- Return 400 Invalid JSON body when PUT /api/profile/wallet-addresses receives malformed JSON.
- Keep validation and profile updates unchanged for valid JSON payloads.
- Add a regression test that verifies malformed JSON does not update wallet addresses.

Fixes #432.

## Tests

- node_modules/.bin/vitest run src/app/api/profile/wallet-addresses/route.test.ts
- node_modules/.bin/eslint src/app/api/profile/wallet-addresses/route.ts src/app/api/profile/wallet-addresses/route.test.ts
- git diff --check