### PR TITLE
feat(invoices): pay cheapest invoices first, or flip to largest first

### DIFF
--- a/src/app/dashboard/invoices/BulkPayAccepted.test.tsx
+++ b/src/app/dashboard/invoices/BulkPayAccepted.test.tsx
@@ -370,6 +370,65 @@ describe("BulkPayAccepted", () => {
     expect(screen.getByText(/were limited/)).toBeInTheDocument();
   });
 
+  it("pays cheapest first, and lets you flip to largest first", async () => {
+    // Not cosmetic: a wallet that runs dry part-way through settles the most
+    // invoices when the small ones go first, so the chosen order has to reach
+    // the prepare call — not just the list on screen.
+    installWallet();
+    const invoices = [
+      { id: "inv-big", label: "Big", amountUsd: 90 },
+      { id: "inv-small", label: "Small", amountUsd: 1 },
+      { id: "inv-mid", label: "Mid", amountUsd: 20 },
+    ];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const ids = JSON.parse(String(init?.body ?? "{}")).invoice_ids as string[];
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            payments: ids.map((id) => ({
+              id,
+              gig_id: "g",
+              chain: "usdc_pol",
+              to: "0xabc",
+              amount: "1",
+              label: id,
+              amountUsd: 1,
+              expires_at: "2030-01-01T00:00:00Z",
+              reused: false,
+            })),
+            skipped: [],
+            total_usd: ids.length,
+          },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<BulkPayAccepted invoices={invoices} totalUsd={111} />);
+    fireEvent.click(screen.getByRole("button", { name: /Pay 3/ }));
+    await screen.findByRole("button", { name: /Approve in wallet/ });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body)).invoice_ids).toEqual([
+      "inv-small",
+      "inv-mid",
+      "inv-big",
+    ]);
+
+    // Flipping the toggle reverses what the wallet is handed.
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/ }));
+    fireEvent.click(screen.getByRole("button", { name: /largest first/i }));
+    fetchMock.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: /Pay 3/ }));
+    await screen.findByRole("button", { name: /Approve in wallet/ });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body)).invoice_ids).toEqual([
+      "inv-big",
+      "inv-mid",
+      "inv-small",
+    ]);
+  });
+
   it("surfaces a preparation failure without opening the wallet", async () => {
     const wallet = installWallet();
     vi.stubGlobal(

--- a/src/app/dashboard/invoices/BulkPayAccepted.tsx
+++ b/src/app/dashboard/invoices/BulkPayAccepted.tsx
@@ -79,6 +79,10 @@ export function BulkPayAccepted({ invoices, totalUsd }: Props) {
   // normal path require 80 clicks.
   const [selected, setSelected] = useState<Set<string>>(() => new Set(invoiceIds));
   const [showRows, setShowRows] = useState(false);
+  // Cheapest first by default: a wallet that runs dry part-way through
+  // settles the most invoices that way, and the big ones can wait for a
+  // top-up. This drives the actual payment order, not just the display.
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
   const [phase, setPhase] = useState<Phase>("idle");
   const [payments, setPayments] = useState<PreparedPayment[]>([]);
   const [skipped, setSkipped] = useState<SkippedInvoice[]>([]);
@@ -109,9 +113,20 @@ export function BulkPayAccepted({ invoices, totalUsd }: Props) {
     });
   }, [invoiceIds]);
 
+  const orderedInvoices = useMemo(
+    () =>
+      [...invoices].sort((a, b) =>
+        sortDir === "asc" ? a.amountUsd - b.amountUsd : b.amountUsd - a.amountUsd
+      ),
+    [invoices, sortDir]
+  );
+
+  // Derived from the sorted list, so the order the payer sees is the order the
+  // wallet is handed — pay-cheapest-first only means anything if it reaches
+  // `payBatch` that way.
   const selectedIds = useMemo(
-    () => invoiceIds.filter((id) => selected.has(id)),
-    [invoiceIds, selected]
+    () => orderedInvoices.filter((i) => selected.has(i.id)).map((i) => i.id),
+    [orderedInvoices, selected]
   );
   const selectedTotal = useMemo(
     () => invoices.filter((i) => selected.has(i.id)).reduce((sum, i) => sum + i.amountUsd, 0),
@@ -342,19 +357,33 @@ export function BulkPayAccepted({ invoices, totalUsd }: Props) {
               />
               {allSelected ? "Deselect all" : "Select all"}
             </label>
-            <button
-              type="button"
-              onClick={() => setShowRows((v) => !v)}
-              className="text-xs text-muted-foreground hover:text-foreground hover:underline"
-              aria-expanded={showRows}
-            >
-              {showRows ? "Hide invoices" : `Show ${acceptedCount} invoices`}
-            </button>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+                className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                aria-label={
+                  sortDir === "asc"
+                    ? "Sort by amount, largest first"
+                    : "Sort by amount, smallest first"
+                }
+              >
+                {sortDir === "asc" ? "Cheapest first ↑" : "Largest first ↓"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowRows((v) => !v)}
+                className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                aria-expanded={showRows}
+              >
+                {showRows ? "Hide invoices" : `Show ${acceptedCount} invoices`}
+              </button>
+            </div>
           </div>
 
           {showRows && (
             <ul className="max-h-64 divide-y divide-border overflow-y-auto">
-              {invoices.map((invoice) => (
+              {orderedInvoices.map((invoice) => (
                 <li key={invoice.id}>
                   <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted/50">
                     <input


### PR DESCRIPTION
## Why

Bulk pay handed invoices to the wallet in whatever order the dashboard happened to list them. When the paying wallet runs dry part-way through a batch — exactly what happens on a large run — **that order decides which invoices settle and which don't.**

Cheapest first clears the most invoices for a given balance, so it's the default. A toggle flips to largest first when the priority is the big ones.

## What

- **Sort toggle** beside "Show N invoices": `Cheapest first ↑` / `Largest first ↓`
- Default is cheapest first
- The rows list re-orders, and so does the payment run

## The part that matters

The sort drives the **actual payment order**, not just the display. `selectedIds` is derived from the sorted list, so the sequence the payer sees is the sequence handed to `payBatch`.

Sorting only the on-screen rows would have looked like it worked while changing nothing about who actually gets paid — which is the whole point of the feature.

## Verification

- Full `precommit` gate passed (lint, type-check, tests, production build)
- New test asserts the prepare call receives ids in ascending amount order, then re-asserts descending after the toggle — pinning payment order, not DOM order

🤖 Generated with [Claude Code](https://claude.com/claude-code)