### PR TITLE
Return 400 for malformed notification settings JSON

### DIFF
--- a/src/app/api/notification-settings/route.test.ts
+++ b/src/app/api/notification-settings/route.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { PUT } from "./route";
+
+const mocks = vi.hoisted(() => ({
+  mockGetAuthContext: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: mocks.mockGetAuthContext,
+}));
+
+function makePutRequest(body: BodyInit) {
+  return new NextRequest("http://localhost/api/notification-settings", {
+    method: "PUT",
+    body,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("PUT /api/notification-settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockGetAuthContext.mockResolvedValue({
+      user: { id: "user-1" },
+      supabase: { from: mocks.mockFrom },
+    });
+  });
+
+  it("returns 400 for malformed JSON before touching settings", async () => {
+    const response = await PUT(makePutRequest("{not valid json"));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Invalid JSON body");
+    expect(mocks.mockFrom).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/notification-settings/route.ts
+++ b/src/app/api/notification-settings/route.ts
@@ -14,6 +14,18 @@ const SETTING_KEYS = [
   "email_upvote_milestone",
 ] as const;
 
+async function readJsonObject(request: NextRequest) {
+  try {
+    const body = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return null;
+    }
+    return body as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
 // GET /api/notification-settings
 export async function GET(request: NextRequest) {
   try {
@@ -60,7 +72,10 @@ export async function PUT(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
+    const body = await readJsonObject(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
 
     // Only allow known boolean keys
     const updateData: Record<string, boolean> = {};


### PR DESCRIPTION
Fixes #468.

## Changes
- parse notification settings bodies safely
- return 400 for malformed or non-object JSON before any upsert
- add a regression test

## Verification
- `corepack pnpm vitest run src/app/api/notification-settings/route.test.ts`
- `corepack pnpm tsc --noEmit`