### PR TITLE
Guard affiliate commissions against non-finite amounts

### DIFF
--- a/src/lib/affiliates/commission.test.ts
+++ b/src/lib/affiliates/commission.test.ts
@@ -33,6 +33,34 @@ describe("calculateCommission", () => {
     );
     expect(result).toBe(0);
   });
+
+  it("returns 0 for non-finite sale amounts", () => {
+    const result = calculateCommission(
+      { commission_rate: 0.20, commission_type: "percentage", commission_flat_sats: 0 },
+      Number.POSITIVE_INFINITY
+    );
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 for non-finite commission settings", () => {
+    expect(
+      calculateCommission(
+        {
+          commission_rate: Number.POSITIVE_INFINITY,
+          commission_type: "percentage",
+          commission_flat_sats: 0,
+        },
+        10000
+      )
+    ).toBe(0);
+
+    expect(
+      calculateCommission(
+        { commission_rate: 0.20, commission_type: "flat", commission_flat_sats: Number.NaN },
+        10000
+      )
+    ).toBe(0);
+  });
 });
 
 describe("calculatePlatformFee", () => {
@@ -46,6 +74,11 @@ describe("calculatePlatformFee", () => {
 
   it("returns 0 for zero commission", () => {
     expect(calculatePlatformFee(0)).toBe(0);
+  });
+
+  it("returns 0 for non-finite commission", () => {
+    expect(calculatePlatformFee(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(calculatePlatformFee(Number.NaN)).toBe(0);
   });
 });
 
@@ -143,6 +176,23 @@ function createAdminMock(options: {
 }
 
 describe("recordConversion", () => {
+  it("rejects non-finite sale amounts before fetching an offer", async () => {
+    const { admin, calls } = createAdminMock();
+
+    const result = await recordConversion(admin as never, {
+      offerId: "offer_1",
+      affiliateId: "affiliate_1",
+      saleAmountSats: Number.POSITIVE_INFINITY,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Sale amount must be a positive finite number",
+    });
+    expect(calls.some((call) => call.table === "affiliate_offers")).toBe(false);
+    expect(calls.some((call) => call.op === "insert")).toBe(false);
+  });
+
   it("returns an existing purchase conversion without inserting or incrementing metrics", async () => {
     const existingConversion = {
       id: "conversion_existing",

--- a/src/lib/affiliates/commission.ts
+++ b/src/lib/affiliates/commission.ts
@@ -56,9 +56,20 @@ export function calculateCommission(
   offer: Pick<AffiliateOffer, "commission_rate" | "commission_type" | "commission_flat_sats">,
   saleAmountSats: number
 ): number {
-  if (offer.commission_type === "flat") {
-    return offer.commission_flat_sats || 0;
+  if (!Number.isFinite(saleAmountSats) || saleAmountSats <= 0) {
+    return 0;
   }
+
+  if (offer.commission_type === "flat") {
+    return Number.isFinite(offer.commission_flat_sats) && offer.commission_flat_sats > 0
+      ? offer.commission_flat_sats
+      : 0;
+  }
+
+  if (!Number.isFinite(offer.commission_rate) || offer.commission_rate <= 0) {
+    return 0;
+  }
+
   return Math.floor(saleAmountSats * offer.commission_rate);
 }
 
@@ -66,6 +77,10 @@ export function calculateCommission(
  * Calculate platform fee on a commission (platform takes a cut of the commission, not the sale).
  */
 export function calculatePlatformFee(commissionSats: number): number {
+  if (!Number.isFinite(commissionSats) || commissionSats <= 0) {
+    return 0;
+  }
+
   return Math.floor(commissionSats * AFFILIATE_DEFAULTS.platformFeeRate);
 }
 
@@ -88,6 +103,10 @@ export async function recordConversion(
 
   const existing = await findConversionByPurchaseId(admin, purchaseId);
   if (existing) return existing;
+
+  if (!Number.isFinite(saleAmountSats) || saleAmountSats <= 0) {
+    return { ok: false, error: "Sale amount must be a positive finite number" };
+  }
 
   // Fetch offer
   const { data: offer, error: offerErr } = await (admin as AnySupabase)


### PR DESCRIPTION
## Summary
- Reject non-finite or non-positive affiliate sale amounts before creating conversions
- Guard commission and platform fee calculations against NaN/Infinity inputs
- Add regression coverage for non-finite sale amounts and commission settings

## Why
`recordConversion` is shared by automatic purchase flows as well as manual conversions. If an unexpected non-finite amount reached the helper, it could produce non-finite commission values and pollute conversion records or aggregate metrics.

## Tests
- `node_modules\\.bin\\vitest.cmd run src/lib/affiliates/commission.test.ts`
- `git diff --check`