### PR TITLE
Fix partial bulk application status updates

### DIFF
--- a/src/app/api/applications/bulk-status/route.test.ts
+++ b/src/app/api/applications/bulk-status/route.test.ts
@@ -33,4 +33,55 @@ describe("PUT /api/applications/bulk-status", () => {
     await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
     expect(mockFrom).not.toHaveBeenCalled();
   });
+
+  it("returns 404 when any requested application id is missing", async () => {
+    const existingId = "11111111-1111-4111-8111-111111111111";
+    const missingId = "22222222-2222-4222-8222-222222222222";
+    const applicationsIn = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: existingId,
+          applicant_id: "worker-1",
+          gig_id: "gig-1",
+          gig: { poster_id: "poster-1" },
+        },
+      ],
+      error: null,
+    });
+    const applicationsSelect = vi.fn(() => ({ in: applicationsIn }));
+    const applicationsUpdate = vi.fn();
+    const notificationsInsert = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "applications") {
+        return {
+          select: applicationsSelect,
+          update: applicationsUpdate,
+        };
+      }
+
+      if (table === "notifications") {
+        return { insert: notificationsInsert };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    const res = await PUT(
+      makeRequest(
+        JSON.stringify({
+          application_ids: [existingId, missingId],
+          status: "accepted",
+        })
+      )
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      error: "Some applications were not found",
+    });
+    expect(applicationsIn).toHaveBeenCalledWith("id", [existingId, missingId]);
+    expect(applicationsUpdate).not.toHaveBeenCalled();
+    expect(notificationsInsert).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/applications/bulk-status/route.ts
+++ b/src/app/api/applications/bulk-status/route.ts
@@ -74,6 +74,17 @@ export async function PUT(request: NextRequest) {
       );
     }
 
+    const requestedIds = [...new Set(application_ids)];
+    const foundIds = new Set(applications.map((app) => app.id));
+    const missingIds = requestedIds.filter((id) => !foundIds.has(id));
+
+    if (missingIds.length > 0) {
+      return NextResponse.json(
+        { error: "Some applications were not found" },
+        { status: 404 }
+      );
+    }
+
     // Verify user owns all the gigs these applications belong to
     const unauthorizedApplications = applications.filter(
       (app) => (app.gig as { poster_id: string })?.poster_id !== user.id


### PR DESCRIPTION
## Summary

Fixes #484.

The bulk application status route now rejects a batch when any requested application ID is missing, instead of updating the subset Supabase returned and reporting success.

## Verification

- `npm test -- run src/app/api/applications/bulk-status/route.test.ts`
- `npm run type-check`
