### PR TITLE
Guard escrow webhook state transitions

### DIFF
--- a/src/app/api/payments/coinpayportal/webhook/route.test.ts
+++ b/src/app/api/payments/coinpayportal/webhook/route.test.ts
@@ -547,6 +547,137 @@ describe("POST /api/payments/coinpayportal/webhook", () => {
     expect(notifChain.insert).not.toHaveBeenCalled();
   });
 
+  it("escrow.released does not release a pending payment escrow", async () => {
+    const payload = makeWebhookPayload("escrow.released", {
+      payment_id: "cp-escrow-pending",
+      status: "released",
+    });
+
+    const escrowFetchChain = chainResult({
+      data: {
+        id: "escrow-pending",
+        coinpay_escrow_id: "cp-escrow-pending",
+        status: "pending_payment",
+        application_id: "app-escrow",
+        gig_id: "gig-escrow",
+        worker_id: "worker-escrow",
+        poster_id: "poster-escrow",
+        amount_usd: 20,
+      },
+      error: null,
+    });
+    const escrowUpdateChain = chainResult({ data: null, error: null });
+    const appChain = chainResult({ data: null, error: null });
+    let escrowCalls = 0;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "gig_escrows") {
+        escrowCalls += 1;
+        return escrowCalls === 1 ? escrowFetchChain : escrowUpdateChain;
+      }
+      if (table === "applications") return appChain;
+      return chainResult({ data: null, error: null });
+    });
+
+    const res = await POST(makeRequest(payload, WEBHOOK_SECRET));
+    expect(res.status).toBe(200);
+    expect(escrowUpdateChain.update).not.toHaveBeenCalled();
+    expect(appChain.update).not.toHaveBeenCalled();
+  });
+
+  it("escrow.released transitions a funded escrow and completes the application", async () => {
+    const payload = makeWebhookPayload("escrow.released", {
+      payment_id: "cp-escrow-funded",
+      status: "released",
+    });
+
+    const escrowFetchChain = chainResult({
+      data: {
+        id: "escrow-funded",
+        coinpay_escrow_id: "cp-escrow-funded",
+        status: "funded",
+        application_id: "app-escrow",
+        gig_id: "gig-escrow",
+        worker_id: "worker-escrow",
+        poster_id: "poster-escrow",
+        amount_usd: 20,
+      },
+      error: null,
+    });
+    const escrowUpdateChain = chainResult({ data: { id: "escrow-funded" }, error: null });
+    const appChain = chainResult({ data: null, error: null });
+    let escrowCalls = 0;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "gig_escrows") {
+        escrowCalls += 1;
+        return escrowCalls === 1 ? escrowFetchChain : escrowUpdateChain;
+      }
+      if (table === "applications") return appChain;
+      return chainResult({ data: null, error: null });
+    });
+
+    const res = await POST(makeRequest(payload, WEBHOOK_SECRET));
+    expect(res.status).toBe(200);
+    expect(escrowUpdateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "released" })
+    );
+    expect(escrowUpdateChain.eq).toHaveBeenCalledWith("status", "funded");
+    expect(appChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "completed" })
+    );
+  });
+
+  it("escrow.refunded transitions a funded escrow and notifies the poster", async () => {
+    const payload = makeWebhookPayload("escrow.refunded", {
+      payment_id: "cp-escrow-funded",
+      status: "refunded",
+    });
+
+    const escrowFetchChain = chainResult({
+      data: {
+        id: "escrow-funded",
+        coinpay_escrow_id: "cp-escrow-funded",
+        status: "funded",
+        application_id: "app-escrow",
+        gig_id: "gig-escrow",
+        worker_id: "worker-escrow",
+        poster_id: "poster-escrow",
+        amount_usd: 20,
+      },
+      error: null,
+    });
+    const escrowUpdateChain = chainResult({ data: { id: "escrow-funded" }, error: null });
+    const notifChain = chainResult({ data: null, error: null });
+    let escrowCalls = 0;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "gig_escrows") {
+        escrowCalls += 1;
+        return escrowCalls === 1 ? escrowFetchChain : escrowUpdateChain;
+      }
+      if (table === "notifications") return notifChain;
+      return chainResult({ data: null, error: null });
+    });
+
+    const res = await POST(makeRequest(payload, WEBHOOK_SECRET));
+    expect(res.status).toBe(200);
+    expect(escrowUpdateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "refunded" })
+    );
+    expect(escrowUpdateChain.in).toHaveBeenCalledWith("status", [
+      "pending_payment",
+      "funded",
+      "disputed",
+    ]);
+    expect(notifChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "poster-escrow",
+        title: "Escrow refunded",
+      })
+    );
+  });
+
   it("escrow.refunded does not override an already released escrow", async () => {
     const payload = makeWebhookPayload("escrow.refunded", {
       payment_id: "cp-escrow-released",

--- a/src/app/api/payments/coinpayportal/webhook/route.test.ts
+++ b/src/app/api/payments/coinpayportal/webhook/route.test.ts
@@ -458,6 +458,133 @@ describe("POST /api/payments/coinpayportal/webhook", () => {
     expect(notifChain.insert).not.toHaveBeenCalled();
   });
 
+  it("escrow.funded transitions a pending escrow and sends funded notifications", async () => {
+    const payload = makeWebhookPayload("escrow.funded", {
+      payment_id: "cp-escrow-pending",
+      status: "funded",
+    });
+
+    const escrowFetchChain = chainResult({
+      data: {
+        id: "escrow-pending",
+        coinpay_escrow_id: "cp-escrow-pending",
+        status: "pending_payment",
+        application_id: "app-escrow",
+        gig_id: "gig-escrow",
+        worker_id: "worker-escrow",
+        poster_id: "poster-escrow",
+        amount_usd: 20,
+      },
+      error: null,
+    });
+    const escrowUpdateChain = chainResult({ data: { id: "escrow-pending" }, error: null });
+    const appChain = chainResult({ data: null, error: null });
+    const gigChain = chainResult({ data: { title: "Escrow bugfix" }, error: null });
+    const notifChain = chainResult({ data: null, error: null });
+    let escrowCalls = 0;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "gig_escrows") {
+        escrowCalls += 1;
+        return escrowCalls === 1 ? escrowFetchChain : escrowUpdateChain;
+      }
+      if (table === "applications") return appChain;
+      if (table === "gigs") return gigChain;
+      if (table === "notifications") return notifChain;
+      return chainResult({ data: null, error: null });
+    });
+
+    const res = await POST(makeRequest(payload, WEBHOOK_SECRET));
+    expect(res.status).toBe(200);
+    expect(escrowUpdateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "funded" })
+    );
+    expect(escrowUpdateChain.eq).toHaveBeenCalledWith("status", "pending_payment");
+    expect(appChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "in_progress" })
+    );
+    expect(notifChain.insert).toHaveBeenCalledTimes(2);
+  });
+
+  it("escrow.funded does not downgrade an already released escrow", async () => {
+    const payload = makeWebhookPayload("escrow.funded", {
+      payment_id: "cp-escrow-released",
+      status: "funded",
+    });
+
+    const escrowFetchChain = chainResult({
+      data: {
+        id: "escrow-released",
+        coinpay_escrow_id: "cp-escrow-released",
+        status: "released",
+        application_id: "app-escrow",
+        gig_id: "gig-escrow",
+        worker_id: "worker-escrow",
+        poster_id: "poster-escrow",
+        amount_usd: 20,
+      },
+      error: null,
+    });
+    const escrowUpdateChain = chainResult({ data: null, error: null });
+    const appChain = chainResult({ data: null, error: null });
+    const notifChain = chainResult({ data: null, error: null });
+    let escrowCalls = 0;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "gig_escrows") {
+        escrowCalls += 1;
+        return escrowCalls === 1 ? escrowFetchChain : escrowUpdateChain;
+      }
+      if (table === "applications") return appChain;
+      if (table === "notifications") return notifChain;
+      return chainResult({ data: null, error: null });
+    });
+
+    const res = await POST(makeRequest(payload, WEBHOOK_SECRET));
+    expect(res.status).toBe(200);
+    expect(escrowUpdateChain.update).not.toHaveBeenCalled();
+    expect(appChain.update).not.toHaveBeenCalled();
+    expect(notifChain.insert).not.toHaveBeenCalled();
+  });
+
+  it("escrow.refunded does not override an already released escrow", async () => {
+    const payload = makeWebhookPayload("escrow.refunded", {
+      payment_id: "cp-escrow-released",
+      status: "refunded",
+    });
+
+    const escrowFetchChain = chainResult({
+      data: {
+        id: "escrow-released",
+        coinpay_escrow_id: "cp-escrow-released",
+        status: "released",
+        application_id: "app-escrow",
+        gig_id: "gig-escrow",
+        worker_id: "worker-escrow",
+        poster_id: "poster-escrow",
+        amount_usd: 20,
+      },
+      error: null,
+    });
+    const escrowUpdateChain = chainResult({ data: null, error: null });
+    const notifChain = chainResult({ data: null, error: null });
+    let escrowCalls = 0;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "gig_escrows") {
+        escrowCalls += 1;
+        return escrowCalls === 1 ? escrowFetchChain : escrowUpdateChain;
+      }
+      if (table === "notifications") return notifChain;
+      return chainResult({ data: null, error: null });
+    });
+
+    const res = await POST(makeRequest(payload, WEBHOOK_SECRET));
+    expect(res.status).toBe(200);
+    expect(escrowUpdateChain.update).not.toHaveBeenCalled();
+    expect(notifChain.insert).not.toHaveBeenCalled();
+  });
+
   it("uses service client (not cookie-based auth)", async () => {
     // This test verifies the fix: service client is used for webhooks
     // The mock is set up for createServiceClient, not createClient

--- a/src/app/api/payments/coinpayportal/webhook/route.ts
+++ b/src/app/api/payments/coinpayportal/webhook/route.ts
@@ -7,6 +7,9 @@ import { parseGitHubIssueUrl } from "@/lib/github-links";
 import { updateIssueComment } from "@/lib/github-app";
 
 const PAYABLE_GIG_INVOICE_STATUSES = new Set(["sent", "expired"]);
+const ESCROW_FUNDABLE_STATUSES = ["pending_payment"] as const;
+const ESCROW_RELEASABLE_STATUSES = ["funded"] as const;
+const ESCROW_REFUNDABLE_STATUSES = ["pending_payment", "funded", "disputed"] as const;
 
 // POST /api/payments/coinpayportal/webhook - Handle CoinPayPortal webhooks
 export async function POST(request: NextRequest) {
@@ -747,6 +750,31 @@ async function updateGigInvoicePaymentMetadata(
 
 // ─── Escrow webhook handlers ───────────────────────────────────────────────
 
+async function transitionEscrowStatus(
+  supabase: ReturnType<typeof createServiceClient>,
+  escrowId: string,
+  allowedStatuses: readonly string[],
+  update: Record<string, unknown>
+): Promise<boolean> {
+  let query = (supabase as any)
+    .from("gig_escrows")
+    .update(update)
+    .eq("id", escrowId);
+
+  query =
+    allowedStatuses.length === 1
+      ? query.eq("status", allowedStatuses[0])
+      : query.in("status", Array.from(allowedStatuses));
+
+  const { data, error } = await query.select("id").single();
+
+  if (error || !data) {
+    return false;
+  }
+
+  return true;
+}
+
 async function handleEscrowFunded(
   supabase: ReturnType<typeof createServiceClient>,
   payload: CoinPayWebhookPayload
@@ -766,15 +794,19 @@ async function handleEscrowFunded(
     return;
   }
 
-  // Update escrow status
-  await (supabase as any)
-    .from("gig_escrows")
-    .update({
+  if (!ESCROW_FUNDABLE_STATUSES.includes(escrow.status as any)) return;
+
+  const transitioned = await transitionEscrowStatus(
+    supabase,
+    escrow.id,
+    ESCROW_FUNDABLE_STATUSES,
+    {
       status: "funded",
       funded_at: now,
       updated_at: now,
-    })
-    .eq("id", escrow.id);
+    }
+  );
+  if (!transitioned) return;
 
   // Update application status to in_progress
   await supabase
@@ -835,25 +867,29 @@ async function handleEscrowReleased(
     return;
   }
 
-  // Update if not already released (release route may have already updated)
-  if (escrow.status !== "released") {
-    await (supabase as any)
-      .from("gig_escrows")
-      .update({
-        status: "released",
-        released_at: now,
-        updated_at: now,
-      })
-      .eq("id", escrow.id);
+  // Release route may have already updated this record before the webhook arrives.
+  if (escrow.status === "released") return;
+  if (!ESCROW_RELEASABLE_STATUSES.includes(escrow.status as any)) return;
 
-    await supabase
-      .from("applications")
-      .update({
-        status: "completed" as any,
-        updated_at: now,
-      })
-      .eq("id", escrow.application_id);
-  }
+  const transitioned = await transitionEscrowStatus(
+    supabase,
+    escrow.id,
+    ESCROW_RELEASABLE_STATUSES,
+    {
+      status: "released",
+      released_at: now,
+      updated_at: now,
+    }
+  );
+  if (!transitioned) return;
+
+  await supabase
+    .from("applications")
+    .update({
+      status: "completed" as any,
+      updated_at: now,
+    })
+    .eq("id", escrow.application_id);
 }
 
 async function handleEscrowRefunded(
@@ -874,13 +910,18 @@ async function handleEscrowRefunded(
     return;
   }
 
-  await (supabase as any)
-    .from("gig_escrows")
-    .update({
+  if (!ESCROW_REFUNDABLE_STATUSES.includes(escrow.status as any)) return;
+
+  const transitioned = await transitionEscrowStatus(
+    supabase,
+    escrow.id,
+    ESCROW_REFUNDABLE_STATUSES,
+    {
       status: "refunded",
       updated_at: now,
-    })
-    .eq("id", escrow.id);
+    }
+  );
+  if (!transitioned) return;
 
   // Notify poster
   await supabase.from("notifications").insert({


### PR DESCRIPTION
## Summary
- Guard escrow webhook status updates with allowed current states so stale events cannot overwrite closed escrow states
- Keep funded, released, and refunded transitions idempotent before application updates or notifications run
- Add webhook tests for the pending funded flow and stale funded/refunded events on released escrows

## Tests
- pnpm test:run src/app/api/payments/coinpayportal/webhook/route.test.ts
- pnpm exec eslint src/app/api/payments/coinpayportal/webhook/route.ts src/app/api/payments/coinpayportal/webhook/route.test.ts
- pnpm type-check
- pre-commit hook: lint, type-check, full test suite, production build