### PR TITLE
Return 400 for malformed application status JSON

### DIFF
--- a/src/app/api/applications/[id]/status/route.test.ts
+++ b/src/app/api/applications/[id]/status/route.test.ts
@@ -40,6 +40,15 @@ function makeRequest(body: Record<string, unknown>) {
   });
 }
 
+function makeRawRequest(body: string) {
+  const url = "http://localhost/api/applications/test-app-id/status";
+  return new NextRequest(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+}
+
 const routeParams = { params: Promise.resolve({ id: "test-app-id" }) };
 
 /** Build a chain-able Supabase query mock that resolves to `result`. */
@@ -97,6 +106,20 @@ describe("PUT /api/applications/[id]/status", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for malformed JSON without querying Supabase", async () => {
+    mockGetAuthContext.mockResolvedValue({
+      user: { id: "poster-user-id", authMethod: "session" },
+      supabase: supabaseClient,
+    } as MockAuthContext);
+
+    const res = await PUT(makeRawRequest("{"), routeParams);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("Invalid JSON body");
+    expect(mockFrom).not.toHaveBeenCalled();
   });
 
   it("returns 404 when application not found", async () => {

--- a/src/app/api/applications/[id]/status/route.ts
+++ b/src/app/api/applications/[id]/status/route.ts
@@ -3,6 +3,16 @@ import { getAuthContext } from "@/lib/auth/get-user";
 import { applicationStatusSchema } from "@/lib/validations";
 import { getUserDid, onHired } from "@/lib/reputation-hooks";
 
+async function parseJsonBody(request: NextRequest) {
+  try {
+    return { body: await request.json() };
+  } catch {
+    return {
+      response: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+}
+
 // PUT /api/applications/[id]/status - Update application status
 export async function PUT(
   request: NextRequest,
@@ -16,7 +26,10 @@ export async function PUT(
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
+    const parsed = await parseJsonBody(request);
+    if (parsed.response) return parsed.response;
+
+    const body = parsed.body;
     const validationResult = applicationStatusSchema.safeParse(body);
 
     if (!validationResult.success) {


### PR DESCRIPTION
Closes #464.

## Summary
- Add guarded JSON parsing to `PUT /api/applications/[id]/status`.
- Return `400 Invalid JSON body` for malformed request JSON before Supabase queries.
- Add regression coverage for the malformed-body path.

## Verification
- `corepack pnpm vitest run 'src/app/api/applications/[id]/status/route.test.ts'`
- `corepack pnpm tsc --noEmit`