### PR TITLE
Sanitize affiliate tracking code prefixes

### DIFF
--- a/src/lib/affiliates/tracking.test.ts
+++ b/src/lib/affiliates/tracking.test.ts
@@ -98,6 +98,19 @@ describe("generateTrackingCode", () => {
     expect(code1).toMatch(/^bob-[a-f0-9]{6}$/);
     expect(code2).toMatch(/^bob-[a-f0-9]{6}$/);
   });
+
+  it("sanitizes username prefixes for URL-safe tracking codes", () => {
+    const code = generateTrackingCode("Alice Smith/@Example", "offer-1");
+
+    expect(code).toMatch(/^alice-smith-example-[a-f0-9]{6}$/);
+    expect(code).not.toMatch(/[ /@]/);
+  });
+
+  it("falls back when the username has no URL-safe characters", () => {
+    const code = generateTrackingCode("!!!", "offer-1");
+
+    expect(code).toMatch(/^affiliate-[a-f0-9]{6}$/);
+  });
 });
 
 describe("hashIP", () => {

--- a/src/lib/affiliates/tracking.ts
+++ b/src/lib/affiliates/tracking.ts
@@ -19,12 +19,17 @@ async function getAttributionWindowStart(admin: SupabaseClient, offerId: string)
  */
 export function generateTrackingCode(username: string, offerSlug: string): string {
   const base = `${username}-${offerSlug}`;
+  const prefix = username
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "affiliate";
   const hash = crypto
     .createHash("sha256")
     .update(base + Date.now())
     .digest("hex")
     .slice(0, 6);
-  return `${username}-${hash}`;
+  return `${prefix}-${hash}`;
 }
 
 /**


### PR DESCRIPTION
Closes #462.

## Summary
- Normalize the username prefix used by `generateTrackingCode()` to URL-safe lowercase slug characters.
- Add an `affiliate` fallback when a username has no safe characters.
- Add regression coverage for usernames containing spaces/symbols and fallback-only values.

## Verification
- `corepack pnpm vitest run src/lib/affiliates/tracking.test.ts`
- `corepack pnpm tsc --noEmit`