### PR TITLE
feat(invoices): show the crypto amount alongside the dollar figure

### DIFF
--- a/src/app/dashboard/invoices/BulkPayAccepted.test.tsx
+++ b/src/app/dashboard/invoices/BulkPayAccepted.test.tsx
@@ -429,6 +429,28 @@ describe("BulkPayAccepted", () => {
     ]);
   });
 
+  it("shows the quoted crypto amount beside the dollar figure", async () => {
+    installWallet();
+    render(
+      <BulkPayAccepted
+        invoices={[
+          { id: "a", label: "Worker A", amountUsd: 1, currency: "usdc_sol", amountCrypto: "0.0138508" },
+          // No quote minted yet — a currency with no amount would imply a live
+          // price we do not have, so the row stays fiat-only.
+          { id: "b", label: "Worker B", amountUsd: 2, currency: "sol", amountCrypto: null },
+        ]}
+        totalUsd={3}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Show 2 invoices/ }));
+
+    expect(screen.getByText("0.013851 USDC")).toBeInTheDocument();
+    expect(screen.getByText("$1.00")).toBeInTheDocument();
+    expect(screen.getByText("$2.00")).toBeInTheDocument();
+    expect(screen.queryByText(/ SOL$/)).not.toBeInTheDocument();
+  });
+
   it("surfaces a preparation failure without opening the wallet", async () => {
     const wallet = installWallet();
     vi.stubGlobal(

--- a/src/app/dashboard/invoices/BulkPayAccepted.tsx
+++ b/src/app/dashboard/invoices/BulkPayAccepted.tsx
@@ -42,6 +42,27 @@ export interface PayableInvoice {
   /** Who is owed, and for what — enough to recognise a row without opening it. */
   label: string;
   amountUsd: number;
+  /** CoinPay currency the worker receives in, e.g. `usdc_sol`. */
+  currency?: string | null;
+  /**
+   * Quoted crypto amount, when a payment request has already been minted.
+   * Absent until one exists, and re-quoted at market when it is — so the row
+   * shows it only when it is a real number rather than implying a live price.
+   */
+  amountCrypto?: string | number | null;
+}
+
+/**
+ * `0.013851 SOL` for a row whose request has been quoted. Returns null when no
+ * quote exists yet — showing a currency with no amount, or an amount derived
+ * from a stale rate, would misrepresent what is about to be sent.
+ */
+function formatCrypto(invoice: PayableInvoice): string | null {
+  const amount = Number(invoice.amountCrypto);
+  if (!invoice.currency || !Number.isFinite(amount) || amount <= 0) return null;
+  const symbol = invoice.currency.split("_")[0]!.toUpperCase();
+  // Six places covers BTC's satoshi and reads sanely for SOL and stablecoins.
+  return `${amount.toFixed(6).replace(/0+$/, "").replace(/\.$/, "")} ${symbol}`;
 }
 
 interface Props {
@@ -393,8 +414,13 @@ export function BulkPayAccepted({ invoices, totalUsd }: Props) {
                       className="h-4 w-4 shrink-0 cursor-pointer accent-emerald-600"
                     />
                     <span className="min-w-0 flex-1 truncate">{invoice.label}</span>
-                    <span className="shrink-0 tabular-nums text-muted-foreground">
-                      ${invoice.amountUsd.toFixed(2)}
+                    <span className="shrink-0 text-right tabular-nums">
+                      <span className="block">${invoice.amountUsd.toFixed(2)}</span>
+                      {formatCrypto(invoice) && (
+                        <span className="block text-[11px] text-muted-foreground">
+                          {formatCrypto(invoice)}
+                        </span>
+                      )}
                     </span>
                   </label>
                 </li>

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -312,6 +312,8 @@ export default async function InvoicesDashboardPage({
                 ? `${counterpartyName(i.worker)} — ${i.gig.title}`
                 : counterpartyName(i.worker),
               amountUsd: Number(i.amount_usd || 0),
+              currency: i.metadata?.payment_currency ?? null,
+              amountCrypto: i.metadata?.amount_crypto ?? null,
             }))}
             totalUsd={totalAccepted}
           />


### PR DESCRIPTION
## Why

The bulk pay rows listed only USD, so a payer couldn't see what was actually leaving the wallet — which is the thing that decides whether a balance covers the run, and whether an amount is even *sendable*.

That gap has bitten already: one invoice was **492 satoshis**, below Bitcoin's ~546-sat dust limit and impossible to broadcast. `$0.50` gave no way to notice.

## What

Rows now show the quoted crypto amount under the dollar figure:

```
Maya Santos — Create High-Quality Ads…        $1.00
                                        0.013851 USDC
```

## Deliberate restraint

It appears **only when a payment request has already been quoted**. A currency with no amount — or an amount derived from a stale rate — would misrepresent what is about to be sent. Quotes are re-priced at market when minted, so an unquoted row stays fiat-only rather than implying a live price we don't have.

## Verification

- Full `precommit` gate passed (lint, type-check, tests, production build)
- New test covers both cases: a quoted row showing `0.013851 USDC`, and an unquoted row staying fiat-only rather than rendering a bare currency

🤖 Generated with [Claude Code](https://claude.com/claude-code)