### PR TITLE
Escape directory search filters

### DIFF
--- a/src/app/api/directory/route.test.ts
+++ b/src/app/api/directory/route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+  createServiceClient: vi.fn(),
+}));
+
+import { GET } from "./route";
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/directory");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+function chainResult(result: {
+  data: unknown;
+  error: unknown;
+  count?: number | null;
+}) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ["select", "eq", "or", "overlaps", "order"]) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.range = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+describe("GET /api/directory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("escapes PostgREST filter punctuation in search", async () => {
+    const chain = chainResult({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeRequest({ search: "100%_demo,(v1.2)*" }));
+
+    expect(res.status).toBe(200);
+    expect(chain.or).toHaveBeenCalledWith(
+      "title.ilike.%100\\%\\_demo\\,\\(v1\\.2\\)\\*%,description.ilike.%100\\%\\_demo\\,\\(v1\\.2\\)\\*%"
+    );
+  });
+});

--- a/src/app/api/directory/route.ts
+++ b/src/app/api/directory/route.ts
@@ -12,7 +12,10 @@ import {
   internalTransfer,
   syncBalanceCache,
 } from "@/lib/lightning/wallet-utils";
-import { sanitizeSearchParams } from "@/lib/security/sanitize";
+import {
+  escapePostgrestSearchValue,
+  sanitizeSearchParams,
+} from "@/lib/security/sanitize";
 
 const LNBITS_INVOICE_KEY = process.env.LNBITS_INVOICE_KEY || "";
 const MAX_DIRECTORY_PAGE = 10_000;
@@ -33,7 +36,7 @@ const createListingSchema = z.object({
 export async function GET(request: NextRequest) {
   try {
     const url = new URL(request.url);
-    const search = url.searchParams.get("search") || "";
+    const search = sanitizeSearchParams(url, "search");
     const tag = sanitizeSearchParams(url, "tag");
     const parsedPage = parseInt(url.searchParams.get("page") || "1", 10);
     const page = Number.isFinite(parsedPage) && parsedPage > 0
@@ -53,8 +56,9 @@ export async function GET(request: NextRequest) {
       .eq("status", "active");
 
     if (search) {
+      const safeSearch = escapePostgrestSearchValue(search);
       query = query.or(
-        `title.ilike.%${search}%,description.ilike.%${search}%`
+        `title.ilike.%${safeSearch}%,description.ilike.%${safeSearch}%`
       );
     }
 


### PR DESCRIPTION
Fixes #447.

### What changed
- Uses the existing `escapePostgrestSearchValue` helper for `/api/directory` search filters.
- Sanitizes the `search` URL parameter through the shared URL parameter sanitizer.
- Adds a regression test for `%`, `_`, comma, parentheses, dot, and `*` in directory search.

### Validation
- `./node_modules/.bin/vitest.cmd run src/app/api/directory/route.test.ts`
- `./node_modules/.bin/tsc.cmd --noEmit`