### PR TITLE
fix(tests): await in-flight requests in loading-state tests

### DIFF
--- a/src/components/notifications/NotificationBell.test.tsx
+++ b/src/components/notifications/NotificationBell.test.tsx
@@ -186,6 +186,13 @@ describe("NotificationBell", () => {
     fireEvent.click(button);
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
+
+    // Let the mocked 100ms request settle before the test ends — a timer that
+    // outlives the test fires after vitest tears down jsdom, and the resulting
+    // state update throws "window is not defined" from an unrelated file.
+    await waitFor(() =>
+      expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
+    );
   });
 
   it("marks notification as read when clicked", async () => {

--- a/src/components/reviews/ReviewForm.test.tsx
+++ b/src/components/reviews/ReviewForm.test.tsx
@@ -315,6 +315,15 @@ describe("ReviewForm", () => {
     fireEvent.click(submitButton);
 
     expect(screen.getByText("Submitting...")).toBeInTheDocument();
+
+    // Let the mocked 100ms request settle before the test ends. Otherwise the
+    // timer outlives the test, vitest tears down jsdom, and the component's
+    // late setIsSubmitting(false) hits React with no `window` — surfacing as
+    // "ReferenceError: window is not defined" in an unrelated file. It only
+    // reproduces under CI timing, so it reads as a random CI failure.
+    await waitFor(() =>
+      expect(screen.queryByText("Submitting...")).not.toBeInTheDocument()
+    );
   });
 
   it("trims comment before sending", async () => {


### PR DESCRIPTION
Fixes the `test` job failure on master ([run 30119962468](https://github.com/profullstack/ugig.net/actions/runs/30119962458)).

## What broke

```
ReferenceError: window is not defined
  ❯ resolveUpdatePriority  react-dom-client.development.js:1308
  ❯ dispatchSetState       react-dom-client.development.js:9126
  ❯ handleSubmit           src/components/reviews/ReviewForm.tsx:58
```

Two loading-state tests mock a request that resolves on a **100ms timer**, assert the loading text synchronously, then return without ever awaiting it:

```js
vi.mocked(reviewsApi.create).mockImplementation(
  () => new Promise((resolve) => setTimeout(() => resolve({...}), 100))
);
fireEvent.click(submitButton);
expect(screen.getByText("Submitting...")).toBeInTheDocument();
});  // <- test ends here; the timer is still pending
```

The timer outlives the test. Vitest tears down jsdom, then the component's `finally { setIsSubmitting(false) }` fires and reaches React with no `window`.

## Why it looked random

It only fails when teardown happens to land inside that 100ms window, so it passes locally and on PR branches and then fails on a master push — and it reports against whichever file was unlucky, not the one at fault.

Affected: `ReviewForm.test.tsx` and `NotificationBell.test.tsx` (same pattern).

## Fix

Await the loading state clearing, which keeps the request inside the test. This also strengthens both tests — they previously asserted only that the loading state *appeared*, never that it cleared.

## Not caused by the bulk-payments PR

The pattern dates to `e5703f3` (Jan 2026); #504 didn't touch either file. Adding a test file shifted worker timing just enough to expose the latent race.

Full suite: 1765 pass. Pre-commit gate (lint + type-check + tests + build) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)