### PR TITLE
Block payment requests for rejected invoices

### DIFF
--- a/src/app/api/gigs/[id]/invoice/[invoiceId]/payment-request/route.test.ts
+++ b/src/app/api/gigs/[id]/invoice/[invoiceId]/payment-request/route.test.ts
@@ -166,6 +166,30 @@ describe("POST /api/gigs/[id]/invoice/[invoiceId]/payment-request", () => {
     expect(createPayment).not.toHaveBeenCalled();
   });
 
+  it("does not create a payment request for a rejected invoice", async () => {
+    const invoice = {
+      ...payableInvoice({
+        receiver_payment_currency: "sol",
+        merchant_wallet_address: WALLET_ADDRESS,
+      }),
+      status: "rejected",
+    };
+
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: POSTER_ID },
+      supabase: { from: vi.fn(() => invoiceQuery(invoice)) },
+    });
+    (createServiceClient as any).mockReturnValue(serviceClient({ id: INVOICE_ID }));
+
+    const res = await POST({} as any, params);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invoice is not payable");
+    expect(createPayment).not.toHaveBeenCalled();
+    expect(createServiceClient).not.toHaveBeenCalled();
+  });
+
   it("returns the invoice receiving wallet metadata", async () => {
     const invoice = payableInvoice({
       receiver_payment_currency: "sol",

--- a/src/app/api/gigs/[id]/invoice/[invoiceId]/payment-request/route.ts
+++ b/src/app/api/gigs/[id]/invoice/[invoiceId]/payment-request/route.ts
@@ -6,6 +6,7 @@ import { createServiceClient } from "@/lib/supabase/service";
 export const dynamic = "force-dynamic";
 
 const PAYMENT_REQUEST_SECONDS = 15 * 60;
+const PAYABLE_INVOICE_STATUSES = new Set(["sent", "expired"]);
 type InvoiceContext =
   | { response: NextResponse }
   | {
@@ -76,7 +77,7 @@ async function loadInvoiceContext(
   if (invoice.status === "paid") {
     return { response: NextResponse.json({ error: "Invoice is already paid" }, { status: 400 }) };
   }
-  if (invoice.status === "cancelled" || invoice.status === "draft") {
+  if (!PAYABLE_INVOICE_STATUSES.has(invoice.status)) {
     return { response: NextResponse.json({ error: "Invoice is not payable" }, { status: 400 }) };
   }
 


### PR DESCRIPTION
## Summary
- Restrict invoice payment-request creation to payable invoice statuses only: sent and expired
- Keep paid invoices on the existing already-paid error path
- Add a regression test proving rejected invoices do not create CoinPay payment requests

## Why
Rejected invoices are blocked in the UI, but the payment-request endpoint could still create a fresh CoinPay request for status=rejected when called directly. That could revive an invoice the payer already rejected and confuse payment records.

## Tests
- pnpm test:run src/app/api/gigs/[id]/invoice/[invoiceId]/payment-request/route.test.ts
- pnpm type-check
- pnpm lint
- pre-commit hook: lint, type-check, full test suite, build