### PR TITLE
Fix Follow System: Add missing follows table migration

### DIFF
--- a/supabase/migrations/20260615000000_add_user_follows.sql
+++ b/supabase/migrations/20260615000000_add_user_follows.sql
@@ -1,0 +1,16 @@
+-- Add user follows table
+CREATE TABLE follows (
+    follower_id UUID REFERENCES profiles(id) ON DELETE CASCADE,
+    following_id UUID REFERENCES profiles(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (follower_id, following_id),
+    CHECK (follower_id != following_id)
+);
+
+CREATE INDEX idx_follows_follower ON follows(follower_id);
+CREATE INDEX idx_follows_following ON follows(following_id);
+
+ALTER TABLE follows ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Follows are viewable by everyone" ON follows FOR SELECT USING (true);
+CREATE POLICY "Users can manage their own follows" ON follows FOR ALL USING (auth.uid() = follower_id);


### PR DESCRIPTION
The follow API route exists but the  table was missing from the database migrations. This PR adds the migration with RLS policies.