### PR TITLE
feat(gigs): boost a gig after a week

### DIFF
--- a/src/app/api/gigs/[id]/boost/route.ts
+++ b/src/app/api/gigs/[id]/boost/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { checkRateLimit, rateLimitExceeded, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { getBoostEligibility, BOOST_COOLDOWN_DAYS } from "@/lib/boost";
+import { dispatchWebhookAsync } from "@/lib/webhooks/dispatch";
+
+// POST /api/gigs/[id]/boost - Bump an active gig back to the top of the listing.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { user, supabase } = auth;
+
+    const rl = checkRateLimit(getRateLimitIdentifier(request, user.id), "write");
+    if (!rl.allowed) return rateLimitExceeded(rl);
+
+    const { data: existingGig } = await supabase
+      .from("gigs")
+      .select("poster_id, status, created_at, boosted_at")
+      .eq("id", id)
+      .single();
+
+    if (!existingGig) {
+      return NextResponse.json({ error: "Gig not found" }, { status: 404 });
+    }
+
+    if (existingGig.poster_id !== user.id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Only active gigs appear in the public listing, so only they can be boosted.
+    if (existingGig.status !== "active") {
+      return NextResponse.json(
+        { error: "Only active gigs can be boosted." },
+        { status: 400 }
+      );
+    }
+
+    const eligibility = getBoostEligibility(existingGig);
+    if (!eligibility.eligible) {
+      return NextResponse.json(
+        {
+          error: `Gigs can be boosted once every ${BOOST_COOLDOWN_DAYS} days. Try again later.`,
+          nextEligibleAt: eligibility.nextEligibleAt,
+        },
+        { status: 429 }
+      );
+    }
+
+    const boostedAt = new Date().toISOString();
+    const { data: gig, error } = await supabase
+      .from("gigs")
+      .update({ boosted_at: boostedAt, updated_at: boostedAt })
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    dispatchWebhookAsync(user.id, "gig.update", {
+      gig_id: id,
+      boosted_at: boostedAt,
+    });
+
+    return NextResponse.json({ gig });
+  } catch {
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/gigs/route.ts
+++ b/src/app/api/gigs/route.ts
@@ -135,8 +135,8 @@ export async function GET(request: NextRequest) {
       case "budget_low":
         query = query.order("budget_min", { ascending: true, nullsFirst: false });
         break;
-      default: // newest
-        query = query.order("created_at", { ascending: false });
+      default: // newest — boosted gigs rank by their boost time (ranked_at), else creation time
+        query = query.order("ranked_at", { ascending: false });
     }
 
     // Apply pagination — ensure non-negative offset (#69)

--- a/src/app/dashboard/gigs/page.tsx
+++ b/src/app/dashboard/gigs/page.tsx
@@ -181,7 +181,12 @@ export default async function MyGigsPage({ searchParams }: MyGigsPageProps) {
                       </div>
                     </div>
 
-                    <GigActions gigId={gig.id} status={gig.status} />
+                    <GigActions
+                      gigId={gig.id}
+                      status={gig.status}
+                      createdAt={gig.created_at}
+                      boostedAt={gig.boosted_at}
+                    />
                   </div>
 
                   {(pendingByGig[gig.id]?.length ?? 0) > 0 && (

--- a/src/components/gigs/GigActions.tsx
+++ b/src/components/gigs/GigActions.tsx
@@ -13,21 +13,27 @@ import {
   CheckCircle,
   Loader2,
   XCircle,
+  Rocket,
 } from "lucide-react";
 import Link from "next/link";
 import { useDialog } from "@/components/providers/DialogProvider";
+import { getBoostEligibility } from "@/lib/boost";
 
 interface GigActionsProps {
   gigId: string;
   status: string;
+  createdAt?: string | null;
+  boostedAt?: string | null;
 }
 
-export function GigActions({ gigId, status }: GigActionsProps) {
+export function GigActions({ gigId, status, createdAt, boostedAt }: GigActionsProps) {
   const router = useRouter();
   const { confirm } = useDialog();
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const boost = getBoostEligibility({ created_at: createdAt, boosted_at: boostedAt });
 
   const handleStatusChange = async (newStatus: string) => {
     setIsLoading(true);
@@ -37,6 +43,23 @@ export function GigActions({ gigId, status }: GigActionsProps) {
       gigId,
       newStatus as "draft" | "active" | "paused" | "closed" | "filled"
     );
+
+    if (result.error) {
+      setError(result.error);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsOpen(false);
+    setIsLoading(false);
+    router.refresh();
+  };
+
+  const handleBoost = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    const result = await gigsApi.boost(gigId);
 
     if (result.error) {
       setError(result.error);
@@ -118,6 +141,26 @@ export function GigActions({ gigId, status }: GigActionsProps) {
 
                 {status === "active" && (
                   <>
+                    {boost.eligible ? (
+                      <button
+                        onClick={handleBoost}
+                        className="w-full px-3 py-2 text-left text-sm hover:bg-muted rounded flex items-center gap-2 text-primary"
+                        disabled={isLoading}
+                      >
+                        <Rocket className="h-4 w-4" />
+                        Boost Gig
+                      </button>
+                    ) : (
+                      <div className="w-full px-3 py-2 text-left text-xs text-muted-foreground flex items-center gap-2">
+                        <Rocket className="h-4 w-4 shrink-0" />
+                        <span>
+                          Boost available{" "}
+                          {boost.nextEligibleAt
+                            ? new Date(boost.nextEligibleAt).toLocaleDateString()
+                            : "soon"}
+                        </span>
+                      </div>
+                    )}
                     <button
                       onClick={() => handleStatusChange("paused")}
                       className="w-full px-3 py-2 text-left text-sm hover:bg-muted rounded flex items-center gap-2"

--- a/src/components/gigs/GigCard.test.tsx
+++ b/src/components/gigs/GigCard.test.tsx
@@ -39,6 +39,8 @@ const baseGig = {
   poster_id: "user-1",
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
+  boosted_at: null,
+  ranked_at: new Date().toISOString(),
   expires_at: null,
   applications_count: 0,
   duration: null,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -130,6 +130,11 @@ export const gigs = {
       method: "DELETE",
     }),
 
+  boost: (id: string) =>
+    request(`/api/gigs/${id}/boost`, {
+      method: "POST",
+    }),
+
   getMy: () => request("/api/gigs/my"),
 };
 

--- a/src/lib/boost.test.ts
+++ b/src/lib/boost.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { getBoostEligibility, BOOST_COOLDOWN_DAYS } from "./boost";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const now = new Date("2026-06-14T00:00:00.000Z");
+
+function daysAgo(days: number): string {
+  return new Date(now.getTime() - days * DAY_MS).toISOString();
+}
+
+describe("getBoostEligibility", () => {
+  it("is not eligible when created less than the cooldown ago", () => {
+    const result = getBoostEligibility({ created_at: daysAgo(3) }, now);
+    expect(result.eligible).toBe(false);
+    expect(result.nextEligibleAt).not.toBeNull();
+  });
+
+  it("is eligible once the cooldown has elapsed since creation", () => {
+    const result = getBoostEligibility({ created_at: daysAgo(BOOST_COOLDOWN_DAYS) }, now);
+    expect(result.eligible).toBe(true);
+    expect(result.nextEligibleAt).toBeNull();
+  });
+
+  it("is eligible well past the cooldown", () => {
+    const result = getBoostEligibility({ created_at: daysAgo(30) }, now);
+    expect(result.eligible).toBe(true);
+  });
+
+  it("uses the last boost time, not creation, for the cooldown", () => {
+    const result = getBoostEligibility(
+      { created_at: daysAgo(30), boosted_at: daysAgo(2) },
+      now
+    );
+    expect(result.eligible).toBe(false);
+  });
+
+  it("becomes eligible again a cooldown after the last boost", () => {
+    const result = getBoostEligibility(
+      { created_at: daysAgo(30), boosted_at: daysAgo(BOOST_COOLDOWN_DAYS) },
+      now
+    );
+    expect(result.eligible).toBe(true);
+  });
+
+  it("reports the next eligible time as one cooldown after the reference", () => {
+    const result = getBoostEligibility({ created_at: daysAgo(1) }, now);
+    expect(result.nextEligibleAt).toBe(
+      new Date(now.getTime() + (BOOST_COOLDOWN_DAYS - 1) * DAY_MS).toISOString()
+    );
+  });
+
+  it("treats gigs with no timestamps as eligible rather than locked", () => {
+    expect(getBoostEligibility({}, now).eligible).toBe(true);
+    expect(getBoostEligibility({ created_at: "not-a-date" }, now).eligible).toBe(true);
+  });
+});

--- a/src/lib/boost.ts
+++ b/src/lib/boost.ts
@@ -1,0 +1,48 @@
+// Gig boosting rules, shared between the API route and the UI so eligibility
+// is computed identically in both places.
+
+/** A gig must be at least this old (since creation or its last boost) to boost again. */
+export const BOOST_COOLDOWN_DAYS = 7;
+
+const COOLDOWN_MS = BOOST_COOLDOWN_DAYS * 24 * 60 * 60 * 1000;
+
+interface BoostableGig {
+  created_at?: string | null;
+  boosted_at?: string | null;
+}
+
+export interface BoostEligibility {
+  eligible: boolean;
+  /** ISO timestamp when the gig becomes boostable again, or null if already eligible. */
+  nextEligibleAt: string | null;
+}
+
+/**
+ * A gig can be boosted once at least BOOST_COOLDOWN_DAYS have passed since it was
+ * created or last boosted (whichever is more recent).
+ */
+export function getBoostEligibility(
+  gig: BoostableGig,
+  now: Date = new Date()
+): BoostEligibility {
+  const reference = gig.boosted_at ?? gig.created_at;
+  if (!reference) {
+    // No timestamp to reason about — treat as eligible rather than locking it forever.
+    return { eligible: true, nextEligibleAt: null };
+  }
+
+  const referenceMs = new Date(reference).getTime();
+  if (!Number.isFinite(referenceMs)) {
+    return { eligible: true, nextEligibleAt: null };
+  }
+
+  const nextEligibleMs = referenceMs + COOLDOWN_MS;
+  if (now.getTime() >= nextEligibleMs) {
+    return { eligible: true, nextEligibleAt: null };
+  }
+
+  return {
+    eligible: false,
+    nextEligibleAt: new Date(nextEligibleMs).toISOString(),
+  };
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -306,6 +306,8 @@ export type Database = {
           views_count: number;
           created_at: string;
           updated_at: string;
+          boosted_at: string | null;
+          ranked_at: string | null;
         };
         Insert: {
           id?: string;
@@ -329,6 +331,7 @@ export type Database = {
           views_count?: number;
           created_at?: string;
           updated_at?: string;
+          boosted_at?: string | null;
         };
         Update: {
           id?: string;
@@ -352,6 +355,7 @@ export type Database = {
           views_count?: number;
           created_at?: string;
           updated_at?: string;
+          boosted_at?: string | null;
         };
         Relationships: [
           {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -363,6 +363,7 @@ export type Database = {
         Row: {
           ai_tools_preferred: string[] | null
           applications_count: number | null
+          boosted_at: string | null
           budget_max: number | null
           budget_min: number | null
           budget_type: Database["public"]["Enums"]["budget_type"]
@@ -377,6 +378,7 @@ export type Database = {
           location_type: Database["public"]["Enums"]["location_type"] | null
           payment_coin: string | null
           poster_id: string
+          ranked_at: string | null
           skills_required: string[] | null
           status: Database["public"]["Enums"]["gig_status"] | null
           title: string
@@ -386,6 +388,7 @@ export type Database = {
         Insert: {
           ai_tools_preferred?: string[] | null
           applications_count?: number | null
+          boosted_at?: string | null
           budget_max?: number | null
           budget_min?: number | null
           budget_type: Database["public"]["Enums"]["budget_type"]
@@ -409,6 +412,7 @@ export type Database = {
         Update: {
           ai_tools_preferred?: string[] | null
           applications_count?: number | null
+          boosted_at?: string | null
           budget_max?: number | null
           budget_min?: number | null
           budget_type?: Database["public"]["Enums"]["budget_type"]

--- a/supabase/migrations/20260614000000_add_gig_boost.sql
+++ b/supabase/migrations/20260614000000_add_gig_boost.sql
@@ -1,0 +1,12 @@
+-- Gig boosting: let posters bump a gig back to the top of the listing.
+-- `boosted_at` records the most recent boost (null = never boosted).
+-- `ranked_at` is the effective recency used for the default "newest" sort:
+-- the later of when the gig was created and when it was last boosted.
+ALTER TABLE gigs ADD COLUMN boosted_at TIMESTAMPTZ;
+
+ALTER TABLE gigs
+  ADD COLUMN ranked_at TIMESTAMPTZ
+  GENERATED ALWAYS AS (GREATEST(created_at, boosted_at)) STORED;
+
+-- Drive the default listing order off the effective recency.
+CREATE INDEX idx_gigs_ranked_at ON gigs (ranked_at DESC);


### PR DESCRIPTION
## Summary
Lets a poster **boost** an active gig to bump it back to the top of the listing, once the gig is at least 7 days old (since creation or its last boost). Pricing is intentionally out of scope for now — this ships the mechanic only.

## Changes
- **Migration** `20260614000000_add_gig_boost.sql`: adds `boosted_at` (nullable) + a stored generated `ranked_at = GREATEST(created_at, boosted_at)` and an index on `ranked_at`. For existing/never-boosted rows `ranked_at == created_at`, so order is unchanged until a gig is boosted. **Already applied to the linked Supabase project.**
- **Listing** (`/api/gigs`): default `newest` sort now orders by `ranked_at DESC`, so boosted gigs rise.
- **Boost API** `POST /api/gigs/[id]/boost`: owner-only, rate-limited, requires `active` status, enforces a 7-day cooldown (`429` + `nextEligibleAt` when too soon), fires the existing `gig.update` webhook.
- **Shared rule** `src/lib/boost.ts` (`getBoostEligibility`, `BOOST_COOLDOWN_DAYS = 7`) used by both API and UI.
- **UI**: "Boost Gig" action in `GigActions` (or a disabled "Boost available <date>" hint); `gigs.boost()` API client; regenerated DB types.

## Tests
`pnpm type-check` clean; `pnpm lint` 0 errors; pre-push suite green (1666 tests) + build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)