### PR TITLE
fix(coinpay): read wallets whose chain field is a composite key like USDC_POL

### DIFF
--- a/src/lib/coinpayportal.test.ts
+++ b/src/lib/coinpayportal.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import crypto from "crypto";
 import {
+  coinToPaymentCurrency,
+  getCoinpayGlobalWalletTokens,
   createPayment,
   createInvoice,
   sendInvoice,
@@ -419,5 +421,73 @@ describe("CoinPayPortal invoice API", () => {
         }),
       })
     );
+  });
+});
+
+describe("coinToPaymentCurrency composite identifiers", () => {
+  it("resolves a composite chain token such as USDC_POL", () => {
+    expect(coinToPaymentCurrency({ chain: "USDC_POL" })).toBe("usdc_pol");
+    expect(coinToPaymentCurrency({ chain: "USDT_POL" })).toBe("usdt_pol");
+    expect(coinToPaymentCurrency({ cryptocurrency: "USDC_SOL" })).toBe("usdc_sol");
+  });
+
+  it("still resolves the bare symbol plus separate chain shape", () => {
+    expect(coinToPaymentCurrency({ symbol: "USDT", chain: "POL" })).toBe("usdt_pol");
+    expect(coinToPaymentCurrency({ symbol: "USDC", chain: "ETH" })).toBe("usdc_eth");
+    expect(coinToPaymentCurrency({ symbol: "BTC" })).toBe("btc");
+    expect(coinToPaymentCurrency({ currency: "pol" })).toBe("pol");
+  });
+
+  it("splits a symbol that carries its own chain suffix", () => {
+    expect(coinToPaymentCurrency({ symbol: "USDC-POLYGON" })).toBe("usdc_pol");
+    expect(coinToPaymentCurrency({ symbol: "USDT_ETHEREUM" })).toBe("usdt_eth");
+  });
+
+  it("returns null when nothing identifies the coin", () => {
+    expect(coinToPaymentCurrency({ id: "2d4d2744-a15f-4b60-9b26-8d97a70b07c3" })).toBeNull();
+  });
+});
+
+describe("getCoinpayGlobalWalletTokens via OAuth userinfo", () => {
+  const address = "0xd0f4279fe026eD763bb7619c8ed4ADDEc50BaE4f";
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes the wallets claim returned by /api/oauth/userinfo", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          sub: "ebf95dfc-09f5-4dab-80ab-74bdff9ba71d",
+          wallets: [
+            { address, chain: "USDC_POL", label: "Global", business_id: null },
+            { address, chain: "USDT_POL", label: "ClawedAssistant", business_id: "eca2d5c9" },
+          ],
+        }),
+      })
+    );
+
+    const wallets = await getCoinpayGlobalWalletTokens({ access_token: "cp_at_test" });
+
+    expect(wallets.map((wallet) => wallet.currency)).toEqual(["usdc_pol", "usdt_pol"]);
+    expect(wallets[0].address).toBe(address);
+    expect(wallets[1].label).toBe("ClawedAssistant");
+  });
+
+  it("drops wallets whose address does not match the chain", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          wallets: [{ address: "not-an-address", chain: "USDC_POL" }],
+        }),
+      })
+    );
+
+    await expect(getCoinpayGlobalWalletTokens({ access_token: "cp_at_test" })).resolves.toEqual([]);
   });
 });

--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -238,19 +238,59 @@ function normalizeCoinSymbol(value?: string | null): string {
     .replace(/[\s-]+/g, "_");
 }
 
+const COIN_IDENTIFIER_KEYS = [
+  "currency",
+  "cryptocurrency",
+  "code",
+  "symbol",
+  "id",
+  "chain",
+  "network",
+  "blockchain",
+] as const;
+
+/**
+ * Resolve a composite identifier such as "USDC_POL" that names both the coin and
+ * its chain in a single token. CoinPayPortal's OIDC userinfo `wallets` claim uses
+ * this shape (`{ address, chain: "USDC_POL" }`), as do the `cryptocurrency`
+ * columns of merchant_wallets and business_wallets. A composite match wins over a
+ * bare symbol found elsewhere on the record, because it carries the chain too.
+ */
+function compositeCurrencyKey(coin: SupportedCoin): SupportedCurrency | null {
+  for (const key of COIN_IDENTIFIER_KEYS) {
+    const raw = coin[key];
+    if (typeof raw !== "string") continue;
+    const normalized = normalizeCurrencyKey(raw);
+    if (normalized.includes("_") && isSupportedCurrency(normalized)) return normalized;
+  }
+  return null;
+}
+
 export function coinToPaymentCurrency(coin: SupportedCoin): SupportedCurrency | null {
+  const composite = compositeCurrencyKey(coin);
+  if (composite) return composite;
+
   const directCurrency =
     normalizeCurrencyKey(coin.currency) ||
     normalizeCurrencyKey(coin.id) ||
     normalizeCurrencyKey(coin.code);
   if (isSupportedCurrency(directCurrency)) return directCurrency;
 
-  const symbol =
+  const rawSymbol =
     normalizeCoinSymbol(coin.symbol) ||
     normalizeCoinSymbol(coin.code) ||
     normalizeCoinSymbol(coin.currency) ||
-    normalizeCoinSymbol(coin.id) || normalizeCoinSymbol(coin.chain);
+    normalizeCoinSymbol(typeof coin.cryptocurrency === "string" ? coin.cryptocurrency : null) ||
+    normalizeCoinSymbol(coin.id) ||
+    normalizeCoinSymbol(coin.chain);
+
+  // "USDC_POLYGON" and friends: the leading part is the symbol, the rest is the
+  // chain. A bare symbol splits to itself with no chain parts, so this is a no-op
+  // for the `{ symbol, chain }` shape returned by /api/get-tokens.
+  const [symbol, ...symbolChainParts] = rawSymbol.split("_");
+
   const chain =
+    symbolChainParts.join("_") ||
     normalizeCoinSymbol(coin.chain) ||
     normalizeCoinSymbol(coin.network) ||
     normalizeCoinSymbol(coin.blockchain);
@@ -271,7 +311,6 @@ export function coinToPaymentCurrency(coin: SupportedCoin): SupportedCurrency | 
     if (chain === "ETH" || chain === "ETHEREUM") return "usdc_eth";
     return "usdc_sol";
   }
-
   return null;
 }
 


### PR DESCRIPTION
## Problem

A user who has connected CoinPay with the `wallet:read` scope, and who has active Global Wallet Addresses on CoinPayPortal, still gets an empty wallet list from ugig:

```
GET /api/coinpay/wallets
{"wallets":[],"oauth_required":false,"setup_required":true}
```

`oauth_required: false` shows the OAuth grant is fine, so the setup instructions ugig returns ("connect your CoinPay account", "paste those addresses into Settings > Global Wallet Addresses") send the user round a loop they cannot escape. Invoicing is blocked because the invoice route gates on `workerWallets.length === 0`.

## Cause

`getCoinpayGlobalWalletTokens` reads wallets from CoinPayPortal's OIDC `/api/oauth/userinfo`. That endpoint returns each wallet as:

```json
{ "address": "0x...", "chain": "USDC_POL", "label": "...", "business_id": "..." }
```

One composite token, `USDC_POL`, names both the coin and its chain. `coinToPaymentCurrency` only handles a bare symbol plus a separate chain field:

- `directCurrency` looks at `currency`, `id` and `code`, none of which are present, so it is empty.
- `symbol` falls through to `coin.chain` and becomes `"USDC_POL"`, which matches none of the `BTC` / `ETH` / `USDT` / `USDC` branches.
- The function returns `null`, so `normalizeGlobalWallets` hits `if (!currency || !address) continue` and drops every wallet.

The same shape appears in the `cryptocurrency` column of `merchant_wallets` and `business_wallets`, so anything reading those rows directly is affected too. This became visible to more users after coinpayportal#197, which made userinfo return business wallets as well as account ones.

## Fix

- `compositeCurrencyKey` resolves an identifier that is already a supported currency key containing an underscore (`usdc_pol`, `usdt_pol`, `usdc_eth`, ...). A composite match wins over a bare symbol found elsewhere on the record, because it carries the chain too.
- The symbol lookup now also considers `cryptocurrency`, and splits a symbol that carries its own chain suffix, so `USDC-POLYGON` and `USDT_ETHEREUM` resolve through the existing branches.
- The `{ symbol: "USDT", chain: "POL" }` shape returned by `/api/get-tokens` is unchanged: a bare symbol splits to itself with no chain parts.

## Tests

Added to `src/lib/coinpayportal.test.ts`:

- `coinToPaymentCurrency` resolves composite tokens, still resolves the bare symbol plus chain shape, splits a suffixed symbol, and returns `null` when nothing identifies the coin.
- `getCoinpayGlobalWalletTokens` normalizes a real userinfo payload into `["usdc_pol", "usdt_pol"]`, and still drops a wallet whose address fails validation for its chain.

The three new failing assertions reproduce the bug on `master` before the change (`expected [] to deeply equal [ 'usdc_pol', 'usdt_pol' ]`).

Full suite after the change: 1803 tests across 197 files pass, and `tsc --noEmit` is clean.
