### PR TITLE
fix(invoice): auto-select worker's coinpay wallet when poster creates invoice

### DIFF
--- a/src/app/api/gigs/[id]/invoice/route.ts
+++ b/src/app/api/gigs/[id]/invoice/route.ts
@@ -313,16 +313,6 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       );
     }
 
-    const selectedCurrency = preferredCoinToPaymentCurrency(payment_currency || null);
-    const selectedAddress = merchant_wallet_address?.trim() || "";
-
-    if (!selectedCurrency || !selectedAddress) {
-      return NextResponse.json(
-        { error: "Select a CoinPay receiving wallet before sending the invoice" },
-        { status: 400 }
-      );
-    }
-
     const workerCoinpayToken = await getConnectedCoinpayAccessToken(workerId);
     if (!workerCoinpayToken) {
       return NextResponse.json(
@@ -351,6 +341,24 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         },
         { status: 409 }
       );
+    }
+
+    let selectedCurrency = preferredCoinToPaymentCurrency(payment_currency || null);
+    let selectedAddress = merchant_wallet_address?.trim() || "";
+
+    if (!selectedCurrency || !selectedAddress) {
+      const gigCoin = preferredCoinToPaymentCurrency(gig.payment_coin || null);
+      const preferred = workerWallets.find((w) => w.currency === gigCoin) || workerWallets[0];
+      
+      if (preferred) {
+        selectedCurrency = preferred.currency;
+        selectedAddress = preferred.address;
+      } else {
+        return NextResponse.json(
+          { error: "Select a CoinPay receiving wallet before sending the invoice" },
+          { status: 400 }
+        );
+      }
     }
 
     const selectedWallet = findCoinpayGlobalWallet(

--- a/src/components/gigs/InvoiceButton.tsx
+++ b/src/components/gigs/InvoiceButton.tsx
@@ -234,12 +234,19 @@ export function InvoiceButton({
 
     setIsCreating(true);
     setError(null);
-    const selectedWallet =
-      wallets.find((wallet) => walletKey(wallet) === selectedWalletKey) || null;
-    if (!selectedWallet) {
-      setError("Select a CoinPay receiving wallet");
-      setIsCreating(false);
-      return;
+    let selectedWalletCurrency: string | undefined;
+    let selectedWalletAddress: string | undefined;
+
+    if (isWorker) {
+      const selectedWallet =
+        wallets.find((wallet) => walletKey(wallet) === selectedWalletKey) || null;
+      if (!selectedWallet) {
+        setError("Select a CoinPay receiving wallet");
+        setIsCreating(false);
+        return;
+      }
+      selectedWalletCurrency = selectedWallet.currency;
+      selectedWalletAddress = selectedWallet.address;
     }
 
     try {
@@ -251,8 +258,8 @@ export function InvoiceButton({
           items: lineItems,
           amount: total,
           currency: "USD",
-          payment_currency: selectedWallet.currency,
-          merchant_wallet_address: selectedWallet.address,
+          payment_currency: selectedWalletCurrency,
+          merchant_wallet_address: selectedWalletAddress,
           notes: notes || undefined,
           due_date: dueDate || undefined,
           pr_links: prLinks.length > 0 ? prLinks : undefined,
@@ -844,7 +851,8 @@ function InvoiceForm({
         />
       </div>
 
-      <div className="space-y-2 rounded-md border border-border bg-background p-3">
+      {isWorker && (
+        <div className="space-y-2 rounded-md border border-border bg-background p-3">
         <div className="flex items-center justify-between gap-3">
           <label className="text-xs font-medium text-muted-foreground">
             CoinPay receiving wallet
@@ -906,14 +914,15 @@ function InvoiceForm({
             )}
           </div>
         )}
-      </div>
+        </div>
+      )}
 
       {error && <p className="text-sm text-destructive">{error}</p>}
 
       <div className="flex gap-2">
         <Button
           onClick={onSubmit}
-          disabled={isCreating || total <= 0 || overCap || !hasWallets}
+          disabled={isCreating || total <= 0 || overCap || (isWorker && !hasWallets)}
           className="flex-1"
           size="sm"
         >


### PR DESCRIPTION
Fixes #478.

When the poster initiates an invoice on behalf of the worker, the frontend no longer forces the poster to select a CoinPay receiving wallet (which they wouldn't have access to). The backend API now automatically falls back to selecting the worker's CoinPay wallet matching the gig's payment coin.