### PR TITLE
Allow itemized invoices for multiple PR fixes

### DIFF
--- a/src/app/api/gigs/[id]/invoice/route.test.ts
+++ b/src/app/api/gigs/[id]/invoice/route.test.ts
@@ -574,6 +574,194 @@ describe("POST /api/gigs/[id]/invoice", () => {
     expect(createPayment).not.toHaveBeenCalled();
   });
 
+  it("allows a fixed-price code gig to bill multiple merged PRs in one itemized invoice", async () => {
+    const gig = {
+      id: GIG_ID,
+      title: "PR fixes",
+      poster_id: POSTER_ID,
+      payment_coin: "SOL",
+      budget_type: "fixed",
+      budget_min: 1,
+      budget_max: 1,
+    };
+    const application = {
+      id: APP_ID,
+      applicant_id: WORKER_ID,
+      status: "accepted",
+      proposed_rate: 1,
+    };
+    const prLinks = [
+      "https://github.com/profullstack/aiornot.vote/pull/15",
+      "https://github.com/profullstack/aiornot.vote/pull/19",
+    ];
+
+    let inserted: any = null;
+    let itemRows: any[] | null = null;
+    const sb = mockSupabase({
+      gigs: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: gig, error: null }),
+      },
+      applications: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: application, error: null }),
+      },
+      gig_invoices: mockInvoiceTable({
+        insertResult: { id: "local-inv-multi-pr", metadata: {} },
+        onInsert: (row) => {
+          inserted = row;
+        },
+      }),
+      profiles: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi
+          .fn()
+          .mockResolvedValue({ data: { username: "w", full_name: "Test Worker" }, error: null }),
+      },
+      notifications: { insert: vi.fn().mockResolvedValue({ error: null }) },
+    });
+    (getAuthContext as any).mockResolvedValue({ user: { id: WORKER_ID }, supabase: sb });
+    (createServiceClient as any).mockReturnValue({
+      auth: {
+        admin: {
+          getUserById: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { email: "poster@example.com" } } }),
+        },
+      },
+      from: vi.fn(() => ({
+        insert: vi.fn((rows: any[]) => {
+          itemRows = rows;
+          return Promise.resolve({ error: null });
+        }),
+      })),
+    });
+
+    const res = await POST(
+      req({
+        application_id: APP_ID,
+        category: "code",
+        items: [{ description: "Merged PRs", quantity: 2, unit_price: 1 }],
+        payment_currency: "sol",
+        merchant_wallet_address: "So11111111111111111111111111111111111111112",
+        pr_links: prLinks,
+      }),
+      params
+    );
+
+    expect(res.status).toBe(201);
+    expect(inserted.amount_usd).toBe(2);
+    expect(inserted.metadata.pr_links).toEqual(prLinks);
+    expect(itemRows).toEqual([
+      expect.objectContaining({ quantity: 2, unit_price_usd: 1, amount_usd: 2 }),
+    ]);
+    expect(invoiceReceivedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ amountUsd: 2, prLinks })
+    );
+  });
+
+  it("still rejects a fixed-price code invoice above the agreed amount without enough PR links", async () => {
+    const gig = {
+      id: GIG_ID,
+      title: "PR fixes",
+      poster_id: POSTER_ID,
+      payment_coin: "SOL",
+      budget_type: "fixed",
+      budget_min: 1,
+      budget_max: 1,
+    };
+    const application = {
+      id: APP_ID,
+      applicant_id: WORKER_ID,
+      status: "accepted",
+      proposed_rate: 1,
+    };
+
+    const sb = mockSupabase({
+      gigs: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: gig, error: null }),
+      },
+      applications: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: application, error: null }),
+      },
+    });
+    (getAuthContext as any).mockResolvedValue({ user: { id: WORKER_ID }, supabase: sb });
+
+    const res = await POST(
+      req({
+        application_id: APP_ID,
+        category: "code",
+        items: [{ description: "Merged PRs", quantity: 2, unit_price: 1 }],
+        payment_currency: "sol",
+        merchant_wallet_address: "So11111111111111111111111111111111111111112",
+        pr_links: ["https://github.com/profullstack/aiornot.vote/pull/15"],
+      }),
+      params
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/exceeds the agreed amount/i);
+  });
+
+  it("does not count the same PR twice when owner or repo casing differs", async () => {
+    const gig = {
+      id: GIG_ID,
+      title: "PR fixes",
+      poster_id: POSTER_ID,
+      payment_coin: "SOL",
+      budget_type: "fixed",
+      budget_min: 1,
+      budget_max: 1,
+    };
+    const application = {
+      id: APP_ID,
+      applicant_id: WORKER_ID,
+      status: "accepted",
+      proposed_rate: 1,
+    };
+
+    const sb = mockSupabase({
+      gigs: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: gig, error: null }),
+      },
+      applications: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: application, error: null }),
+      },
+    });
+    (getAuthContext as any).mockResolvedValue({ user: { id: WORKER_ID }, supabase: sb });
+
+    const res = await POST(
+      req({
+        application_id: APP_ID,
+        category: "code",
+        items: [{ description: "Merged PRs", quantity: 2, unit_price: 1 }],
+        payment_currency: "sol",
+        merchant_wallet_address: "So11111111111111111111111111111111111111112",
+        pr_links: [
+          "https://github.com/profullstack/aiornot.vote/pull/15",
+          "https://github.com/ProFullStack/AIOrNot.Vote/pull/15",
+        ],
+      }),
+      params
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/exceeds the agreed amount/i);
+  });
+
   it("caps bounty-type gigs at the agreed amount too (not just fixed)", async () => {
     const gig = {
       id: GIG_ID,

--- a/src/app/api/gigs/[id]/invoice/route.ts
+++ b/src/app/api/gigs/[id]/invoice/route.ts
@@ -94,6 +94,42 @@ const COINPAY_WALLET_SETUP_INSTRUCTIONS = [
   "Paste those addresses into Settings > Global Wallet Addresses in CoinPay, then refresh the invoice form.",
 ];
 
+function countSinglePullRequestLinks(links: string[]) {
+  return new Set(
+    links
+      .map((url) => parseGitHubPullUrl(url))
+      .filter((pr): pr is NonNullable<typeof pr> => pr !== null)
+      .map((pr) => `${pr.owner.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`)
+  ).size;
+}
+
+function canBillMultipleCodePrsOnSinglePayoutGig({
+  category,
+  lineItems,
+  agreedCap,
+  prLinks,
+}: {
+  category?: (typeof INVOICE_CATEGORIES)[number];
+  lineItems: Array<{ quantity: number; unit_price: number }>;
+  agreedCap: number;
+  prLinks: string[];
+}) {
+  if (category !== "code" || lineItems.length === 0) return false;
+
+  const billedUnits = lineItems.reduce((sum, it) => sum + it.quantity, 0);
+  const billIsWholePrUnits = lineItems.every((it) => Number.isInteger(it.quantity));
+  const eachUnitAtOrBelowAgreedRate = lineItems.every(
+    (it) => it.unit_price <= agreedCap + 1e-6
+  );
+
+  return (
+    billedUnits > 1 &&
+    billIsWholePrUnits &&
+    eachUnitAtOrBelowAgreedRate &&
+    countSinglePullRequestLinks(prLinks) >= billedUnits
+  );
+}
+
 // GET /api/gigs/[id]/invoice - Get invoices for a gig
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -251,7 +287,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
           { status: 400 }
         );
       }
-      if (nativeTotal > agreedCap + 1e-6) {
+      const canBillMultipleCodePrs = canBillMultipleCodePrsOnSinglePayoutGig({
+        category,
+        lineItems,
+        agreedCap,
+        prLinks: allPrLinks,
+      });
+
+      if (nativeTotal > agreedCap + 1e-6 && !canBillMultipleCodePrs) {
         return NextResponse.json(
           {
             error: `Invoice total (${fmtNative(nativeTotal)}) exceeds the agreed amount for this gig (${fmtNative(
@@ -489,7 +532,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
           native_amount: nativeTotal,
           ...(category ? { category } : {}),
           ...(isSats ? { btc_usd_rate: btcUsd } : {}),
-          ...(prLinks.length > 0 ? { pr_links: prLinks } : {}),
+          ...(allPrLinks.length > 0 ? { pr_links: allPrLinks } : {}),
         },
       })
       .select()
@@ -566,7 +609,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
             gigTitle: gig.title,
             amountUsd: total,
             invoiceId: invoice.id,
-            prLinks,
+            prLinks: allPrLinks,
             items: lineItems.map((it) => ({
               description: it.description,
               quantity: it.quantity,

--- a/src/components/gigs/InvoiceButton.tsx
+++ b/src/components/gigs/InvoiceButton.tsx
@@ -15,7 +15,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { CryptoPaymentBox } from "@/components/payments/CryptoPaymentBox";
-import { isGitHubPrLink } from "@/lib/github-links";
+import { isGitHubPrLink, parseGitHubPullUrl } from "@/lib/github-links";
 
 interface CoinPayWalletOption {
   currency: string;
@@ -114,6 +114,55 @@ const INVOICE_CATEGORIES = [
   { value: "other", label: "Other" },
 ] as const;
 type InvoiceCategory = (typeof INVOICE_CATEGORIES)[number]["value"];
+
+type InvoiceLineForCap = { quantity: number; unit_price: number; link?: string };
+
+function parsePrLinksText(value: string) {
+  return value
+    .split(/[\n,]+/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+function countSinglePullRequestLinks(links: string[]) {
+  return new Set(
+    links
+      .map((url) => parseGitHubPullUrl(url))
+      .filter((pr): pr is NonNullable<typeof pr> => pr !== null)
+      .map((pr) => `${pr.owner.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`)
+  ).size;
+}
+
+function canBillMultipleCodePrs({
+  category,
+  capAmount,
+  lineItems,
+  prLinks,
+}: {
+  category: InvoiceCategory;
+  capAmount: number | null;
+  lineItems: InvoiceLineForCap[];
+  prLinks: string[];
+}) {
+  if (category !== "code" || capAmount == null || lineItems.length === 0) return false;
+
+  const billedUnits = lineItems.reduce((sum, it) => sum + it.quantity, 0);
+  const billIsWholePrUnits = lineItems.every((it) => Number.isInteger(it.quantity));
+  const eachUnitAtOrBelowAgreedRate = lineItems.every(
+    (it) => it.unit_price <= capAmount + 1e-6
+  );
+  const allPrLinks = [
+    ...prLinks,
+    ...lineItems.map((it) => it.link).filter((link): link is string => Boolean(link)),
+  ];
+
+  return (
+    billedUnits > 1 &&
+    billIsWholePrUnits &&
+    eachUnitAtOrBelowAgreedRate &&
+    countSinglePullRequestLinks(allPrLinks) >= billedUnits
+  );
+}
 
 export function InvoiceButton({
   gigId,
@@ -237,22 +286,26 @@ export function InvoiceButton({
       lineItems.reduce((s, it) => s + it.quantity * it.unit_price, 0) * 100
     ) / 100;
 
-    if (capAmount != null && total > capAmount + 1e-6) {
-      const fmt = (n: number) =>
-        isSats ? `${n.toLocaleString()} sats` : `$${n.toFixed(2)}`;
-      setError(`Invoice total (${fmt(total)}) can't exceed the agreed amount (${fmt(capAmount)}).`);
-      return;
-    }
-
     // Split the textarea into one link per line/comma and validate each looks
     // like a GitHub PR URL (matches the server's check) before sending.
-    const prLinks = prLinksText
-      .split(/[\n,]+/)
-      .map((l) => l.trim())
-      .filter(Boolean);
+    const prLinks = parsePrLinksText(prLinksText);
     const badLink = prLinks.find((u) => !isGitHubPrLink(u));
     if (badLink) {
       setError(`Not a GitHub pull request link: ${badLink}`);
+      return;
+    }
+
+    const canExceedCapForMultiplePrs = canBillMultipleCodePrs({
+      category,
+      capAmount,
+      lineItems,
+      prLinks,
+    });
+
+    if (capAmount != null && total > capAmount + 1e-6 && !canExceedCapForMultiplePrs) {
+      const fmt = (n: number) =>
+        isSats ? `${n.toLocaleString()} sats` : `$${n.toFixed(2)}`;
+      setError(`Invoice total (${fmt(total)}) can't exceed the agreed amount (${fmt(capAmount)}).`);
       return;
     }
 
@@ -854,7 +907,21 @@ function InvoiceForm({
     const price = parseFloat(it.unit_price) || 0;
     return s + qty * price;
   }, 0);
-  const overCap = capAmount != null && total > capAmount + 1e-6;
+  const normalizedItems = items
+    .map((it) => ({
+      quantity: parseFloat(it.quantity) || 1,
+      unit_price: parseFloat(it.unit_price) || 0,
+      link: it.link.trim() || undefined,
+    }))
+    .filter((it) => Number.isFinite(it.unit_price) && it.unit_price > 0);
+  const canExceedCapForMultiplePrs = canBillMultipleCodePrs({
+    category,
+    capAmount,
+    lineItems: normalizedItems,
+    prLinks: parsePrLinksText(prLinksText),
+  });
+  const overCap =
+    capAmount != null && total > capAmount + 1e-6 && !canExceedCapForMultiplePrs;
   const fmtAmount = (n: number) =>
     isSats ? `${n.toLocaleString()} sats` : `$${n.toFixed(2)}`;
   const updateItem = (i: number, patch: Partial<LineItem>) =>


### PR DESCRIPTION
## Summary
- allow fixed/bounty code gigs to submit one itemized invoice for multiple PR fixes when enough direct PR links back the billed units
- keep the agreed-amount cap for non-code invoices, flat over-cap invoices, overpriced PR units, or invoices without enough unique PR links
- include both top-level and line-item PR links in invoice metadata/emails so posters can verify all merged work
- mirror the same validation in the invoice form so the UI does not block valid multi-PR code invoices

## Why
The current fixed-price cap treats a $1 code gig as a single total payout, even when the work agreement is effectively $1 per merged PR. That prevents workers from submitting one clean invoice for 2+ merged PRs and forces serial revoke/resend invoice flows.

## Guardrails
- Only applies to category=code invoices with itemized line items
- Each billed unit must be at or below the agreed rate
- The invoice needs at least as many unique direct GitHub PR URLs as billed units
- GitHub owner/repo casing is normalized before dedupe so the same PR cannot be counted twice with different casing

## Tests
- pnpm exec vitest run 'src/app/api/gigs/[id]/invoice/route.test.ts' src/lib/github-links.test.ts
- pnpm run type-check
- pnpm exec eslint 'src/app/api/gigs/[id]/invoice/route.ts' 'src/app/api/gigs/[id]/invoice/route.test.ts' src/components/gigs/InvoiceButton.tsx
- pnpm run build
- pre-commit: full lint + type-check + test:run + build