### PR TITLE
fix(lightning): resolve Lightning Addresses case-insensitively (211 users still 404ing)

### DIFF
--- a/src/app/.well-known/lnurlp/[username]/route.ts
+++ b/src/app/.well-known/lnurlp/[username]/route.ts
@@ -20,25 +20,51 @@ export async function GET(
   try {
     const supabase = createServiceClient();
 
-    // Look up the user's profile and LNbits wallet
-    const { data: profile } = await supabase
+    // Look up the user's profile and LNbits wallet.
+    //
+    // Usernames are stored with their original case but Lightning Addresses are
+    // advertised lowercased, so this has to match case-insensitively — comparing
+    // against username.toLowerCase() alone never matches a mixed-case profile.
+    // ilike is only a prefilter (its wildcards are escaped, but the strict
+    // lowercase comparison below is what actually decides the match, so an
+    // over-broad pattern can never resolve to the wrong person).
+    const pattern = username.replace(/[\\%_]/g, (c) => `\\${c}`);
+    const { data: candidates } = await supabase
       .from('profiles')
-      .select('id')
-      .eq('username', username.toLowerCase())
-      .single();
+      .select('id, username')
+      .ilike('username', pattern)
+      .limit(10);
 
-    if (!profile) {
+    const wanted = username.toLowerCase();
+    const matches = (candidates ?? []).filter(
+      (c: { username: string | null }) => c.username?.toLowerCase() === wanted
+    );
+    // Prefer an exact-case match; a handful of usernames differ only by case.
+    const ordered = [
+      ...matches.filter((c: { username: string | null }) => c.username === username),
+      ...matches.filter((c: { username: string | null }) => c.username !== username),
+    ];
+
+    if (ordered.length === 0) {
       return NextResponse.json(
         { status: 'ERROR', reason: `Unknown user: ${username}` },
         { status: 404, headers: { 'Access-Control-Allow-Origin': '*' } }
       );
     }
 
-    const { data: lnWallet } = await (supabase
-      .from('user_ln_wallets' as any)
-      .select('invoice_key')
-      .eq('user_id', profile.id)
-      .single() as any);
+    // Where names collide only by case, the one with a wallet is the payee.
+    let lnWallet: { invoice_key?: string } | null = null;
+    for (const candidate of ordered) {
+      const { data } = await (supabase
+        .from('user_ln_wallets' as any)
+        .select('invoice_key')
+        .eq('user_id', candidate.id)
+        .maybeSingle() as any);
+      if (data?.invoice_key) {
+        lnWallet = data;
+        break;
+      }
+    }
 
     if (!lnWallet?.invoice_key) {
       return NextResponse.json(


### PR DESCRIPTION
Follow-up to #532. **That PR was squash-merged before this commit was pushed**, so master has the wallet/pay-link fix but *not* this one, and 211 users are still broken in production right now:

```
$ curl https://ugig.net/.well-known/lnurlp/Riot_SecOps
{"status":"ERROR","reason":"Unknown user: Riot_SecOps"}   # HTTP 404
```

## The bug

`/.well-known/lnurlp/<username>` matched profiles with:

```ts
.eq('username', username.toLowerCase())
```

That is a **case-sensitive** equality against a column that stores the username in its original case. So a profile stored as `Riot_SecOps` can never be found — `/Riot_SecOps` lowercases the input to `riot_secops` and misses, and `/riot_secops` misses too. Every mixed-case username 404s `Unknown user` in *both* case forms, regardless of whether its wallet has a pay link.

**211 of 687** wallet holders have a mixed-case username, and all 211 advertise an `ln_address`. The #532 backfill gave them working pay links — this is the only thing still standing between them and receiving payments.

## The fix

Match case-insensitively. `ilike` is used only as a prefilter and its wildcards are escaped; the authoritative check is a strict `toLowerCase()` comparison in JS, so an over-broad pattern can never resolve to the wrong payee. This matters here because usernames contain `_`, which is a single-character wildcard in SQL `LIKE`.

Three usernames collide case-insensitively — `AgentHansaHelper`/`agenthansahelper`, `AidenLy`/`aidenly`, `Vault9000`/`vault9000`. In each pair exactly one profile has a wallet, so the lookup prefers an exact-case match and then the candidate that actually has a wallet, which disambiguates all three.

## Verification

- `npx tsc --noEmit` clean, `eslint` clean.
- Backfill from #532 is done and confirmed: a full rescan of all 687 wallets shows **687 with pay links, 0 remaining, 0 errors**.
- Lowercase users already resolve in prod today (`davidanup`, `aks_escrow`, `weruh`, `sunsonai`, `ratamaha`, `jonyd`, `voltron_agent`, `vianerds_scoutworkshop` — all HTTP 200, each with its own distinct callback).
- After this deploys, `Riot_SecOps` and the other 210 should return 200 rather than `Unknown user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)