### PR TITLE
Fix: skip username uniqueness check on partial profile updates

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -79,18 +79,20 @@ export async function PUT(request: NextRequest) {
     }
 
     // Check if username is taken by another user
-    const { data: existingUser } = await supabase
-      .from("profiles")
-      .select("id")
-      .eq("username", validationResult.data.username)
-      .neq("id", user.id)
-      .single();
+    if (validationResult.data.username) {
+      const { data: existingUser } = await supabase
+        .from("profiles")
+        .select("id")
+        .eq("username", validationResult.data.username)
+        .neq("id", user.id)
+        .maybeSingle();
 
-    if (existingUser) {
-      return NextResponse.json(
-        { error: "Username is already taken" },
-        { status: 400 }
-      );
+      if (existingUser) {
+        return NextResponse.json(
+          { error: "Username is already taken" },
+          { status: 400 }
+        );
+      }
     }
 
     // Get current profile to check for resume changes

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -80,7 +80,8 @@ export const profileSchema = z.object({
     .regex(
       /^[a-zA-Z0-9_-]+$/,
       "Username can only contain letters, numbers, underscores, and hyphens"
-    ),
+    )
+    .optional(),
   full_name: z.string().max(100).optional().nullable(),
   bio: z.string().max(1000).optional().nullable(),
   skills: z.array(z.string()).max(20).default([]),


### PR DESCRIPTION
The PATCH /api/profile endpoint crashed with a 500 error when the request body didn't include a `username` field. The username uniqueness check used `.single()` which throws on zero matches. Wrapping the check in `if (validationResult.data.username)` and using `.maybeSingle()` allows partial profile updates to work correctly.