### PR TITLE
fix: filter dashboard applications by owned gigs

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -99,7 +99,7 @@ export default async function DashboardPage() {
       id,
       status,
       created_at,
-      gig:gigs!gig_id (
+      gig:gigs!gig_id!inner (
         id,
         title,
         poster_id


### PR DESCRIPTION
## Summary

- use an inner join when loading recent applications for the dashboard
- exclude applications that do not belong to gigs posted by the current user
- prevent broken `/gigs/undefined` links

Closes #435

## Testing

- `npm run type-check`
- `npm run lint -- --quiet`
- `npm run test:run`
- `npm run build`