### PR TITLE
Return 400 for malformed testimonial JSON

### DIFF
--- a/src/app/api/testimonials/route.test.ts
+++ b/src/app/api/testimonials/route.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendEmail: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { createServiceClient } from "@/lib/supabase/service";
+
+function postReq(json: () => Promise<unknown>) {
+  return {
+    url: "http://localhost/api/testimonials",
+    headers: new Headers(),
+    json,
+  } as any;
+}
+
+describe("POST /api/testimonials", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 for malformed JSON before creating a testimonial", async () => {
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: "11111111-1111-4111-8111-111111111111" },
+      supabase: {},
+    });
+
+    const res = await POST(postReq(() => Promise.reject(new SyntaxError("bad json"))));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON body");
+    expect(createServiceClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -70,7 +70,12 @@ export async function POST(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
+    let body: any;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const { profile_id, gig_id, rating, content } = body;
 
     // Must provide exactly one target


### PR DESCRIPTION
Fixes #453.

## Summary
- Return a stable 400 response when `POST /api/testimonials` receives malformed JSON
- Avoid falling through to the generic 500 handler for client parse errors
- Add a regression test that ensures testimonial creation is not attempted after invalid JSON

## Verification
- `vitest run src/app/api/testimonials/route.test.ts`
- `tsc --noEmit`