### PR TITLE
Return 400 for malformed affiliate payout JSON

### DIFF
--- a/src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts
@@ -32,6 +32,17 @@ function makePostRequest(id: string, body: Record<string, unknown>) {
   );
 }
 
+function makeRawPostRequest(id: string, body: string) {
+  return new NextRequest(
+    `http://localhost/api/affiliates/offers/${id}/conversions/pay`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    }
+  );
+}
+
 function makeParams(id: string) {
   return { params: Promise.resolve({ id }) };
 }
@@ -52,6 +63,25 @@ function chainable(data: unknown, error: unknown = null) {
 describe("POST /api/affiliates/offers/[id]/conversions/pay", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("rejects malformed JSON before querying the affiliate offer", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "seller-1", authMethod: "session" },
+    });
+
+    const res = await POST(
+      makeRawPostRequest("offer-1", "{not valid json"),
+      makeParams("offer-1")
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Invalid JSON body",
+    });
+    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockGetUserLnWallet).not.toHaveBeenCalled();
+    expect(mockInternalTransfer).not.toHaveBeenCalled();
   });
 
   it("rejects non-string conversion_id before querying conversions (#422)", async () => {

--- a/src/app/api/affiliates/offers/[id]/conversions/pay/route.ts
+++ b/src/app/api/affiliates/offers/[id]/conversions/pay/route.ts
@@ -21,6 +21,25 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    const conversion_id =
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>).conversion_id
+        : undefined;
+
+    if (typeof conversion_id !== "string" || conversion_id.trim() === "") {
+      return NextResponse.json(
+        { error: "conversion_id must be a non-empty string" },
+        { status: 400 }
+      );
+    }
+    const conversionId = conversion_id.trim();
+
     const admin = createServiceClient();
 
     // Verify seller ownership
@@ -33,17 +52,6 @@ export async function POST(
     if (!offer || offer.seller_id !== auth.user.id) {
       return NextResponse.json({ error: "Not authorized" }, { status: 403 });
     }
-
-    const body = await request.json();
-    const { conversion_id } = body;
-
-    if (typeof conversion_id !== "string" || conversion_id.trim() === "") {
-      return NextResponse.json(
-        { error: "conversion_id must be a non-empty string" },
-        { status: 400 }
-      );
-    }
-    const conversionId = conversion_id.trim();
 
     // Get the conversion
     const { data: conv } = await (admin as AnySupabase)


### PR DESCRIPTION
Follow-up for #169.

## Summary
- Parse affiliate conversion payout JSON before service-client ownership/conversion queries
- Return 400 for malformed JSON instead of falling through to the generic 500 handler
- Add regression coverage that confirms malformed JSON does not query affiliate offers, wallets, or transfers

## Verification
- `vitest run src/app/api/affiliates/offers/[id]/conversions/pay/route.test.ts`
- `tsc --noEmit`