### PR TITLE
Escape agent and candidate search filters

### DIFF
--- a/src/lib/queries/agents.test.ts
+++ b/src/lib/queries/agents.test.ts
@@ -28,10 +28,10 @@ describe("buildAgentsQuery", () => {
   });
 
   it("applies search query across full_name, username, and bio", () => {
-    buildAgentsQuery(mock.client, { q: "typescript" });
+    buildAgentsQuery(mock.client, { q: "typescript,(v1.2)%" });
 
     expect(mock.chain.or).toHaveBeenCalledWith(
-      "full_name.ilike.%typescript%,username.ilike.%typescript%,bio.ilike.%typescript%"
+      "full_name.ilike.%typescript\\,\\(v1\\.2\\)\\%%,username.ilike.%typescript\\,\\(v1\\.2\\)\\%%,bio.ilike.%typescript\\,\\(v1\\.2\\)\\%%"
     );
   });
 

--- a/src/lib/queries/agents.ts
+++ b/src/lib/queries/agents.ts
@@ -1,4 +1,5 @@
 import { SupabaseClient } from "@supabase/supabase-js";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 
 const MAX_PAGE = 100_000;
 
@@ -31,8 +32,9 @@ export function buildAgentsQuery(
     .eq("is_spam", false);
 
   if (q) {
+    const safeQuery = escapePostgrestSearchValue(q);
     query = query.or(
-      `full_name.ilike.%${q}%,username.ilike.%${q}%,bio.ilike.%${q}%`
+      `full_name.ilike.%${safeQuery}%,username.ilike.%${safeQuery}%,bio.ilike.%${safeQuery}%`
     );
   }
 

--- a/src/lib/queries/candidates.test.ts
+++ b/src/lib/queries/candidates.test.ts
@@ -28,10 +28,10 @@ describe("buildCandidatesQuery", () => {
   });
 
   it("applies search query across full_name, username, and bio", () => {
-    buildCandidatesQuery(mock.client, { q: "python" });
+    buildCandidatesQuery(mock.client, { q: "python,(v1.2)%" });
 
     expect(mock.chain.or).toHaveBeenCalledWith(
-      "full_name.ilike.%python%,username.ilike.%python%,bio.ilike.%python%"
+      "full_name.ilike.%python\\,\\(v1\\.2\\)\\%%,username.ilike.%python\\,\\(v1\\.2\\)\\%%,bio.ilike.%python\\,\\(v1\\.2\\)\\%%"
     );
   });
 

--- a/src/lib/queries/candidates.ts
+++ b/src/lib/queries/candidates.ts
@@ -1,4 +1,5 @@
 import { SupabaseClient } from "@supabase/supabase-js";
+import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 
 const MAX_PAGE = 100_000;
 
@@ -31,8 +32,9 @@ export function buildCandidatesQuery(
     .eq("is_spam", false);
 
   if (q) {
+    const safeQuery = escapePostgrestSearchValue(q);
     query = query.or(
-      `full_name.ilike.%${q}%,username.ilike.%${q}%,bio.ilike.%${q}%`
+      `full_name.ilike.%${safeQuery}%,username.ilike.%${safeQuery}%,bio.ilike.%${safeQuery}%`
     );
   }
 


### PR DESCRIPTION
Fixes #449.

### What changed
- Escapes `q` before interpolating it into agent profile `.or(...)` filters.
- Applies the same fix to candidate profile query filters.
- Updates regression tests to cover PostgREST/LIKE punctuation.

### Validation
- `./node_modules/.bin/vitest.cmd run src/lib/queries/agents.test.ts src/lib/queries/candidates.test.ts`
- `./node_modules/.bin/tsc.cmd --noEmit`