### PR TITLE
fix: replace .single() with .maybeSingle() in reviews, saved-gigs, work-history, api-keys, wallet-addresses

### DIFF
--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -127,7 +127,7 @@ export async function POST(request: NextRequest) {
         scope,
       })
       .select("id, name, key_prefix, created_at, expires_at, scope")
-      .single();
+      .maybeSingle();
 
     if (error || !apiKey) {
       console.error("API key creation error:", error);

--- a/src/app/api/profile/wallet-addresses/route.ts
+++ b/src/app/api/profile/wallet-addresses/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
       .from("profiles")
       .select("wallet_addresses")
       .eq("id", user.id)
-      .single();
+      .maybeSingle();
 
     const posterAddresses = Array.isArray(posterProfile?.wallet_addresses)
       ? posterProfile.wallet_addresses
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
         .from("gigs")
         .select("id, poster_id")
         .eq("id", gigId)
-        .single();
+        .maybeSingle();
 
       if (!gig || gig.poster_id !== user.id) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
@@ -76,7 +76,7 @@ export async function GET(request: NextRequest) {
         .from("profiles")
         .select("wallet_addresses")
         .eq("id", workerId)
-        .single();
+        .maybeSingle();
 
       workerAddresses = Array.isArray(workerProfile?.wallet_addresses)
         ? workerProfile.wallet_addresses

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -152,7 +152,7 @@ export async function POST(request: NextRequest) {
       .from("gigs")
       .select("id, title, poster_id, status")
       .eq("id", gig_id)
-      .single();
+      .maybeSingle();
 
     if (!gig) {
       return NextResponse.json({ error: "Gig not found" }, { status: 404 });
@@ -168,7 +168,7 @@ export async function POST(request: NextRequest) {
       .eq("gig_id", gig_id)
       .eq("applicant_id", user.id)
       .eq("status", "accepted")
-      .single();
+      .maybeSingle();
 
     const isAcceptedApplicant = !!application;
 
@@ -187,7 +187,7 @@ export async function POST(request: NextRequest) {
       .eq("gig_id", gig_id)
       .eq("applicant_id", reviewee_id)
       .eq("status", "accepted")
-      .single();
+      .maybeSingle();
 
     const revieweeIsAcceptedApplicant = !!revieweeApplication;
 
@@ -205,7 +205,7 @@ export async function POST(request: NextRequest) {
       .eq("gig_id", gig_id)
       .eq("reviewer_id", user.id)
       .eq("reviewee_id", reviewee_id)
-      .single();
+      .maybeSingle();
 
     if (existingReview) {
       return NextResponse.json(
@@ -241,7 +241,7 @@ export async function POST(request: NextRequest) {
         )
       `
       )
-      .single();
+      .maybeSingle();
 
     if (createError) {
       console.error("[POST /api/reviews] Supabase error:", createError);
@@ -254,7 +254,7 @@ export async function POST(request: NextRequest) {
       .from("profiles")
       .select("did")
       .eq("id", reviewee_id)
-      .single();
+      .maybeSingle();
     if (userDid) {
       onReviewCreated(userDid, review.id, revieweeProfile?.did || undefined);
     }

--- a/src/app/api/saved-gigs/route.ts
+++ b/src/app/api/saved-gigs/route.ts
@@ -140,7 +140,7 @@ export async function POST(request: NextRequest) {
         gig_id,
       })
       .select()
-      .single();
+      .maybeSingle();
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/work-history/route.ts
+++ b/src/app/api/work-history/route.ts
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest) {
         ...validationResult.data,
       })
       .select()
-      .single();
+      .maybeSingle();
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 400 });


### PR DESCRIPTION
Continues the .single() to .maybeSingle() migration. Fixed routes:\n- GET/POST /api/reviews\n- GET/POST /api/saved-gigs\n- GET/POST /api/work-history\n- GET/DELETE /api/api-keys\n- GET/POST/DELETE /api/profile/wallet-addresses