### PR TITLE
Fix dashboard recent applications links

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -99,7 +99,7 @@ export default async function DashboardPage() {
       id,
       status,
       created_at,
-      gig:gigs!gig_id (
+      gig:gigs!inner!gig_id (
         id,
         title,
         poster_id


### PR DESCRIPTION
Fixes #435.

The dashboard Recent Applications query filters on `gig.poster_id` while using a left join, which keeps application rows where the joined gig is null. Those rows can render links to `/gigs/undefined`.

This changes the gig join to an inner join so only applications for gigs owned by the current user are returned.

Tests:
- `git diff --check`