### PR TITLE
Return 400 for malformed bulk status JSON

### DIFF
--- a/src/app/api/applications/bulk-status/route.test.ts
+++ b/src/app/api/applications/bulk-status/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { PUT } from "./route";
+
+const mockGetAuthContext = vi.fn();
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: (...args: unknown[]) => mockGetAuthContext(...args),
+}));
+
+const mockFrom = vi.fn();
+
+function makeRequest(body: string) {
+  return new NextRequest("http://localhost/api/applications/bulk-status", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+}
+
+describe("PUT /api/applications/bulk-status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "poster-1" },
+      supabase: { from: mockFrom },
+    });
+  });
+
+  it("returns 400 for malformed JSON without querying Supabase", async () => {
+    const res = await PUT(makeRequest("{"));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/applications/bulk-status/route.ts
+++ b/src/app/api/applications/bulk-status/route.ts
@@ -13,6 +13,16 @@ const bulkStatusSchema = z.object({
   ]),
 });
 
+async function parseJsonBody(request: NextRequest) {
+  try {
+    return { body: await request.json() };
+  } catch {
+    return {
+      response: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+}
+
 // PUT /api/applications/bulk-status - Bulk update application statuses
 export async function PUT(request: NextRequest) {
   try {
@@ -22,7 +32,10 @@ export async function PUT(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
+    const parsed = await parseJsonBody(request);
+    if (parsed.response) return parsed.response;
+
+    const body = parsed.body;
     const validationResult = bulkStatusSchema.safeParse(body);
 
     if (!validationResult.success) {


### PR DESCRIPTION
Closes #460.

## Summary
- Parse `PUT /api/applications/bulk-status` bodies with a small guarded JSON helper.
- Return `400 Invalid JSON body` for malformed request JSON instead of the generic 500.
- Add regression coverage that malformed JSON returns before any Supabase query.

## Verification
- `corepack pnpm vitest run src/app/api/applications/bulk-status/route.test.ts`
- `corepack pnpm tsc --noEmit`