### PR TITLE
fix(auth): compare webhook secrets by byte length

### DIFF
--- a/src/app/api/auth/backfill-dids/route.ts
+++ b/src/app/api/auth/backfill-dids/route.ts
@@ -6,14 +6,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { timingSafeEqual } from "crypto";
 import { createServiceClient } from "@/lib/supabase/service";
 import { generateAndStoreDid } from "@/lib/auth/did";
-
-function safeCompare(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
-}
+import { timingSafeStringEqual } from "@/lib/security/constant-time";
 
 export async function POST(request: NextRequest) {
   const authHeader = request.headers.get("authorization") || "";
@@ -24,7 +19,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Server misconfiguration" }, { status: 500 });
   }
 
-  if (!safeCompare(authHeader, `Bearer ${secret}`) && !safeCompare(authHeader, secret)) {
+  if (
+    !timingSafeStringEqual(authHeader, `Bearer ${secret}`) &&
+    !timingSafeStringEqual(authHeader, secret)
+  ) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/src/app/api/auth/confirmed/route.test.ts
+++ b/src/app/api/auth/confirmed/route.test.ts
@@ -162,6 +162,11 @@ describe("POST /api/auth/confirmed", () => {
       expect(res.status).toBe(401);
     });
 
+    it("rejects Unicode secrets with mismatched byte lengths", async () => {
+      const res = await POST(makeRequest(confirmationPayload(), "éest-webhook-secret"));
+      expect(res.status).toBe(401);
+    });
+
     it("returns 500 when AUTH_WEBHOOK_SECRET is not configured", async () => {
       delete process.env.AUTH_WEBHOOK_SECRET;
       const res = await POST(makeRequest(confirmationPayload(), null));

--- a/src/app/api/auth/confirmed/route.ts
+++ b/src/app/api/auth/confirmed/route.ts
@@ -13,13 +13,13 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { timingSafeEqual } from "crypto";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { sendEmail, welcomeEmail } from "@/lib/email";
 import { generateAndStoreDid } from "@/lib/auth/did";
 import { createUserLnWallet } from "@/lib/lightning/create-wallet";
 import { safeParseBody } from "@/lib/sanitize";
+import { timingSafeStringEqual } from "@/lib/security/constant-time";
 
 type AuthWebhookPayload = {
   type?: string;
@@ -33,11 +33,6 @@ type AuthWebhookPayload = {
   };
 };
 
-function safeCompare(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
-}
-
 export async function POST(request: NextRequest) {
   try {
     // Verify the webhook secret to prevent unauthorized calls
@@ -49,7 +44,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server misconfiguration" }, { status: 500 });
     }
 
-    if (!safeCompare(authHeader, `Bearer ${webhookSecret}`) && !safeCompare(authHeader, webhookSecret)) {
+    if (
+      !timingSafeStringEqual(authHeader, `Bearer ${webhookSecret}`) &&
+      !timingSafeStringEqual(authHeader, webhookSecret)
+    ) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/lib/security/constant-time.test.ts
+++ b/src/lib/security/constant-time.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { timingSafeStringEqual } from "./constant-time";
+
+describe("timingSafeStringEqual", () => {
+  it("compares equal and unequal ASCII strings", () => {
+    expect(timingSafeStringEqual("secret", "secret")).toBe(true);
+    expect(timingSafeStringEqual("secret", "public")).toBe(false);
+  });
+
+  it("rejects strings with equal character length but unequal byte length", () => {
+    expect(timingSafeStringEqual("é", "a")).toBe(false);
+  });
+});

--- a/src/lib/security/constant-time.ts
+++ b/src/lib/security/constant-time.ts
@@ -1,0 +1,7 @@
+import { timingSafeEqual } from "crypto";
+
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  const aBytes = Buffer.from(a);
+  const bBytes = Buffer.from(b);
+  return aBytes.length === bBytes.length && timingSafeEqual(aBytes, bBytes);
+}


### PR DESCRIPTION
## Summary
- compare authorization secrets using encoded byte lengths before `timingSafeEqual`
- share the constant-time string helper between the confirmation and DID backfill endpoints
- add Unicode regression coverage and an endpoint assertion for malformed authorization

## Bug
Both endpoints checked JavaScript character length before converting strings to buffers. An authorization value containing a multibyte character could have the same character count as the configured ASCII secret but a different byte length, causing `timingSafeEqual` to throw and return a server error instead of a normal 401 response.

## Tests
- constant-time helper tests: 2/2 passed
- changed-file ESLint: passed
- `git diff --check`: passed

## Notes
The confirmation route regression test is included, but the current reused installation cannot load `@profullstack/stack/email`; a fresh install is temporarily blocked by the minimum-release-age policy for today's package release. CI should exercise it with the current dependency set. No invoice will be sent until the PR is merged and accepted.