### PR TITLE
fix(masspay): survive CoinPay's rate limit instead of writing off invoices

### DIFF
--- a/src/app/api/invoices/bulk-payment-request/route.test.ts
+++ b/src/app/api/invoices/bulk-payment-request/route.test.ts
@@ -17,6 +17,7 @@ import { POST } from "./route";
 import { createPayment } from "@/lib/coinpayportal";
 import { getAuthContext } from "@/lib/auth/get-user";
 import { createServiceClient } from "@/lib/supabase/service";
+import { CoinpayRateLimitError } from "@/lib/coinpay-throttle";
 
 const POSTER_ID = "4f16c625-c37a-4654-82db-e391067cbb13";
 const WORKER_ID = "666cbaba-c6ea-4756-ad44-d6a5b4248f8f";
@@ -231,6 +232,53 @@ describe("POST /api/invoices/bulk-payment-request", () => {
     expect(res.status).toBe(200);
     expect(body.data.payments.map((p: any) => p.id)).toEqual([ID_B]);
     expect(body.data.skipped[0]).toMatchObject({ id: ID_A, reason: "CoinPay is down" });
+  });
+
+  it("marks a rate-limited invoice retryable, not written off", async () => {
+    // The bug this guards: CoinPay limits every /api/ route to 60 requests a
+    // minute per IP, so a bulk run exhausts it mid-batch. Every one of those is
+    // a payable invoice — reporting them like "already paid" or "not accepted"
+    // is how a whole payroll run got reported as un-payable.
+    mockAuth([invoice(ID_A), invoice(ID_B)]);
+    mockPaymentCreation();
+    const succeed = (createPayment as any).getMockImplementation();
+    (createPayment as any).mockImplementation(async (opts: any) => {
+      if (opts.metadata.invoice_id === ID_A) throw new CoinpayRateLimitError();
+      return succeed(opts);
+    });
+
+    const res = await POST(request({ invoice_ids: [ID_A, ID_B] }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.payments.map((p: any) => p.id)).toEqual([ID_B]);
+    expect(body.data.skipped).toHaveLength(1);
+    expect(body.data.skipped[0]).toMatchObject({ id: ID_A, retryable: true });
+    expect(body.data.skipped[0].reason).toMatch(/rate limit/i);
+  });
+
+  it("does not mark a genuine provider rejection retryable", async () => {
+    mockAuth([invoice(ID_A)]);
+    (createPayment as any).mockRejectedValue(new Error("CoinPay create failed 400: bad currency"));
+
+    const res = await POST(request({ invoice_ids: [ID_A] }));
+    const body = await res.json();
+
+    expect(body.data.skipped[0]).toMatchObject({ id: ID_A, retryable: false });
+  });
+
+  it("bounds the batch with one shared deadline so early quotes stay live", async () => {
+    mockAuth([invoice(ID_A), invoice(ID_B)]);
+    mockPaymentCreation();
+
+    await POST(request({ invoice_ids: [ID_A, ID_B] }));
+
+    const deadlines = (createPayment as any).mock.calls.map((c: any[]) => c[0].deadline);
+    expect(deadlines).toHaveLength(2);
+    expect(deadlines[0]).toBeGreaterThan(Date.now());
+    // One deadline for the run, not a fresh budget per invoice — otherwise the
+    // last invoice could still be waiting long after the first quote expired.
+    expect(deadlines[1]).toBe(deadlines[0]);
   });
 
   it("skips an invoice with no quoted crypto amount", async () => {

--- a/src/app/api/invoices/bulk-payment-request/route.ts
+++ b/src/app/api/invoices/bulk-payment-request/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getAuthContext } from "@/lib/auth/get-user";
+import { isCoinpayRateLimitError } from "@/lib/coinpay-throttle";
 import {
   PAYABLE_INVOICE_STATUSES,
   ensureInvoicePaymentRequest,
@@ -28,9 +29,17 @@ export const dynamic = "force-dynamic";
 // 15-minute expiry clock that must outlast the on-chain sending that follows.
 const MAX_INVOICES = 100;
 
-// Enough concurrency to prepare 62 requests in seconds, low enough to stay
-// friendly to the payment provider's rate limits.
+// Enough concurrency to keep the provider busy. The real throughput limit is
+// the paced client in `coinpay-throttle`, which holds us inside CoinPay's
+// 60-requests-per-minute window rather than sprinting into a wall of 429s.
 const CONCURRENCY = 5;
+
+// How long the whole preparation may take. CoinPay's rolling limit means a
+// large batch has to wait out at least one window, so this cannot be short —
+// but every quote minted at the start is only good for 15 minutes, so it
+// cannot be long either. Anything still unprepared when it elapses comes back
+// as a retryable skip rather than holding the request open.
+const PREPARE_BUDGET_MS = 4 * 60_000;
 
 const bulkPaymentRequestSchema = z.object({
   invoice_ids: z.array(z.string().uuid()).min(1).max(MAX_INVOICES),
@@ -56,6 +65,13 @@ export interface BulkPaymentItem {
 export interface BulkPaymentSkip {
   id: string;
   reason: string;
+  /**
+   * True when the invoice itself is fine and only a transient condition — a
+   * provider rate limit, a dropped connection — stopped it. The UI offers these
+   * as a one-click retry; without the flag they look identical to "already
+   * paid", which is how 30 perfectly payable invoices got written off.
+   */
+  retryable?: boolean;
 }
 
 /** Run tasks with a bounded number in flight, preserving input order. */
@@ -165,15 +181,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       payable.push(invoice);
     }
 
+    // One deadline for the whole batch, not one per invoice: otherwise the last
+    // invoice could still be waiting out a rate-limit window long after the
+    // first invoice's quote expired.
+    const deadline = Date.now() + PREPARE_BUDGET_MS;
+
     const prepared = await mapWithConcurrency(payable, CONCURRENCY, async (invoice) => {
       try {
-        const result = await ensureInvoicePaymentRequest(invoice);
-        if (!result.ok) return { invoice, error: result.error };
+        const result = await ensureInvoicePaymentRequest(invoice, { deadline });
+        if (!result.ok) return { invoice, error: result.error, retryable: result.retryable };
         return { invoice, data: result.data, reused: result.reused };
       } catch (err) {
         return {
           invoice,
           error: err instanceof Error ? err.message : "Failed to create payment request",
+          retryable: isCoinpayRateLimitError(err),
         };
       }
     });
@@ -181,7 +203,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const payments: BulkPaymentItem[] = [];
     for (const entry of prepared) {
       if (!("data" in entry) || !entry.data) {
-        skipped.push({ id: entry.invoice.id, reason: entry.error || "Could not be prepared" });
+        skipped.push({
+          id: entry.invoice.id,
+          reason: entry.error || "Could not be prepared",
+          retryable: entry.retryable ?? false,
+        });
         continue;
       }
 

--- a/src/app/dashboard/invoices/BulkPayAccepted.tsx
+++ b/src/app/dashboard/invoices/BulkPayAccepted.tsx
@@ -52,6 +52,8 @@ interface PreparedPayment {
 interface SkippedInvoice {
   id: string;
   reason: string;
+  /** Transient — the invoice is payable, preparing it just did not get through. */
+  retryable?: boolean;
 }
 
 type Phase = "idle" | "preparing" | "confirming" | "paying" | "done";
@@ -176,6 +178,7 @@ export function BulkPayAccepted({ invoiceIds, totalUsd }: Props) {
 
   if (acceptedCount === 0) return null;
 
+  const retryableSkips = skipped.filter((s) => s.retryable);
   const sentCount = results?.filter((r) => r.status === "sent").length ?? 0;
   const failedResults = results?.filter((r) => r.status !== "sent") ?? [];
   const labelFor = (id: string) => payments.find((p) => p.id === id)?.label || id;
@@ -265,6 +268,15 @@ export function BulkPayAccepted({ invoiceIds, totalUsd }: Props) {
             </details>
           )}
 
+          {/* A skip the payer can clear by waiting is not the same as one they
+              cannot, so it gets its own action rather than living in the list. */}
+          {retryableSkips.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {retryableSkips.length} of those hit a temporary limit at the payment
+              provider. Prepare them again to add them to this run.
+            </p>
+          )}
+
           <div className="flex flex-wrap items-center gap-2">
             <Button
               type="button"
@@ -275,6 +287,23 @@ export function BulkPayAccepted({ invoiceIds, totalUsd }: Props) {
               <Wallet className="h-4 w-4" />
               Approve in wallet
             </Button>
+            {retryableSkips.length > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  // Re-prepare the whole set: the already-prepared requests are
+                  // reused as-is, so this costs one provider call per invoice
+                  // that is actually still missing one.
+                  void prepare([
+                    ...payments.map((p) => p.id),
+                    ...retryableSkips.map((s) => s.id),
+                  ])
+                }
+              >
+                Prepare the {retryableSkips.length} that were limited
+              </Button>
+            )}
             <Button type="button" variant="ghost" onClick={() => setPhase("idle")}>
               Cancel
             </Button>

--- a/src/lib/coinpay-client.ts
+++ b/src/lib/coinpay-client.ts
@@ -1,4 +1,5 @@
 import { verifyCoinPayWebhook } from "@profullstack/stack/coinpay";
+import { coinpayFetch } from "@/lib/coinpay-throttle";
 
 const COINPAY_API_URL = "https://coinpayportal.com/api";
 
@@ -92,7 +93,7 @@ export async function createCoinpayPayment(opts: {
   const { apiKey, merchantId } = getCreds();
   const baseUrl =
     process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
-  const res = await fetch(`${COINPAY_API_URL}/payments/create`, {
+  const res = await coinpayFetch(`${COINPAY_API_URL}/payments/create`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -134,7 +135,7 @@ export async function getCoinpayPaymentStatus(paymentId: string): Promise<{
   tx_hash?: string | null;
 }> {
   const { apiKey } = getCreds();
-  const res = await fetch(`${COINPAY_API_URL}/payments/${paymentId}`, {
+  const res = await coinpayFetch(`${COINPAY_API_URL}/payments/${paymentId}`, {
     headers: { Authorization: `Bearer ${apiKey}` },
     cache: "no-store",
   });

--- a/src/lib/coinpay-throttle.test.ts
+++ b/src/lib/coinpay-throttle.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  coinpayFetch,
+  resetCoinpayThrottle,
+  CoinpayRateLimitError,
+  isCoinpayRateLimitError,
+} from "./coinpay-throttle";
+
+/**
+ * These tests are about one thing: a 429 from CoinPay must never end up
+ * recorded as "this invoice cannot be paid". A rate limit clears on its own.
+ */
+
+function response(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(status === 204 ? null : JSON.stringify({ ok: status < 400 }), {
+    status,
+    headers,
+  });
+}
+
+describe("coinpayFetch", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    resetCoinpayThrottle();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("passes a successful response straight through", async () => {
+    fetchMock.mockResolvedValue(response(200));
+
+    const res = await coinpayFetch("https://coinpayportal.com/api/payments/create");
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 429 and returns the eventual success", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(429, { "retry-after": "0" }))
+      .mockResolvedValueOnce(response(200));
+
+    const res = await coinpayFetch("https://coinpayportal.com/api/payments/create");
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a 5xx as well — a flaky provider is not a bad invoice", async () => {
+    fetchMock.mockResolvedValueOnce(response(502)).mockResolvedValueOnce(response(200));
+
+    const res = await coinpayFetch("https://coinpayportal.com/api/payments/create", undefined, {
+      deadline: Date.now() + 10_000,
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a 4xx that is the caller's fault", async () => {
+    fetchMock.mockResolvedValue(response(400));
+
+    const res = await coinpayFetch("https://coinpayportal.com/api/payments/create");
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands back a response it cannot classify instead of replaying it", async () => {
+    // A payment creation replayed on a guess mints a second live address for
+    // one debt, so anything without a readable status is returned as-is.
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    await coinpayFetch("https://coinpayportal.com/api/payments/create");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives back the 429 rather than throwing when retries run out", async () => {
+    fetchMock.mockResolvedValue(response(429, { "retry-after": "0" }));
+
+    const res = await coinpayFetch("https://coinpayportal.com/api/payments/create", undefined, {
+      deadline: Date.now() + 5_000,
+    });
+
+    expect(res.status).toBe(429);
+    // Bounded, not infinite.
+    expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  it("stops waiting once the deadline has passed", async () => {
+    // A 429 that says "come back in a minute" against an already-spent budget.
+    fetchMock.mockResolvedValue(response(429, { "retry-after": "60" }));
+
+    await coinpayFetch("https://coinpayportal.com/api/payments/create", undefined, {
+      deadline: Date.now() + 100,
+    });
+
+    // The first call goes out; waiting 60s past a 100ms deadline does not.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // A caller arriving now inherits the provider-stated block and, with no
+    // time budget left, fails fast instead of sitting on the request.
+    await expect(
+      coinpayFetch("https://coinpayportal.com/api/payments/create", undefined, {
+        deadline: Date.now() + 50,
+      })
+    ).rejects.toBeInstanceOf(CoinpayRateLimitError);
+  });
+
+  it("paces concurrent callers instead of firing them all at once", async () => {
+    // One slot per minute makes the pacing observable without waiting for it.
+    vi.stubEnv("COINPAY_MAX_REQUESTS_PER_MINUTE", "1");
+    vi.resetModules();
+    const throttle = await import("./coinpay-throttle");
+    throttle.resetCoinpayThrottle();
+
+    fetchMock.mockResolvedValue(response(200));
+
+    const first = throttle.coinpayFetch("https://coinpayportal.com/api/payments/create");
+    const second = throttle.coinpayFetch(
+      "https://coinpayportal.com/api/payments/create",
+      undefined,
+      {
+        deadline: Date.now() + 200,
+      }
+    );
+
+    await expect(first).resolves.toMatchObject({ status: 200 });
+    // The second has to wait out the window, which outlasts its budget.
+    await expect(second).rejects.toBeInstanceOf(throttle.CoinpayRateLimitError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllEnvs();
+  });
+
+  it("retries a dropped connection, then rethrows if it keeps dropping", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNRESET"));
+
+    await expect(
+      coinpayFetch("https://coinpayportal.com/api/payments/create", undefined, {
+        deadline: Date.now() + 3_000,
+      })
+    ).rejects.toThrow("ECONNRESET");
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+  });
+});
+
+describe("isCoinpayRateLimitError", () => {
+  it("distinguishes a rate limit from a provider rejection", () => {
+    expect(isCoinpayRateLimitError(new CoinpayRateLimitError())).toBe(true);
+    expect(isCoinpayRateLimitError(new Error("bad currency"))).toBe(false);
+    expect(isCoinpayRateLimitError(null)).toBe(false);
+  });
+});

--- a/src/lib/coinpay-throttle.ts
+++ b/src/lib/coinpay-throttle.ts
@@ -1,0 +1,221 @@
+/**
+ * Outbound pacing and retry for CoinPayPortal API calls.
+ *
+ * CoinPayPortal rate-limits *every* `/api/` route to 60 requests per rolling
+ * minute per client IP. ugig.net talks to it from a single server IP, so that
+ * budget is shared by every payment request, status poll and webhook replay the
+ * box makes — for all users at once. A bulk pay of 62 invoices fires 62 create
+ * calls, which alone exhausts the minute in seconds.
+ *
+ * A 429 is transient by definition: it clears when the window rolls. Treating
+ * one as a terminal error is what turned a whole payroll run into 30 invoices
+ * reported as un-payable. So every CoinPay call goes through here, which:
+ *
+ *   1. paces requests to stay inside the provider's window, and
+ *   2. retries the ones that get limited anyway, honouring `Retry-After`.
+ *
+ * The counters are per-process. `railway.json` pins `numReplicas: 1`, so one
+ * process is the whole outbound budget; if that ever scales out, lower
+ * `COINPAY_MAX_REQUESTS_PER_MINUTE` to this value divided by the replica count,
+ * because the provider counts the replicas together and we cannot see across
+ * them.
+ */
+
+const WINDOW_MS = 60_000;
+
+/**
+ * Requests we allow ourselves per rolling minute. Deliberately under the
+ * provider's 60 so single-invoice payments, status polls and OAuth calls
+ * sharing this IP still fit while a bulk run is in flight.
+ */
+const MAX_PER_WINDOW = positiveInt(process.env.COINPAY_MAX_REQUESTS_PER_MINUTE, 45);
+
+/** Total attempts per call, including the first. */
+const MAX_ATTEMPTS = positiveInt(process.env.COINPAY_MAX_ATTEMPTS, 4);
+
+/** How long a single call may spend waiting before it gives up. */
+const DEFAULT_BUDGET_MS = 120_000;
+
+/** Cap on any single sleep, so a wild `Retry-After` cannot park us for hours. */
+const MAX_SLEEP_MS = 65_000;
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
+/**
+ * Raised when a call could not be made within its time budget because the
+ * provider's rate limit was saturated. Distinct from a provider rejection: the
+ * request is still valid and will succeed once the window rolls.
+ */
+export class CoinpayRateLimitError extends Error {
+  readonly retryable = true;
+
+  constructor(message = "CoinPay rate limit reached — try again in a minute") {
+    super(message);
+    this.name = "CoinpayRateLimitError";
+  }
+}
+
+export function isCoinpayRateLimitError(error: unknown): boolean {
+  return error instanceof CoinpayRateLimitError;
+}
+
+// ── Rolling-window state ───────────────────────────────────────────────────
+
+/** Timestamps of the requests we have issued inside the current window. */
+let issuedAt: number[] = [];
+
+/**
+ * Set when the provider tells us we are over the limit. Our own accounting is
+ * optimistic — it cannot see traffic from other parts of the app — so their
+ * answer overrides it until the stated reset.
+ */
+let blockedUntil = 0;
+
+/** Serializes slot reservation so two callers cannot claim the same last slot. */
+let gate: Promise<void> = Promise.resolve();
+
+/** Test seam: drop all pacing state. */
+export function resetCoinpayThrottle(): void {
+  issuedAt = [];
+  blockedUntil = 0;
+  gate = Promise.resolve();
+}
+
+/**
+ * Take one slot in the rolling window, waiting for the window to roll if the
+ * budget is spent. Throws if waiting would run past `deadline`.
+ */
+async function reserveSlot(deadline: number): Promise<void> {
+  const previous = gate;
+  let release!: () => void;
+  gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+
+  try {
+    for (;;) {
+      const now = Date.now();
+      issuedAt = issuedAt.filter((at) => now - at < WINDOW_MS);
+
+      const windowWait = issuedAt.length < MAX_PER_WINDOW ? 0 : issuedAt[0]! + WINDOW_MS - now;
+      const wait = Math.max(windowWait, blockedUntil - now);
+
+      if (wait <= 0) {
+        issuedAt.push(now);
+        return;
+      }
+      if (now + wait > deadline) {
+        throw new CoinpayRateLimitError();
+      }
+      await sleep(Math.min(wait, MAX_SLEEP_MS));
+    }
+  } finally {
+    release();
+  }
+}
+
+// ── Retry ──────────────────────────────────────────────────────────────────
+
+/** How long the provider says to wait, from whichever header it sent. */
+function providerWaitMs(response: Response): number | null {
+  // Partial `Response` stand-ins do not always carry headers; without them we
+  // just fall back to backoff.
+  const headers: Headers | undefined = response.headers;
+  if (!headers) return null;
+
+  const retryAfter = headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+    const at = Date.parse(retryAfter);
+    if (!Number.isNaN(at)) return Math.max(0, at - Date.now());
+  }
+
+  const reset = Number(headers.get("x-ratelimit-reset"));
+  if (Number.isFinite(reset) && reset > 0) {
+    return Math.max(0, reset * 1000 - Date.now());
+  }
+
+  return null;
+}
+
+/** Exponential backoff with jitter, for when the provider tells us nothing. */
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_SLEEP_MS, 1000 * 2 ** (attempt - 1)) * (1 + Math.random() * 0.25);
+}
+
+export interface CoinpayFetchOptions {
+  /**
+   * Epoch ms after which we stop waiting and surface the failure. Callers
+   * preparing many payments should share one deadline so the batch as a whole
+   * stays bounded — quotes minted early must still be live at the end.
+   */
+  deadline?: number;
+  /** Short label for logs, e.g. `payments/create`. */
+  label?: string;
+}
+
+/**
+ * `fetch` for CoinPayPortal: paced against the provider's rolling limit, and
+ * retried on 429 or a 5xx.
+ *
+ * Returns the final `Response` untouched — including a last-attempt 429 — so
+ * callers keep their existing error handling. Only exhausting the time budget
+ * before a request could even be sent throws (`CoinpayRateLimitError`), because
+ * that is the one case with no response to hand back.
+ */
+export async function coinpayFetch(
+  url: string,
+  init?: RequestInit,
+  options: CoinpayFetchOptions = {}
+): Promise<Response> {
+  const deadline = options.deadline ?? Date.now() + DEFAULT_BUDGET_MS;
+  const label = options.label ?? url;
+
+  for (let attempt = 1; ; attempt++) {
+    await reserveSlot(deadline);
+
+    let response: Response;
+    try {
+      response = await fetch(url, init);
+    } catch (err) {
+      // A dropped connection mid-batch is as transient as a 429 and just as
+      // wrong to record as "this invoice cannot be paid".
+      const wait = backoffMs(attempt);
+      if (attempt >= MAX_ATTEMPTS || Date.now() + wait > deadline) throw err;
+      console.warn(`[coinpay] ${label} attempt ${attempt} failed: ${String(err)}`);
+      await sleep(wait);
+      continue;
+    }
+
+    // Only replay when we can positively identify a transient failure. A
+    // response we cannot classify is handed back untouched — re-sending a
+    // payment creation on a guess is far worse than surfacing it once.
+    const status = typeof response.status === "number" ? response.status : 0;
+    if (status !== 429 && status < 500) return response;
+
+    const wait = providerWaitMs(response) ?? backoffMs(attempt);
+    if (status === 429) {
+      // Their count is authoritative; hold every other caller off too.
+      blockedUntil = Math.max(blockedUntil, Date.now() + wait);
+    }
+
+    if (attempt >= MAX_ATTEMPTS || Date.now() + wait > deadline) return response;
+
+    // Drain before sleeping so the socket is not held open for the wait.
+    await Promise.resolve(response.text?.()).catch(() => "");
+    console.warn(
+      `[coinpay] ${label} got ${status}, retrying in ${Math.round(wait)}ms ` +
+        `(attempt ${attempt}/${MAX_ATTEMPTS})`
+    );
+    await sleep(Math.min(wait, MAX_SLEEP_MS));
+  }
+}

--- a/src/lib/coinpayportal.ts
+++ b/src/lib/coinpayportal.ts
@@ -1,4 +1,5 @@
 import { verifyCoinPayWebhook } from "@profullstack/stack/coinpay";
+import { coinpayFetch, CoinpayRateLimitError } from "@/lib/coinpay-throttle";
 
 const COINPAY_API_URL = "https://coinpayportal.com/api";
 
@@ -50,6 +51,11 @@ export interface CreatePaymentOptions {
   metadata?: Record<string, unknown>;
   business_id?: string;
   merchant_wallet_address?: string;
+  /**
+   * Epoch ms after which this call stops waiting out the provider's rate limit.
+   * Bulk callers pass one shared deadline so the batch stays bounded.
+   */
+  deadline?: number;
 }
 
 export interface CreatePaymentResponse {
@@ -138,33 +144,43 @@ export async function createPayment(options: CreatePaymentOptions): Promise<Crea
     throw new Error("CoinPayPortal credentials not configured");
   }
 
-  const response = await fetch(`${COINPAY_API_URL}/payments/create`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
+  const response = await coinpayFetch(
+    `${COINPAY_API_URL}/payments/create`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      cache: "no-store",
+      body: JSON.stringify({
+        business_id: merchantId,
+        amount_usd: options.amount_usd,
+        payment_method: "crypto",
+        currency: options.currency,
+        description: options.description,
+        success_url: options.redirect_url || appUrl,
+        cancel_url: options.redirect_url || appUrl,
+        redirect_url: options.redirect_url,
+        expires_at: options.expires_at,
+        expires_in: options.expires_in,
+        webhook_url: `${appUrl}/api/webhooks/coinpay`,
+        merchant_wallet_address: options.merchant_wallet_address,
+        metadata: options.metadata,
+      }),
     },
-    cache: "no-store",
-    body: JSON.stringify({
-      business_id: merchantId,
-      amount_usd: options.amount_usd,
-      payment_method: "crypto",
-      currency: options.currency,
-      description: options.description,
-      success_url: options.redirect_url || appUrl,
-      cancel_url: options.redirect_url || appUrl,
-      redirect_url: options.redirect_url,
-      expires_at: options.expires_at,
-      expires_in: options.expires_in,
-      webhook_url: `${appUrl}/api/webhooks/coinpay`,
-      merchant_wallet_address: options.merchant_wallet_address,
-      metadata: options.metadata,
-    }),
-  });
+    { label: "payments/create", deadline: options.deadline }
+  );
 
   if (!response.ok) {
     const text = await response.text();
     console.error(`[coinpayportal] create payment failed ${response.status}: ${text}`);
+
+    // Already retried and paced by `coinpayFetch`; still limited means the
+    // provider's budget is genuinely exhausted, not that this payment is bad.
+    if (response.status === 429) {
+      throw new CoinpayRateLimitError();
+    }
 
     let message = text;
     try {
@@ -503,7 +519,7 @@ export async function getCoinpayGlobalWalletTokens(
   // and /api/get-tokens endpoints use a different verifier (merchant-login
   // JWT or business API key) and reject OAuth access tokens.
   if (options.access_token) {
-    const response = await fetch(`${COINPAY_API_URL}/oauth/userinfo`, {
+    const response = await coinpayFetch(`${COINPAY_API_URL}/oauth/userinfo`, {
       headers: { Authorization: `Bearer ${options.access_token}` },
       cache: "no-store",
     });
@@ -537,7 +553,7 @@ export async function getCoinpayGlobalWalletTokens(
   let sawSuccessfulResponse = false;
 
   for (const url of urls) {
-    const response = await fetch(url.toString(), {
+    const response = await coinpayFetch(url.toString(), {
       headers: { Authorization: `Bearer ${apiKey}` },
       cache: "no-store",
     });
@@ -587,7 +603,7 @@ export async function getBusinessWalletCurrencies(
     throw new Error("CoinPayPortal credentials not configured");
   }
 
-  const response = await fetch(`${COINPAY_API_URL}/businesses/${businessId}`, {
+  const response = await coinpayFetch(`${COINPAY_API_URL}/businesses/${businessId}`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
@@ -640,7 +656,7 @@ export async function getSupportedCoins(
   if (businessId) url.searchParams.set("business_id", businessId);
   if (options.active_only !== false) url.searchParams.set("active_only", "true");
 
-  const response = await fetch(url.toString(), {
+  const response = await coinpayFetch(url.toString(), {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
@@ -700,7 +716,7 @@ export async function getPaymentStatus(paymentId: string): Promise<PaymentStatus
     throw new Error("CoinPayPortal credentials not configured");
   }
 
-  const response = await fetch(`${COINPAY_API_URL}/payments/${paymentId}`, {
+  const response = await coinpayFetch(`${COINPAY_API_URL}/payments/${paymentId}`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
@@ -772,7 +788,7 @@ export async function createEscrow(options: CreateEscrowOptions): Promise<Escrow
 
   const appUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || "https://ugig.net";
 
-  const response = await fetch(`${COINPAY_API_URL}/escrow`, {
+  const response = await coinpayFetch(`${COINPAY_API_URL}/escrow`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -814,7 +830,7 @@ export async function releaseEscrow(escrowId: string): Promise<EscrowStatusRespo
     throw new Error("CoinPayPortal credentials not configured");
   }
 
-  const response = await fetch(`${COINPAY_API_URL}/escrow/${escrowId}/release`, {
+  const response = await coinpayFetch(`${COINPAY_API_URL}/escrow/${escrowId}/release`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -865,7 +881,7 @@ export async function createInvoice(options: CreateInvoiceOptions): Promise<Invo
     throw new Error("CoinPayPortal credentials not configured");
   }
 
-  const response = await fetch(`${COINPAY_API_URL}/invoices`, {
+  const response = await coinpayFetch(`${COINPAY_API_URL}/invoices`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -901,7 +917,7 @@ export async function sendInvoice(invoiceId: string): Promise<InvoiceResponse> {
     throw new Error("CoinPayPortal credentials not configured");
   }
 
-  const response = await fetch(`${COINPAY_API_URL}/invoices/${invoiceId}/send`, {
+  const response = await coinpayFetch(`${COINPAY_API_URL}/invoices/${invoiceId}/send`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -927,7 +943,7 @@ export async function getEscrowStatus(escrowId: string): Promise<EscrowStatusRes
     throw new Error("CoinPayPortal credentials not configured");
   }
 
-  const response = await fetch(`${COINPAY_API_URL}/escrow/${escrowId}`, {
+  const response = await coinpayFetch(`${COINPAY_API_URL}/escrow/${escrowId}`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },

--- a/src/lib/invoices/payment-request.ts
+++ b/src/lib/invoices/payment-request.ts
@@ -1,4 +1,5 @@
 import { createPayment, preferredCoinToPaymentCurrency } from "@/lib/coinpayportal";
+import { isCoinpayRateLimitError } from "@/lib/coinpay-throttle";
 import { createServiceClient } from "@/lib/supabase/service";
 
 /**
@@ -27,7 +28,17 @@ export interface InvoicePaymentRequestData {
 
 export type PaymentRequestResult =
   | { ok: true; data: InvoicePaymentRequestData; reused: boolean }
-  | { ok: false; error: string; code: "NO_WALLET" | "PROVIDER" | "PERSIST" };
+  | {
+      ok: false;
+      error: string;
+      code: "NO_WALLET" | "PROVIDER" | "PERSIST" | "RATE_LIMITED";
+      /**
+       * True when nothing about this invoice is wrong and the same call would
+       * likely succeed shortly. The bulk payer surfaces these as retryable
+       * instead of burying them with "not accepted yet" style skips.
+       */
+      retryable?: boolean;
+    };
 
 export function metadataObject(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
@@ -82,7 +93,7 @@ function receivingWallet(metadata: Record<string, unknown>): {
  */
 export async function ensureInvoicePaymentRequest(
   invoice: any,
-  options: { appUrl?: string; businessId?: string } = {}
+  options: { appUrl?: string; businessId?: string; deadline?: number } = {}
 ): Promise<PaymentRequestResult> {
   const metadata = metadataObject(invoice.metadata);
 
@@ -124,6 +135,7 @@ export async function ensureInvoicePaymentRequest(
       currency: wallet.currency as any,
       description: invoice.notes || `Invoice for gig: ${gig?.title || invoice.gig_id}`,
       business_id: businessId,
+      deadline: options.deadline,
       merchant_wallet_address: wallet.address,
       redirect_url: `${appUrl}/dashboard/invoices?tab=received`,
       expires_in: PAYMENT_REQUEST_SECONDS,
@@ -142,6 +154,16 @@ export async function ensureInvoicePaymentRequest(
       },
     });
   } catch (err) {
+    if (isCoinpayRateLimitError(err)) {
+      // The invoice is fine — CoinPay's per-minute budget is spent. Saying so
+      // plainly keeps a whole payroll run from reading as un-payable.
+      return {
+        ok: false,
+        code: "RATE_LIMITED",
+        retryable: true,
+        error: "CoinPay is rate limiting us — retry this one in a minute",
+      };
+    }
     return {
       ok: false,
       code: "PROVIDER",


### PR DESCRIPTION
## The bug

A bulk pay run reported 30 accepted invoices as un-payable:

```
67af1bc1… — CoinPay create failed 429: Too many requests
c9c788e9… — CoinPay create failed 429: Too many requests
…
```

None of them were actually un-payable.

## Why

CoinPayPortal's edge proxy limits **every** `/api/` route to **60 requests per rolling minute per client IP** (`coinpayportal/src/proxy.ts`). ugig.net calls it from a single server IP, so that budget is shared across every payment request, status poll and webhook the box makes — for all users at once.

`/api/invoices/bulk-payment-request` fires one `payments/create` per invoice at concurrency 5 with no pacing and no retry. A 62-invoice run exhausts the minute in seconds, `createPayment` throws on the resulting 429, and the bulk payer records each one as a permanent skip — rendered in the same list as "Already paid" and "Not accepted yet".

A 429 is transient by definition. Treating it as terminal is what turned a payroll run into 30 write-offs.

## The fix

**`src/lib/coinpay-throttle.ts` (new)** — `coinpayFetch`, a paced + retrying `fetch` that every CoinPay call now goes through:

- Rolling-window pacer (45/min by default, under the provider's 60 so single-invoice flows and status polls still fit alongside a bulk run). Slot reservation is serialized so concurrent callers can't both claim the last slot.
- Retries 429 and 5xx, honouring `Retry-After` / `X-RateLimit-Reset`, with jittered exponential backoff as fallback.
- On a 429 it syncs to the provider's stated reset and holds *every* caller off — our local count is optimistic because it can't see the app's other CoinPay traffic.
- Retries dropped connections too, which fail a batch the same way.
- Only replays a positively-identified 429/5xx. Anything it can't classify is returned untouched — replaying a payment creation on a guess would mint a second live address for one debt.

**Reporting** — a rate-limited invoice comes back `retryable: true` with a reason that says so, instead of a raw provider string. The confirm step surfaces those separately and offers a one-click "prepare the N that were limited". Re-preparing reuses unexpired requests, so it costs one provider call per invoice actually still missing a quote.

**Bounding** — the batch shares one deadline (4 min) rather than a per-invoice budget. Quotes are only good for 15 minutes, so the last invoice must not still be waiting out a rate-limit window long after the first quote expired. Anything unprepared when it elapses returns as a retryable skip rather than holding the request open.

## Behaviour change

A large batch now takes up to ~2 minutes to prepare instead of failing fast — it waits out the provider's window rather than sprinting into it. Well inside the 15-minute quote validity.

`COINPAY_MAX_REQUESTS_PER_MINUTE` and `COINPAY_MAX_ATTEMPTS` are env-tunable. The counters are per-process; `railway.json` pins `numReplicas: 1`, so one process is the whole outbound budget. If that ever scales out, divide the setting by the replica count — the provider counts replicas together and we can't see across them.

## Verification

- 1810 tests pass across 198 files, including 10 new throttle tests and 3 new bulk-route regression tests covering the exact reported failure
- `tsc --noEmit` clean, `eslint` clean on changed files, production build succeeds
- Full `precommit` (lint + type-check + tests + build) passed on commit

## Not done here

CoinPayPortal's 60/min-per-IP cap is low for a server-to-server integration, and this PR works around it rather than changing it. Raising it for API-key-authenticated callers would be the other half of the fix, but it weakens a rate limiter in a payments product, so it's left as a deliberate call rather than folded in silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)