### PR TITLE
fix(messages): isolate broadcast history by recipient roster

### DIFF
--- a/src/app/api/messages/broadcast/route.test.ts
+++ b/src/app/api/messages/broadcast/route.test.ts
@@ -47,7 +47,7 @@ function makeServiceClient(options: {
   bounties?: { id: string }[];
   bountySubmissions?: { submitter_id: string }[];
   profilesAll?: { id: string }[];
-  existingConversation?: { id: string } | null;
+  existingConversation?: { id: string; participant_ids: string[] } | null;
   notificationSettings?: Record<string, unknown>[];
 }) {
   const {
@@ -300,7 +300,10 @@ describe("POST /api/messages/broadcast", () => {
     const svc = makeServiceClient({
       gigs: [{ id: "gig-1" }],
       applications: [{ applicant_id: APPLICANT_1 }],
-      existingConversation: { id: CONVERSATION_ID },
+      existingConversation: {
+        id: CONVERSATION_ID,
+        participant_ids: [SENDER, APPLICANT_1],
+      },
     });
 
     mockCreateServiceClient.mockReturnValue(svc as any);
@@ -309,9 +312,30 @@ describe("POST /api/messages/broadcast", () => {
 
     expect((await res.json()).conversation_id).toBe(CONVERSATION_ID);
     expect(svc.__inserted.conversations).toBeUndefined();
-    // Roster refreshed on reuse
     const convUpdates = svc.__updated.conversations as Record<string, unknown>[];
-    expect(convUpdates[0].participant_ids).toBeDefined();
+    expect(convUpdates.some((update) => "participant_ids" in update)).toBe(false);
+  });
+
+  it("creates a separate thread when the audience roster changes", async () => {
+    authAs(SENDER);
+    const svc = makeServiceClient({
+      gigs: [{ id: "gig-1" }],
+      applications: [{ applicant_id: APPLICANT_1 }],
+      existingConversation: {
+        id: CONVERSATION_ID,
+        participant_ids: [SENDER, APPLICANT_2],
+      },
+    });
+
+    mockCreateServiceClient.mockReturnValue(svc as any);
+
+    const res = await POST(postRequest({ content: "new audience", audience: "gig_applicants" }));
+
+    expect(res.status).toBe(200);
+    const convInsert = svc.__inserted.conversations?.[0] as Record<string, unknown>;
+    expect(convInsert.participant_ids).toEqual([APPLICANT_1, SENDER].sort());
+    const convUpdates = svc.__updated.conversations as Record<string, unknown>[];
+    expect(convUpdates.some((update) => "participant_ids" in update)).toBe(false);
   });
 
   it("notifies, webhooks, and emails every recipient", async () => {

--- a/src/app/api/messages/broadcast/route.ts
+++ b/src/app/api/messages/broadcast/route.ts
@@ -39,6 +39,12 @@ function forbiddenAudience(audience: BroadcastAudience, admin: boolean): boolean
   return ADMIN_ONLY_AUDIENCES.includes(audience) && !admin;
 }
 
+function hasSameParticipants(existing: string[] | null, current: string[]): boolean {
+  if (!existing || existing.length !== current.length) return false;
+  const existingIds = new Set(existing);
+  return current.every((id) => existingIds.has(id));
+}
+
 // GET /api/messages/broadcast
 // Recipient counts per audience, so the composer can show "will reach N people"
 // before anything is sent. Admin-only audiences are omitted for non-admins.
@@ -116,25 +122,24 @@ export async function POST(request: NextRequest) {
 
     const participantIds = [user.id, ...recipientIds].sort();
 
-    // Reuse the thread for this (owner, audience) pair so repeat broadcasts
-    // stay in one conversation. Looked up by the indexed columns rather than a
-    // participant_ids containment probe, which degrades at broadcast sizes.
-    const { data: existing } = await svc
+    // Reuse a thread only when both the audience key and exact roster match.
+    // Changing participant_ids on an older thread would grant the new roster
+    // access to its entire message history.
+    const { data: existingThreads } = await svc
       .from("conversations")
-      .select("id")
+      .select("id, participant_ids")
       .eq("broadcast_owner_id", user.id)
       .eq("broadcast_audience", audience)
-      .eq("is_broadcast", true)
-      .maybeSingle();
+      .eq("is_broadcast", true);
+
+    const existing = (existingThreads ?? []).find((thread) =>
+      hasSameParticipants(thread.participant_ids, participantIds)
+    );
 
     let conversationId: string;
     if (existing?.id) {
       conversationId = existing.id;
-      // Audiences grow between sends; keep the roster current.
-      await svc
-        .from("conversations")
-        .update({ participant_ids: participantIds, archived_at: null })
-        .eq("id", conversationId);
+      await svc.from("conversations").update({ archived_at: null }).eq("id", conversationId);
     } else {
       const { data: created, error: convError } = await svc
         .from("conversations")


### PR DESCRIPTION
## Summary
- reuse broadcast conversations only when the resolved participant roster matches exactly
- preserve the original participant access boundary when applicants or status filters change
- add regression coverage for both matching and changed rosters

Fixes #529

## Validation
- `pnpm exec vitest run src/app/api/messages/broadcast/route.test.ts` (16/16)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/app/api/messages/broadcast/route.ts src/app/api/messages/broadcast/route.test.ts`
- `git diff --check`