### PR TITLE
Return 400 for malformed affiliate offer JSON

### DIFF
--- a/src/app/api/affiliates/offers/route.test.ts
+++ b/src/app/api/affiliates/offers/route.test.ts
@@ -170,6 +170,23 @@ describe("POST /api/affiliates/offers", () => {
     vi.clearAllMocks();
   });
 
+  it("returns 400 for malformed JSON before touching affiliate offers", async () => {
+    mockGetAuthContext.mockResolvedValue({ user: { id: "user1" } });
+
+    const req = new NextRequest("http://localhost/api/affiliates/offers", {
+      method: "POST",
+      body: "{not valid json",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid JSON body");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
   it("rejects javascript: URL in product_url (#18)", async () => {
     mockGetAuthContext.mockResolvedValue({ user: { id: "user1" } });
 

--- a/src/app/api/affiliates/offers/route.ts
+++ b/src/app/api/affiliates/offers/route.ts
@@ -6,7 +6,7 @@ import { escapePostgrestSearchValue } from "@/lib/security/sanitize";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySupabase = any;
-import { validateOfferInput } from "@/lib/affiliates/validation";
+import { validateOfferInput, type OfferInput } from "@/lib/affiliates/validation";
 
 function parsePaginationParam(
   value: string | null,
@@ -26,6 +26,18 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, "")
     .slice(0, 80);
   return slug || "offer";
+}
+
+async function readJsonObject(request: NextRequest) {
+  try {
+    const body = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return null;
+    }
+    return body as Record<string, unknown>;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -148,8 +160,11 @@ export async function POST(request: NextRequest) {
     const rl = checkRateLimit(getRateLimitIdentifier(request, auth.user.id), "write");
     if (!rl.allowed) return rateLimitExceeded(rl);
 
-    const body = await request.json();
-    const validation = validateOfferInput(body);
+    const body = await readJsonObject(request);
+    if (!body) {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    const validation = validateOfferInput(body as unknown as OfferInput);
 
     if (!validation.ok) {
       return NextResponse.json({ error: validation.errors.join("; ") }, { status: 400 });


### PR DESCRIPTION
Fixes #470.

## Changes
- parse affiliate offer POST bodies safely
- return 400 for malformed or non-object JSON before service/database work
- add a regression test

## Verification
- `corepack pnpm vitest run src/app/api/affiliates/offers/route.test.ts`
- `corepack pnpm tsc --noEmit`