### PR TITLE
Let invoice senders revoke and resend

### DIFF
--- a/src/app/api/gigs/[id]/invoice/[invoiceId]/revoke/route.test.ts
+++ b/src/app/api/gigs/[id]/invoice/[invoiceId]/revoke/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { createServiceClient } from "@/lib/supabase/service";
+
+const GIG_ID = "8489a861-0999-4107-afca-2592021ac338";
+const INVOICE_ID = "f53e4a56-3cf7-42f9-9a33-bc1cb770c4f6";
+const POSTER_ID = "4f16c625-c37a-4654-82db-e391067cbb13";
+const WORKER_ID = "666cbaba-c6ea-4756-ad44-d6a5b4248f8f";
+
+const params = { params: Promise.resolve({ id: GIG_ID, invoiceId: INVOICE_ID }) };
+
+function invoiceQuery(invoice: any) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: invoice, error: null }),
+  };
+}
+
+// Records the row passed to update() so the test can assert on it.
+function updateSpy(onUpdate: (row: any) => void) {
+  return {
+    update: vi.fn((row: any) => {
+      onUpdate(row);
+      return { eq: vi.fn().mockResolvedValue({ error: null }) };
+    }),
+  };
+}
+
+function baseInvoice(status: string) {
+  return {
+    id: INVOICE_ID,
+    gig_id: GIG_ID,
+    worker_id: WORKER_ID,
+    poster_id: POSTER_ID,
+    amount_usd: 125,
+    status,
+    gig: { id: GIG_ID, title: "Build thing" },
+  };
+}
+
+describe("POST /api/gigs/[id]/invoice/[invoiceId]/revoke", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("lets the sender cancel a sent invoice and notifies the payer", async () => {
+    let updatePayload: any = null;
+    let notification: any = null;
+
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: WORKER_ID },
+      supabase: {
+        from: vi.fn(() => ({
+          ...invoiceQuery(baseInvoice("sent")),
+          ...updateSpy((row) => {
+            updatePayload = row;
+          }),
+        })),
+      },
+    });
+    (createServiceClient as any).mockReturnValue({
+      from: vi.fn(() => ({
+        insert: vi.fn((row: any) => {
+          notification = row;
+          return Promise.resolve({ error: null });
+        }),
+      })),
+    });
+
+    const res = await POST({} as any, params);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ invoice_id: INVOICE_ID, status: "cancelled" });
+    expect(updatePayload).toMatchObject({ status: "cancelled" });
+    expect(notification).toMatchObject({
+      user_id: POSTER_ID,
+      title: "Invoice revoked",
+    });
+  });
+
+  it("blocks anyone but the sender from revoking", async () => {
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: POSTER_ID },
+      supabase: { from: vi.fn(() => invoiceQuery(baseInvoice("sent"))) },
+    });
+
+    const res = await POST({} as any, params);
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Only the sender can revoke this invoice");
+  });
+
+  it("refuses to revoke a paid invoice", async () => {
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: WORKER_ID },
+      supabase: { from: vi.fn(() => invoiceQuery(baseInvoice("paid"))) },
+    });
+
+    const res = await POST({} as any, params);
+
+    expect(res.status).toBe(409);
+  });
+
+  it("is idempotent when the invoice is already cancelled", async () => {
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: WORKER_ID },
+      supabase: { from: vi.fn(() => invoiceQuery(baseInvoice("cancelled"))) },
+    });
+
+    const res = await POST({} as any, params);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ invoice_id: INVOICE_ID, status: "cancelled" });
+  });
+});

--- a/src/app/api/gigs/[id]/invoice/[invoiceId]/revoke/route.ts
+++ b/src/app/api/gigs/[id]/invoice/[invoiceId]/revoke/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthContext } from "@/lib/auth/get-user";
+import { createServiceClient } from "@/lib/supabase/service";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/gigs/[id]/invoice/[invoiceId]/revoke
+// Lets the sender (the worker who billed) take back an invoice they sent before
+// it's paid — e.g. they billed the wrong amount or forgot a PR link. Sets
+// status='cancelled' and notifies the payer. The worker can then send a fresh
+// invoice ("resend"), which the create route already allows because a cancelled
+// invoice no longer counts as an open (draft/sent) one.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; invoiceId: string }> }
+) {
+  try {
+    const { id: gigId, invoiceId } = await params;
+    const auth = await getAuthContext(request);
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { user, supabase } = auth;
+    const { data: invoice, error } = await (supabase as any)
+      .from("gig_invoices")
+      .select(
+        `
+          id,
+          gig_id,
+          worker_id,
+          poster_id,
+          amount_usd,
+          status,
+          gig:gigs(id, title)
+        `
+      )
+      .eq("id", invoiceId)
+      .eq("gig_id", gigId)
+      .maybeSingle();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    if (!invoice) {
+      return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    }
+    // Only the worker who sent the invoice can revoke it. (The payer's equivalent
+    // is "reject".)
+    if (invoice.worker_id !== user.id) {
+      return NextResponse.json(
+        { error: "Only the sender can revoke this invoice" },
+        { status: 403 }
+      );
+    }
+    if (invoice.status === "paid") {
+      return NextResponse.json(
+        { error: "A paid invoice can't be revoked." },
+        { status: 409 }
+      );
+    }
+    if (invoice.status === "cancelled") {
+      return NextResponse.json({ data: { invoice_id: invoice.id, status: "cancelled" } });
+    }
+    // A payer-rejected invoice is already off the table; treat revoke as a no-op
+    // so the sender can just go straight to resending.
+    if (invoice.status === "rejected") {
+      return NextResponse.json({ data: { invoice_id: invoice.id, status: "rejected" } });
+    }
+
+    const { error: updateError } = await (supabase as any)
+      .from("gig_invoices")
+      .update({
+        status: "cancelled",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", invoiceId);
+
+    if (updateError) {
+      return NextResponse.json({ error: updateError.message }, { status: 400 });
+    }
+
+    const gig = Array.isArray(invoice.gig) ? invoice.gig[0] : invoice.gig;
+    const title = gig?.title || "your gig";
+    const serviceSupabase = createServiceClient();
+    await (serviceSupabase.from("notifications") as any).insert({
+      user_id: invoice.poster_id,
+      type: "payment_received",
+      title: "Invoice revoked",
+      body: `The worker revoked their invoice for "${title}". A corrected one may follow.`,
+      data: {
+        gig_id: invoice.gig_id,
+        invoice_id: invoice.id,
+        previous_status: invoice.status,
+      },
+    });
+
+    return NextResponse.json({ data: { invoice_id: invoice.id, status: "cancelled" } });
+  } catch (err) {
+    console.error("[revoke invoice] failed:", err);
+    return NextResponse.json({ error: "Failed to revoke invoice" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/invoices/SentInvoiceActions.tsx
+++ b/src/app/dashboard/invoices/SentInvoiceActions.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Loader2, RefreshCw, Send } from "lucide-react";
+
+type InvoiceStatus =
+  | "draft"
+  | "sent"
+  | "paid"
+  | "cancelled"
+  | "expired"
+  | "rejected";
+
+interface SentInvoiceActionsProps {
+  invoiceId: string;
+  gigId: string;
+  status: InvoiceStatus;
+}
+
+// Sender-side controls on the "Invoices Sent" tab: revoke an invoice you sent
+// before it's paid, or resend a corrected one after it was revoked/rejected.
+// Resend hands off to the gig page, where the invoice form pre-fills from the
+// original (it has the wallet + line-item context this list doesn't).
+export function SentInvoiceActions({ invoiceId, gigId, status }: SentInvoiceActionsProps) {
+  const router = useRouter();
+  const [revoking, setRevoking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canRevoke = status === "sent" || status === "draft" || status === "expired";
+  const canResend = status === "cancelled" || status === "rejected";
+
+  if (!canRevoke && !canResend) return null;
+
+  const revoke = async () => {
+    setRevoking(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/gigs/${gigId}/invoice/${invoiceId}/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || "Failed to revoke invoice");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setRevoking(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2">
+      {canRevoke && (
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={revoke}
+          disabled={revoking}
+          className="gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
+        >
+          {revoking ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+          Revoke invoice
+        </Button>
+      )}
+      {canResend && (
+        <Link
+          href={`/gigs/${gigId}`}
+          className={buttonVariants({ size: "sm", variant: "outline", className: "gap-2" })}
+        >
+          <Send className="h-4 w-4" />
+          Resend invoice
+        </Link>
+      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { InvoicePaymentActions } from "./InvoicePaymentActions";
 import { InvoiceCharges } from "./InvoiceCharges";
+import { SentInvoiceActions } from "./SentInvoiceActions";
 import {
   ArrowLeft,
   ExternalLink,
@@ -416,6 +417,12 @@ export default async function InvoicesDashboardPage({
                       </div>
                     )}
 
+                    {tab === "sent" && inv.status === "cancelled" && (
+                      <div className="mb-3 rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+                        You revoked this invoice. Resend a corrected one from the gig.
+                      </div>
+                    )}
+
                     <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
                       <span>
                         Created {new Date(inv.created_at).toLocaleDateString()}
@@ -452,6 +459,14 @@ export default async function InvoicesDashboardPage({
                           rejectionReason={inv.rejection_reason}
                         />
                       </div>
+                    )}
+
+                    {tab === "sent" && (
+                      <SentInvoiceActions
+                        invoiceId={inv.id}
+                        gigId={inv.gig_id}
+                        status={inv.status}
+                      />
                     )}
                   </div>
                 );

--- a/src/components/gigs/InvoiceButton.tsx
+++ b/src/components/gigs/InvoiceButton.tsx
@@ -56,6 +56,7 @@ interface GigInvoice {
   pay_url: string | null;
   notes: string | null;
   due_date: string | null;
+  rejection_reason?: string | null;
   created_at: string;
   metadata?: {
     payment_address?: string | null;
@@ -68,7 +69,18 @@ interface GigInvoice {
     expires_at?: string | null;
     replacement_requested_at?: string | null;
     pr_links?: string[] | null;
+    category?: string | null;
   } | null;
+  // Line items (present when the invoice was itemized) — used to pre-fill the
+  // form when the worker resends a revoked or rejected invoice.
+  items?: {
+    description: string | null;
+    quantity: number | null;
+    unit_price_usd: number | null;
+    amount_usd: number;
+    link: string | null;
+    position: number;
+  }[] | null;
   worker?: { id: string; username: string; full_name?: string };
   poster?: { id: string; username: string; full_name?: string };
 }
@@ -128,6 +140,7 @@ export function InvoiceButton({
   const [walletErrorInvoiceId, setWalletErrorInvoiceId] = useState<string | null>(null);
   const [requestingNewId, setRequestingNewId] = useState<string | null>(null);
   const [requestedNewIds, setRequestedNewIds] = useState<string[]>([]);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
   const [wallets, setWallets] = useState<CoinPayWalletOption[]>([]);
   const [selectedWalletKey, setSelectedWalletKey] = useState("");
   const [walletsLoading, setWalletsLoading] = useState(false);
@@ -403,6 +416,72 @@ export function InvoiceButton({
     }
   };
 
+  // Worker takes back an invoice they sent (wrong amount, missing PR, etc.).
+  // Marks it cancelled locally so the "Resend" affordance appears.
+  const handleRevoke = async (invoiceId: string) => {
+    setRevokingId(invoiceId);
+    setError(null);
+    try {
+      const response = await fetch(`/api/gigs/${gigId}/invoice/${invoiceId}/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        setError(result.error || "Failed to revoke invoice");
+        return;
+      }
+      setInvoices((prev) =>
+        prev.map((inv) =>
+          inv.id === invoiceId ? { ...inv, status: "cancelled" } : inv
+        )
+      );
+    } catch {
+      setError("An error occurred. Please try again.");
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  // Opens the invoice form pre-filled from a revoked/rejected invoice so the
+  // worker can fix and resend it. Submitting creates a fresh invoice (the create
+  // route allows it — a cancelled/rejected invoice isn't an open one). For sats
+  // gigs the stored amounts are USD, not the native unit, so we don't pre-fill
+  // prices there and let the worker re-enter them.
+  const startResend = (inv: GigInvoice) => {
+    const sourceItems = inv.items && inv.items.length > 0 ? inv.items : null;
+    if (sourceItems) {
+      setItems(
+        [...sourceItems]
+          .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+          .map((it) => ({
+            description: it.description ?? "",
+            quantity: String(it.quantity ?? 1),
+            unit_price: isSats ? "" : String(it.unit_price_usd ?? it.amount_usd ?? ""),
+            link: it.link ?? "",
+          }))
+      );
+    } else {
+      setItems([
+        {
+          description: inv.notes ?? "",
+          quantity: "1",
+          unit_price: isSats ? "" : String(inv.amount_usd ?? ""),
+          link: "",
+        },
+      ]);
+    }
+    setNotes(inv.notes ?? "");
+    setPrLinksText((inv.metadata?.pr_links ?? []).join("\n"));
+    const cat = (inv.metadata?.category as InvoiceCategory | undefined) ?? undefined;
+    setCategory(
+      cat && INVOICE_CATEGORIES.some((c) => c.value === cat) ? cat : "code"
+    );
+    setDueDate("");
+    setError(null);
+    setShowForm(true);
+  };
+
   const statusBadge = (status: string) => {
     switch (status) {
       case "draft":
@@ -426,7 +505,13 @@ export function InvoiceButton({
       case "cancelled":
         return (
           <Badge variant="secondary" className="gap-1">
-            Cancelled
+            Revoked
+          </Badge>
+        );
+      case "rejected":
+        return (
+          <Badge className="gap-1 bg-red-500/10 text-red-600 border-red-500/20">
+            Rejected
           </Badge>
         );
       case "expired":
@@ -559,6 +644,53 @@ export function InvoiceButton({
               <p className="text-sm text-blue-600">
                 📧 Invoice sent to client. Waiting for payment.
               </p>
+            )}
+
+            {/* Worker: rejection reason so they know what to fix before resending. */}
+            {isWorker && inv.status === "rejected" && (
+              <div className="rounded-md border border-red-500/20 bg-red-500/5 p-2 text-sm text-red-600">
+                <p className="font-medium">The client rejected this invoice.</p>
+                {inv.rejection_reason && (
+                  <p className="mt-0.5 text-red-600/80">Reason: {inv.rejection_reason}</p>
+                )}
+              </div>
+            )}
+
+            {isWorker && inv.status === "cancelled" && (
+              <p className="text-sm text-muted-foreground">
+                You revoked this invoice. Resend a corrected one below.
+              </p>
+            )}
+
+            {/* Worker controls: revoke an unpaid invoice, or resend a
+                revoked/rejected one as a fresh invoice. */}
+            {isWorker && (inv.status === "sent" || inv.status === "draft" || inv.status === "expired") && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleRevoke(inv.id)}
+                disabled={revokingId === inv.id}
+                className="gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              >
+                {revokingId === inv.id ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" />
+                )}
+                Revoke invoice
+              </Button>
+            )}
+
+            {isWorker && (inv.status === "cancelled" || inv.status === "rejected") && !showForm && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => startResend(inv)}
+                className="gap-2"
+              >
+                <Send className="h-4 w-4" />
+                Resend invoice
+              </Button>
             )}
 
             {inv.status === "paid" && <p className="text-sm text-green-600">✅ Invoice paid!</p>}


### PR DESCRIPTION
## Problem
A worker who sent an invoice had no way to take it back. The only mechanism to get a mistaken invoice off the table was for the **payer to reject it** — and after that there was no clear way for the sender to resend a corrected one.

## What this adds
- **`POST /api/gigs/[id]/invoice/[invoiceId]/revoke`** — sender-only (the worker who billed). Cancels a `draft`/`sent`/`expired` invoice (`status='cancelled'`) and notifies the payer. Idempotent for already-cancelled/rejected; refuses `paid`.
- **Gig-page `InvoiceButton`** — a **Revoke invoice** control on the worker's active invoices, plus a **Resend invoice** button on revoked/rejected ones that pre-fills the invoice form from the original (line items, notes, PR links, category). For sats-denominated gigs the stored amounts are USD, so prices are left blank on resend and re-entered.
- **Dashboard "Invoices Sent" tab** — Revoke on active invoices and a Resend hand-off to the gig page (where the pre-filled form and wallet context live).

Resend just creates a fresh invoice through the existing create route, which already allows it — a cancelled/rejected invoice no longer counts as an open (`draft`/`sent`) one, so the retry guard doesn't block it.

## Notes
- **No migration** — `cancelled` is already an allowed status and workers already have an UPDATE RLS policy.
- New route unit tests (4) cover: sender cancels + payer notified, non-sender blocked (403), paid refused (409), idempotent when already cancelled.

## Testing
- `vitest run` on the gigs API suite — 93 passed (incl. 4 new revoke tests).
- `tsc --noEmit` clean; `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)