### PR TITLE
fix: return 400 instead of 500 for malformed JSON body in POST /api/bounties

### DIFF
--- a/src/app/api/bounties/route.test.ts
+++ b/src/app/api/bounties/route.test.ts
@@ -4,8 +4,13 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }));
 
-import { GET } from "./route";
+vi.mock("@/lib/auth/get-user", () => ({
+  getAuthContext: vi.fn(),
+}));
+
+import { GET, POST } from "./route";
 import { createClient } from "@/lib/supabase/server";
+import { getAuthContext } from "@/lib/auth/get-user";
 
 function makeReq(url: string) {
   return { nextUrl: new URL(url) } as any;
@@ -57,6 +62,25 @@ describe("GET /api/bounties", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toMatch(/invalid limit/i);
+  });
+});
+
+describe("POST /api/bounties", () => {
+  it("returns 400 for malformed JSON body and never calls Supabase", async () => {
+    (getAuthContext as any).mockResolvedValue({
+      user: { id: "u1", email: "a@b.com" },
+      supabase: {},
+    });
+
+    const malformedReq = {
+      json: vi.fn().mockRejectedValue(new Error("Unexpected token")),
+    } as any;
+
+    const res = await POST(malformedReq);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/malformed json/i);
   });
 });
 

--- a/src/app/api/bounties/route.ts
+++ b/src/app/api/bounties/route.ts
@@ -109,7 +109,15 @@ export async function POST(request: NextRequest) {
     }
     const { user, supabase } = auth;
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Malformed JSON body" },
+        { status: 400 }
+      );
+    }
     const parsed = createBountySchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(


### PR DESCRIPTION
## Problem
`POST /api/bounties` returns HTTP 500 for malformed JSON because `request.json()` throws inside the broad error handler.

## Fix
Added inner try/catch around `request.json()` that returns HTTP 400 before reaching schema validation or the database.

## Changes
- `route.ts`: Catch JSON parse errors explicitly
- `route.test.ts`: Added regression test

## Test
```
✓ POST /api/bounties > returns 400 for malformed JSON body and never calls Supabase
```

Closes #509