### PR TITLE
feat(invoices): choose which accepted invoices to pay

### DIFF
--- a/src/app/dashboard/invoices/BulkPayAccepted.test.tsx
+++ b/src/app/dashboard/invoices/BulkPayAccepted.test.tsx
@@ -39,6 +39,11 @@ const PREPARED = {
   },
 };
 
+/** The component takes labelled rows now; tests still think in ids. */
+function payable(ids: string[]) {
+  return ids.map((id, i) => ({ id, label: `Worker ${i} — Gig ${i}`, amountUsd: 50 }));
+}
+
 /** Install a fake `window.coinpay`, as the extension would. */
 function installWallet(overrides: Record<string, unknown> = {}) {
   const provider = {
@@ -76,7 +81,7 @@ function mockFetch(handlers: Record<string, unknown> = {}) {
 }
 
 async function openConfirmation() {
-  fireEvent.click(screen.getByRole("button", { name: /Pay all 2/ }));
+  fireEvent.click(screen.getByRole("button", { name: /Pay 2/ }));
   await screen.findByRole("button", { name: /Approve in wallet/ });
 }
 
@@ -93,42 +98,42 @@ describe("BulkPayAccepted", () => {
 
   it("renders nothing when there is nothing accepted to pay", () => {
     installWallet();
-    const { container } = render(<BulkPayAccepted invoiceIds={[]} totalUsd={0} />);
+    const { container } = render(<BulkPayAccepted invoices={[]} totalUsd={0} />);
 
     expect(container).toBeEmptyDOMElement();
   });
 
   it("prompts to install the wallet when the extension is absent", () => {
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
 
     expect(screen.getByText(/Install the CoinPay wallet/)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Pay all/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Pay \\d/ })).not.toBeInTheDocument();
   });
 
   it("offers the bulk action once the wallet is detected", () => {
     installWallet();
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
 
-    expect(screen.getByRole("button", { name: /Pay all 2/ })).toBeInTheDocument();
-    expect(screen.getByText(/2 invoices · \$100\.00/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Pay 2/ })).toBeInTheDocument();
+    expect(screen.getByText(/2 of 2 selected/)).toBeInTheDocument();
   });
 
   it("detects a wallet that finishes injecting after mount", async () => {
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
-    expect(screen.queryByRole("button", { name: /Pay all/ })).not.toBeInTheDocument();
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
+    expect(screen.queryByRole("button", { name: /^Pay \\d/ })).not.toBeInTheDocument();
 
     installWallet();
     act(() => {
       window.dispatchEvent(new Event("coinpay#initialized"));
     });
 
-    expect(await screen.findByRole("button", { name: /Pay all 2/ })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Pay 2/ })).toBeInTheDocument();
   });
 
   it("prepares payment requests for the accepted invoices", async () => {
     installWallet();
     const fetchMock = mockFetch();
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
 
     await openConfirmation();
 
@@ -144,7 +149,7 @@ describe("BulkPayAccepted", () => {
 
   it("does not touch the wallet before the user confirms", async () => {
     const wallet = installWallet();
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
 
     await openConfirmation();
 
@@ -162,7 +167,7 @@ describe("BulkPayAccepted", () => {
         },
       },
     });
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
 
     await openConfirmation();
 
@@ -173,7 +178,7 @@ describe("BulkPayAccepted", () => {
 
   it("hands the prepared payments to the wallet on approval", async () => {
     const wallet = installWallet();
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
     await openConfirmation();
 
     fireEvent.click(screen.getByRole("button", { name: /Approve in wallet/ }));
@@ -190,7 +195,7 @@ describe("BulkPayAccepted", () => {
   it("records the broadcast results afterwards", async () => {
     installWallet();
     const fetchMock = mockFetch();
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
     await openConfirmation();
 
     fireEvent.click(screen.getByRole("button", { name: /Approve in wallet/ }));
@@ -212,7 +217,7 @@ describe("BulkPayAccepted", () => {
 
   it("summarizes a fully successful run", async () => {
     installWallet();
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
     await openConfirmation();
 
     fireEvent.click(screen.getByRole("button", { name: /Approve in wallet/ }));
@@ -239,7 +244,7 @@ describe("BulkPayAccepted", () => {
       })),
     });
     const fetchMock = mockFetch();
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
     await openConfirmation();
     fireEvent.click(screen.getByRole("button", { name: /Approve in wallet/ }));
 
@@ -265,7 +270,7 @@ describe("BulkPayAccepted", () => {
         throw new Error("Payment request rejected");
       }),
     });
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
     await openConfirmation();
 
     fireEvent.click(screen.getByRole("button", { name: /Approve in wallet/ }));
@@ -305,8 +310,8 @@ describe("BulkPayAccepted", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<BulkPayAccepted invoiceIds={many} totalUsd={45} />);
-    fireEvent.click(screen.getByRole("button", { name: /Pay all 45/ }));
+    render(<BulkPayAccepted invoices={payable(many)} totalUsd={45} />);
+    fireEvent.click(screen.getByRole("button", { name: /Pay 45/ }));
 
     await screen.findByRole("button", { name: /Approve in wallet/ });
 
@@ -356,8 +361,8 @@ describe("BulkPayAccepted", () => {
       })
     );
 
-    render(<BulkPayAccepted invoiceIds={many} totalUsd={40} />);
-    fireEvent.click(screen.getByRole("button", { name: /Pay all 40/ }));
+    render(<BulkPayAccepted invoices={payable(many)} totalUsd={40} />);
+    fireEvent.click(screen.getByRole("button", { name: /Pay 40/ }));
 
     // Still reaches the confirmation step with the successful chunks intact,
     // rather than throwing the whole run away.
@@ -371,9 +376,9 @@ describe("BulkPayAccepted", () => {
       "fetch",
       vi.fn(async () => ({ ok: false, json: async () => ({ error: "CoinPay is down" }) }))
     );
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Pay all 2/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Pay 2/ }));
 
     expect(await screen.findByText("CoinPay is down")).toBeInTheDocument();
     expect(wallet.payBatch).not.toHaveBeenCalled();
@@ -390,7 +395,7 @@ describe("BulkPayAccepted", () => {
         throw new Error("network down");
       })
     );
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
     await openConfirmation();
 
     fireEvent.click(screen.getByRole("button", { name: /Approve in wallet/ }));
@@ -402,12 +407,12 @@ describe("BulkPayAccepted", () => {
 
   it("lets the user back out of the confirmation", async () => {
     const wallet = installWallet();
-    render(<BulkPayAccepted invoiceIds={INVOICE_IDS} totalUsd={100} />);
+    render(<BulkPayAccepted invoices={payable(INVOICE_IDS)} totalUsd={100} />);
     await openConfirmation();
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(await screen.findByRole("button", { name: /Pay all 2/ })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Pay 2/ })).toBeInTheDocument();
     expect(wallet.payBatch).not.toHaveBeenCalled();
   });
 });

--- a/src/app/dashboard/invoices/BulkPayAccepted.tsx
+++ b/src/app/dashboard/invoices/BulkPayAccepted.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
@@ -37,9 +37,16 @@ const EXTENSION_URL = "https://coinpayportal.com/extension";
 // promptly even when the provider is pacing us, so the count keeps moving.
 const PREPARE_CHUNK = 20;
 
+export interface PayableInvoice {
+  id: string;
+  /** Who is owed, and for what — enough to recognise a row without opening it. */
+  label: string;
+  amountUsd: number;
+}
+
 interface Props {
-  /** Ids of the accepted-and-unpaid invoices the signed-in user owes. */
-  invoiceIds: string[];
+  /** The accepted-and-unpaid invoices the signed-in user owes. */
+  invoices: PayableInvoice[];
   totalUsd: number;
 }
 
@@ -62,10 +69,16 @@ interface SkippedInvoice {
 
 type Phase = "idle" | "preparing" | "confirming" | "paying" | "done";
 
-export function BulkPayAccepted({ invoiceIds, totalUsd }: Props) {
-  const acceptedCount = invoiceIds.length;
+export function BulkPayAccepted({ invoices, totalUsd }: Props) {
+  const acceptedCount = invoices.length;
+  const invoiceIds = useMemo(() => invoices.map((i) => i.id), [invoices]);
   const router = useRouter();
   const [hasWallet, setHasWallet] = useState(false);
+  // Everything is selected by default — paying all of them is the common case,
+  // and the checkboxes exist to carve out exceptions rather than to make the
+  // normal path require 80 clicks.
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(invoiceIds));
+  const [showRows, setShowRows] = useState(false);
   const [phase, setPhase] = useState<Phase>("idle");
   const [payments, setPayments] = useState<PreparedPayment[]>([]);
   const [skipped, setSkipped] = useState<SkippedInvoice[]>([]);
@@ -84,14 +97,51 @@ export function BulkPayAccepted({ invoiceIds, totalUsd }: Props) {
     return () => window.removeEventListener("coinpay#initialized", detect);
   }, []);
 
+  // Forget ids that are no longer payable (paid elsewhere, revoked, refreshed
+  // away). Invoices that appear later stay unticked until the payer says so —
+  // never auto-select something they have not seen. Returning the same Set when
+  // nothing changed keeps this from re-rendering on every parent render.
+  useEffect(() => {
+    setSelected((current) => {
+      const known = new Set(invoiceIds);
+      const kept = [...current].filter((id) => known.has(id));
+      return kept.length === current.size ? current : new Set(kept);
+    });
+  }, [invoiceIds]);
+
+  const selectedIds = useMemo(
+    () => invoiceIds.filter((id) => selected.has(id)),
+    [invoiceIds, selected]
+  );
+  const selectedTotal = useMemo(
+    () => invoices.filter((i) => selected.has(i.id)).reduce((sum, i) => sum + i.amountUsd, 0),
+    [invoices, selected]
+  );
+  const allSelected = selectedIds.length === invoiceIds.length && invoiceIds.length > 0;
+
+  const toggleOne = useCallback((id: string) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    setSelected((current) =>
+      current.size === invoiceIds.length ? new Set() : new Set(invoiceIds)
+    );
+  }, [invoiceIds]);
+
   /**
-   * Mint payment requests for the given invoices (all of them by default, or
-   * just the failures when retrying). The server re-checks ownership and
-   * payability, so a stale id here is skipped rather than trusted.
+   * Mint payment requests for the given invoices (the current selection by
+   * default, or just the failures when retrying). The server re-checks
+   * ownership and payability, so a stale id here is skipped rather than trusted.
    */
-  const prepare = useCallback(async (ids: string[] = invoiceIds) => {
+  const prepare = useCallback(async (ids: string[] = selectedIds) => {
     if (ids.length === 0) {
-      setError("No accepted invoices are ready to pay.");
+      setError("Select at least one invoice to pay.");
       return;
     }
 
@@ -147,7 +197,7 @@ export function BulkPayAccepted({ invoiceIds, totalUsd }: Props) {
     }
 
     setPhase("confirming");
-  }, [invoiceIds]);
+  }, [selectedIds]);
 
   const pay = useCallback(async () => {
     const provider = window.coinpay;
@@ -221,20 +271,26 @@ export function BulkPayAccepted({ invoiceIds, totalUsd }: Props) {
         <div>
           <h3 className="flex items-center gap-2 font-semibold">
             <Zap className="h-4 w-4 text-emerald-600" />
-            Pay all accepted invoices
+            Pay accepted invoices
           </h3>
           <p className="mt-0.5 text-sm text-muted-foreground">
-            {acceptedCount} invoice{acceptedCount === 1 ? "" : "s"} · $
-            {totalUsd.toFixed(2)} — one confirmation in your CoinPay wallet.
+            {selectedIds.length} of {acceptedCount} selected · $
+            {selectedTotal.toFixed(2)} of ${totalUsd.toFixed(2)} — one
+            confirmation in your CoinPay wallet.
           </p>
         </div>
 
         {phase === "idle" && (
           <div className="flex shrink-0 items-center gap-2">
             {hasWallet ? (
-              <Button type="button" onClick={() => void prepare()} className="gap-2">
+              <Button
+                type="button"
+                onClick={() => void prepare()}
+                disabled={selectedIds.length === 0}
+                className="gap-2"
+              >
                 <Wallet className="h-4 w-4" />
-                Pay all {acceptedCount}
+                Pay {selectedIds.length}
               </Button>
             ) : (
               <a
@@ -263,6 +319,60 @@ export function BulkPayAccepted({ invoiceIds, totalUsd }: Props) {
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
           {error}
         </p>
+      )}
+
+      {/* Which invoices go in the run. Collapsed by default so the common
+          "pay everything" case stays one click, but a payer settling only some
+          of what they owe — or testing with a handful — needs the rows. */}
+      {phase === "idle" && (
+        <div className="mt-3 rounded-lg border border-border bg-background">
+          <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+            <label className="flex cursor-pointer items-center gap-2 text-sm font-medium">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                // Partially-selected reads as neither on nor off, and the
+                // browser only exposes that through the DOM property.
+                ref={(el) => {
+                  if (el) el.indeterminate = selectedIds.length > 0 && !allSelected;
+                }}
+                onChange={toggleAll}
+                className="h-4 w-4 cursor-pointer accent-emerald-600"
+                aria-label={allSelected ? "Deselect all invoices" : "Select all invoices"}
+              />
+              {allSelected ? "Deselect all" : "Select all"}
+            </label>
+            <button
+              type="button"
+              onClick={() => setShowRows((v) => !v)}
+              className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+              aria-expanded={showRows}
+            >
+              {showRows ? "Hide invoices" : `Show ${acceptedCount} invoices`}
+            </button>
+          </div>
+
+          {showRows && (
+            <ul className="max-h-64 divide-y divide-border overflow-y-auto">
+              {invoices.map((invoice) => (
+                <li key={invoice.id}>
+                  <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted/50">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(invoice.id)}
+                      onChange={() => toggleOne(invoice.id)}
+                      className="h-4 w-4 shrink-0 cursor-pointer accent-emerald-600"
+                    />
+                    <span className="min-w-0 flex-1 truncate">{invoice.label}</span>
+                    <span className="shrink-0 tabular-nums text-muted-foreground">
+                      ${invoice.amountUsd.toFixed(2)}
+                    </span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       )}
 
       {/* Confirmation summary — the last stop before the wallet's own approval. */}

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -306,7 +306,13 @@ export default async function InvoicesDashboardPage({
         {/* Bulk pay — only on the received side, where you're the payer. */}
         {tab === "received" && (
           <BulkPayAccepted
-            invoiceIds={accepted.map((i) => i.id)}
+            invoices={accepted.map((i) => ({
+              id: i.id,
+              label: i.gig?.title
+                ? `${counterpartyName(i.worker)} — ${i.gig.title}`
+                : counterpartyName(i.worker),
+              amountUsd: Number(i.amount_usd || 0),
+            }))}
             totalUsd={totalAccepted}
           />
         )}


### PR DESCRIPTION
## Why

Bulk pay was all-or-nothing — it took the whole accepted list, and the only control was "Pay all N". No way to settle part of what you owe, and no way to try a handful before committing to eighty.

## What

- A checkbox per invoice, showing who is owed and how much
- A **select all / deselect all** toggle above them, rendered indeterminate when the selection is partial
- Rows collapsed behind "Show N invoices", so paying everything stays one click
- Summary and button follow the selection: `3 of 80 selected · $4.12 of $78.61` → `Pay 3`

## Decisions worth stating

**Everything starts selected.** Paying all of it is the common case; the checkboxes exist to carve out exceptions, not to make the normal path require eighty clicks.

**Reconciliation is deliberately asymmetric.** Invoices that stop being payable (paid elsewhere, revoked) drop out of the selection. Invoices that appear later stay *unticked* until the payer ticks them — a background refresh must never quietly add money to a run the payer never looked at.

## Verification

Full `precommit` gate passed: lint, `tsc --noEmit`, 1827 tests across 198 files, production build. Existing bulk-pay tests updated for the new prop shape and button label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)