### PR TITLE
Return 400 for malformed work history JSON

### DIFF
--- a/src/app/api/work-history/route.test.ts
+++ b/src/app/api/work-history/route.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+}));
+
+import { getAuthContext } from "@/lib/auth/get-user";
+import { POST } from "./route";
+
+function postReq(json: () => Promise<unknown>) {
+  return {
+    url: "http://localhost/api/work-history",
+    headers: new Headers(),
+    json,
+  } as any;
+}
+
+describe("POST /api/work-history", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 for malformed JSON before inserting work history", async () => {
+    const from = vi.fn();
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: "11111111-1111-4111-8111-111111111111" },
+      supabase: { from },
+    });
+
+    const res = await POST(postReq(() => Promise.reject(new SyntaxError("bad json"))));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON body");
+    expect(from).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/work-history/route.ts
+++ b/src/app/api/work-history/route.ts
@@ -39,7 +39,12 @@ export async function POST(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const validationResult = workHistorySchema.safeParse(body);
 
     if (!validationResult.success) {


### PR DESCRIPTION
Fixes #455.

## Summary
- Return 400 for malformed JSON sent to `POST /api/work-history`
- Prevent invalid request bodies from reaching work history validation or inserts
- Add regression coverage for malformed JSON

## Verification
- `vitest run src/app/api/work-history/route.test.ts`
- `tsc --noEmit`